### PR TITLE
According to http://www.tldp.org/HOWTO/Multicast-HOWTO-6.html: "If the h...

### DIFF
--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1264,9 +1264,12 @@ class Zeroconf(object):
         self._respond_sockets = []
 
         for i in interfaces:
-            self._listen_socket.setsockopt(
-                socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP,
-                socket.inet_aton(_MDNS_ADDR) + socket.inet_aton(i))
+            try:
+                self._listen_socket.setsockopt(
+                    socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP,
+                    socket.inet_aton(_MDNS_ADDR) + socket.inet_aton(i))
+            except Exception:
+                pass
 
             respond_socket = new_socket()
             respond_socket.setsockopt(

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1590,7 +1590,7 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
     log.setLevel(logging.DEBUG)
     print("Multicast DNS Service Discovery for Python, version %s" % __version__)
-    r = Zeroconf()
+    r = Zeroconf(InterfaceChoice.All)
     print("1. Testing registration of a service...")
     desc = {'version': '0.10', 'a': 'test value', 'b': 'another value'}
     info = ServiceInfo("_http._tcp.local.",


### PR DESCRIPTION
These changes are required as a prerequisite on my FreeBSD box. I'v tested this on OS X as well (see comments). I don't expect these changes to break anything.

However, my original observation still stands: the Zeroconf class needs to iterate on all existing interfaces in order to work properly. The trick with the UDP connect catches just a single interface, which in my (special) case is the wrong (external) interface.