### PR TITLE
Fix DNSText repr Python 3 issue

### DIFF
--- a/zeroconf.py
+++ b/zeroconf.py
@@ -409,7 +409,7 @@ class DNSText(DNSRecord):
     def __repr__(self):
         """String representation"""
         if len(self.text) > 10:
-            return self.to_string(self.text[:7] + "...")
+            return self.to_string(self.text[:7]) + "..."
         else:
             return self.to_string(self.text)
 


### PR DESCRIPTION
Prevents following exception in Python 3:
```
  File "/Users/paulus/dev/python/netdisco/lib/python3.4/site-packages/zeroconf.py", line 412, in __repr__
    return self.to_string(self.text[:7] + "...")
TypeError: can't concat bytes to str
```