### PR TITLE
Fix multicast TTL and LOOP options on OpenBSD

### DIFF
--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1308,8 +1308,12 @@ def new_socket():
             if not err.errno == errno.ENOPROTOOPT:
                 raise
 
-    s.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 255)
-    s.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_LOOP, 1)
+    # OpenBSD needs the ttl and loop values for the IP_MULTICAST_TTL and
+    # IP_MULTICAST_LOOP socket options as an unsigned char.
+    ttl = struct.pack(b'B', 255)
+    s.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, ttl)
+    loop = struct.pack(b'B', 1)
+    s.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_LOOP, loop)
 
     s.bind(('', _MDNS_PORT))
     return s


### PR DESCRIPTION
`IP_MULTICAST_TTL` and `IP_MULTICAST_LOOP` socket options on OpenBSD don't accept int, only `unsigned char`.

This causes a kernel error when these options are set: `socket.error: [Errno 22] Invalid argument`.

According to the OpenBSD's [ip(4)](http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man4/ip.4?query=ip) man page, these fields are both `unsigned char`:
>u_char ttl;     /* range: 0 to 255, default = 1 */
>setsockopt(s, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof(ttl));
>
>u_char loop;	/* 0 = disable, 1 = enable (default) */
>setsockopt(s, IPPROTO_IP, IP_MULTICAST_LOOP, &loop, sizeof(loop));

This patch was tested successfully on Linux (Ubuntu 14.04), FreeBSD 10.2 and OpenBSD 5.8 using Python 2.7, 3.4, 3.5.