### PR TITLE
Handle EADDRNOTAVAIL error when adding multicast groups (for windows)

### DIFF
--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1350,6 +1350,12 @@ class Zeroconf(object):
                         'Address in use when adding %s to multicast group, '
                         'it is expected to happen on some systems', i,
                     )
+                elif get_errno(e) == errno.EADDRNOTAVAIL:
+                    log.info(
+                        'Address not available when adding %s to multicast group, '
+                        'it is expected to happen on some systems', i,
+                    )
+                    continue
                 else:
                     raise
 


### PR DESCRIPTION
On my windows machine, I see a few "disconnected" network interfaces (VPN tunnel, Virtual box tunnel, disconnected LAN interface). However, these interfaces do get an ip address in the range 169.254.x.x from windows.

However, when starting zeroconf, the code cannot add these to the multicast group. And you get an EADDRNOTAVAIL error.

This patch handles the error and continues properly by adding the rest of the "real" network interfaces.