### PR TITLE
encode strings to utf-8 in ServiceInfo

### DIFF
--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1069,7 +1069,7 @@ class ServiceInfo(object):
 
                 if value is None:
                     suffix = b''
-                elif isinstance(value, unicode):
+                elif isinstance(value, unicode) or isinstance(value, str):
                     suffix = value.encode('utf-8')
                 elif isinstance(value, int):
                     if value:


### PR DESCRIPTION
I found that properties dict values registered as "False" rather than the intended string value, such as "path" in the provided examples.

eg.

Service Paul's Test Web Site._http._tcp.local. added
  Type is _http._tcp.local.
  Address is 10.0.1.2:80
  Weight is 0, Priority is 0
  Server is ash-2.local.
  Properties are
    path: False
