### PR TITLE
Only install enum34 when Python version < 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function
 
 from os.path import abspath, dirname, join
+import sys
 
 from setuptools import setup
 
@@ -14,6 +15,11 @@ version = (
     .split('=')[-1]
     .strip().strip('\'"')
 )
+
+install_requires = ['netifaces', 'six']
+
+if sys.version_info < (3,4):
+    install_requires.append('enum34')
 
 setup(
     name='zeroconf',
@@ -50,9 +56,5 @@ setup(
         'Bonjour', 'Avahi', 'Zeroconf', 'Multicast DNS', 'Service Discovery',
         'mDNS',
     ],
-    install_requires=[
-        'enum34',
-        'netifaces',
-        'six',
-    ],
+    install_requires=install_requires,
 )


### PR DESCRIPTION
I cannot install enum34 in Python 3.4.3. I get a similar problem as is described here: https://github.com/opentok/Opentok-Python-SDK/pull/70

Without the dependency, python-zeroconf works fine.