### PR TITLE
fix issue #23 race-condition on ServiceBrowser startup

### DIFF
--- a/zeroconf.py
+++ b/zeroconf.py
@@ -972,7 +972,6 @@ class ServiceBrowser(threading.Thread):
         self.done = False
 
         self.zc.add_listener(self, DNSQuestion(self.type, _TYPE_PTR, _CLASS_IN))
-        self.start()
 
         self._service_state_changed = Signal()
 
@@ -995,6 +994,8 @@ class ServiceBrowser(threading.Thread):
 
         for h in handlers:
             self.service_state_changed.register_handler(h)
+
+        self.start()
 
     @property
     def service_state_changed(self):

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -38,7 +38,7 @@ from six.moves import xrange
 
 __author__ = 'Paul Scott-Murphy, William McBrine'
 __maintainer__ = 'Jakub Stasiak <jakub@stasiak.at>'
-__version__ = '0.17.4'
+__version__ = '0.17.4-gbiddison'
 __license__ = 'LGPL'
 
 


### PR DESCRIPTION
As mentioned in issue #23 there is a race condition caused by calling `self.start()` before `__init__` has finished initialization; the intermittent error reports that `self._service_state_changed` is missing and the ServiceBrowser thread terminates. 

The frequency of the error is high enough on my test system to be critically important.

This trivial PR moves the `self.start()` call to the last line of `__init__` eliminating any potential races.