### PR TITLE
fix for unregister_all_services

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,12 @@ See examples directory for more.
 Changelog
 =========
 
+0.17.4
+------
+
+* Fixed support for Linux kernel versions < 3.9 (thanks to Giovanni Harting
+  and Luckydonald, GitHub pull request #26)
+
 0.17.3
 ------
 

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -38,7 +38,7 @@ from six.moves import xrange
 
 __author__ = 'Paul Scott-Murphy, William McBrine'
 __maintainer__ = 'Jakub Stasiak <jakub@stasiak.at>'
-__version__ = '0.17.4-gbiddison'
+__version__ = '0.17.4'
 __license__ = 'LGPL'
 
 

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -972,7 +972,6 @@ class ServiceBrowser(threading.Thread):
         self.done = False
 
         self.zc.add_listener(self, DNSQuestion(self.type, _TYPE_PTR, _CLASS_IN))
-        self.start()
 
         self._service_state_changed = Signal()
 
@@ -995,6 +994,8 @@ class ServiceBrowser(threading.Thread):
 
         for h in handlers:
             self.service_state_changed.register_handler(h)
+
+        self.start()
 
     @property
     def service_state_changed(self):

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -38,7 +38,7 @@ from six.moves import xrange
 
 __author__ = 'Paul Scott-Murphy, William McBrine'
 __maintainer__ = 'Jakub Stasiak <jakub@stasiak.at>'
-__version__ = '0.17.3'
+__version__ = '0.17.4'
 __license__ = 'LGPL'
 
 

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -38,7 +38,7 @@ from six.moves import xrange
 
 __author__ = 'Paul Scott-Murphy, William McBrine'
 __maintainer__ = 'Jakub Stasiak <jakub@stasiak.at>'
-__version__ = '0.17.4'
+__version__ = '0.17.4-gbiddison'
 __license__ = 'LGPL'
 
 


### PR DESCRIPTION
Fixes #34 

Fixed by removing services from internal services & servicetypes structures, copied from working unregister_service code with a local copy of self.services to prevent deletion during iteration problem
