### PR TITLE
Added thread safety to Zeroconf.close()

### DIFF
--- a/test_zeroconf.py
+++ b/test_zeroconf.py
@@ -151,56 +151,74 @@ class Framework(unittest.TestCase):
         rv.close()
 
 
-def test_integration():
-    service_added = Event()
-    service_removed = Event()
+class Misc(unittest.TestCase):
+  def test_integration(self):
+      service_added = Event()
+      service_removed = Event()
 
-    type_ = "_http._tcp.local."
-    registration_name = "xxxyyy.%s" % type_
+      type_ = "_http._tcp.local."
+      registration_name = "xxxyyy.%s" % type_
 
-    def on_service_state_change(zeroconf, service_type, state_change, name):
-        if name == registration_name:
-            if state_change is ServiceStateChange.Added:
-                service_added.set()
-            elif state_change is ServiceStateChange.Removed:
-                service_removed.set()
+      def on_service_state_change(zeroconf, service_type, state_change, name):
+          if name == registration_name:
+              if state_change is ServiceStateChange.Added:
+                  service_added.set()
+              elif state_change is ServiceStateChange.Removed:
+                  service_removed.set()
 
-    zeroconf_browser = Zeroconf()
-    browser = ServiceBrowser(zeroconf_browser, type_, [on_service_state_change])
+      zeroconf_browser = Zeroconf()
+      browser = ServiceBrowser(zeroconf_browser, type_, [on_service_state_change])
 
-    zeroconf_registrar = Zeroconf()
-    desc = {'path': '/~paulsm/'}
-    info = ServiceInfo(
-        type_, registration_name,
-        socket.inet_aton("10.0.1.2"), 80, 0, 0,
-        desc, "ash-2.local.")
-    zeroconf_registrar.register_service(info)
+      zeroconf_registrar = Zeroconf()
+      desc = {'path': '/~paulsm/'}
+      info = ServiceInfo(
+          type_, registration_name,
+          socket.inet_aton("10.0.1.2"), 80, 0, 0,
+          desc, "ash-2.local.")
+      zeroconf_registrar.register_service(info)
 
-    try:
-        service_added.wait(1)
-        assert service_added.is_set()
-        zeroconf_registrar.unregister_service(info)
-        service_removed.wait(1)
-        assert service_removed.is_set()
-    finally:
-        zeroconf_registrar.close()
-        browser.cancel()
-        zeroconf_browser.close()
-
-
-def test_listener_handles_closed_socket_situation_gracefully():
-    error = socket.error(socket.EBADF)
-    error.errno = socket.EBADF
-
-    zeroconf = Mock()
-    zeroconf.socket.recvfrom.side_effect = error
-
-    listener = Listener(zeroconf)
-    listener.handle_read(zeroconf.socket)
+      try:
+          service_added.wait(1)
+          assert service_added.is_set()
+          zeroconf_registrar.unregister_service(info)
+          service_removed.wait(1)
+          assert service_removed.is_set()
+      finally:
+          zeroconf_registrar.close()
+          browser.cancel()
+          zeroconf_browser.close()
 
 
-def test_dnstext_repr_works():
-    # There was an issue on Python 3 that prevented DNSText's repr
-    # from working when the text was longer than 10 bytes
-    text = DNSText('irrelevant', None, 0, 0, b'12345678901')
-    repr(text)
+  def test_listener_handles_closed_socket_situation_gracefully(self):
+      error = socket.error(socket.EBADF)
+      error.errno = socket.EBADF
+
+      zeroconf = Mock()
+      zeroconf.socket.recvfrom.side_effect = error
+
+      listener = Listener(zeroconf)
+      listener.handle_read(zeroconf.socket)
+
+
+  def test_dnstext_repr_works(self):
+      # There was an issue on Python 3 that prevented DNSText's repr
+      # from working when the text was longer than 10 bytes
+      text = DNSText('irrelevant', None, 0, 0, b'12345678901')
+      repr(text)
+
+
+  def test_close_waits_for_threads(self):
+      class Dummy(object):
+        def add_service(self, zeroconf_obj, service_type, name):
+          pass
+        def remove_service(self, zeroconf_obj, service_type, name):
+          pass
+
+      z = Zeroconf()
+      z.add_service_listener('_privet._tcp.local.', listener=Dummy())
+      z.close()
+      assert not z.browsers[0].is_alive()
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1671,14 +1671,38 @@ class Zeroconf(object):
                     'Should not happen, sent %d out of %d bytes' % (
                         bytes_sent, len(packet)))
 
+    def _check_threads(self):
+      """Check if any threads are still active.
+
+      Returns:
+        True if the Reaper or Engine started by this object is still alive or
+        if any ServiceBrowser known to this object is still alive. Otherwise
+        False.
+      """
+      threads = [self.reaper, self.engine] + self.browsers
+      for t in threads:
+          if isinstance(t, threading.Thread) and t.is_alive():
+              return True
+      return False
+
     def close(self):
         """Ends the background threads, and prevent this instance from
-        servicing further queries."""
+        servicing further queries.
+
+        This operation blocks until all threads exit.
+        """
         global _GLOBAL_DONE
         if not _GLOBAL_DONE:
             _GLOBAL_DONE = True
             self.notify_all()
             self.engine.notify()
             self.unregister_all_services()
+
+            # Wait for threads to actually die before destroying the sockets
+            threads_alive = self._check_threads()
+            while threads_alive:
+                time.sleep(0.01)
+                threads_alive = self._check_threads()
+
             for s in [self._listen_socket] + self._respond_sockets:
                 s.close()


### PR DESCRIPTION
Zeroconf.close() immediately closed sockets which child threads may
still need to finish their operations. This was causing EBADF (bad file
descriptor) errors in some cases. Zeroconf.close() now blocks until all
known child threads have stopped then closes the sockets safely. If a
child thread was created that Zeroconf is not aware of (ie a
ServiceBrowser object manually created but not registered in
zeroconf.browsers) the EBADF errors may still occur.

Also some of the unit tests were not in a unittest.TestCase subclass so
they were not running. Added test cases to Misc TestCase and added
default execution of unittest.main().