### PR TITLE
Installation python3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 from __future__ import absolute_import, division, print_function
 
+from io import open
+
 from os.path import abspath, dirname, join
 
 from setuptools import setup
 
 PROJECT_ROOT = abspath(dirname(__file__))
-with open(join(PROJECT_ROOT, 'README.rst')) as f:
+with open(join(PROJECT_ROOT, 'README.rst'), encoding='utf-8') as f:
     readme = f.read()
 
 version = (


### PR DESCRIPTION
Installing using pip resulted in error:

```
Collecting git+https://github.com/jstasiak/python-zeroconf
  Cloning https://github.com/jstasiak/python-zeroconf to /tmp/pip-f2knhtr9-build
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-f2knhtr9-build/setup.py", line 10, in <module>
        readme = f.read()
      File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 4280: ordinal not in range(128)
```

This PR fixes the encoding in Python 3.5 and is also backported to support 2.6+