### PR TITLE
Multiple fixes to speed up querys and remove exceptions at shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,12 @@
 build/
+*.pyc
+*.pyo
+Thumbs.db
+.DS_Store
+.project
+.pydevproject
+.settings
+.idea
+.vslick
+.cache
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,4 @@ universal = 1
 show-source = 1
 import-order-style=google
 application-import-names=zeroconf
+max-line-length=110

--- a/test_zeroconf.py
+++ b/test_zeroconf.py
@@ -10,14 +10,12 @@ import struct
 import unittest
 from threading import Event
 
-from mock import Mock
 from six import indexbytes
 from six.moves import xrange
 
 import zeroconf as r
 from zeroconf import (
     DNSText,
-    Listener,
     ServiceBrowser,
     ServiceInfo,
     ServiceStateChange,
@@ -186,17 +184,6 @@ def test_integration():
         zeroconf_registrar.close()
         browser.cancel()
         zeroconf_browser.close()
-
-
-def test_listener_handles_closed_socket_situation_gracefully():
-    error = socket.error(socket.EBADF)
-    error.errno = socket.EBADF
-
-    zeroconf = Mock()
-    zeroconf.socket.recvfrom.side_effect = error
-
-    listener = Listener(zeroconf)
-    listener.handle_read(zeroconf.socket)
 
 
 def test_dnstext_repr_works():

--- a/test_zeroconf.py
+++ b/test_zeroconf.py
@@ -7,6 +7,7 @@
 import logging
 import socket
 import struct
+import time
 import unittest
 from threading import Event
 
@@ -149,6 +150,84 @@ class Framework(unittest.TestCase):
         rv.close()
 
 
+class Exceptions(unittest.TestCase):
+
+    def test_bad_service_info_name(self):
+        browser = Zeroconf()
+        self.assertRaises(r.BadTypeInNameException,
+                          browser.get_service_info, "type", "type_not")
+        browser.close()
+
+
+class Listener(unittest.TestCase):
+
+    def test_integration_with_listener_class(self):
+
+        service_added = Event()
+        service_removed = Event()
+
+        type_ = "_http._tcp.local."
+        name = "xxxyyy"
+        registration_name = "%s.%s" % (name, type_)
+
+        class MyListener(object):
+            def add_service(self, zeroconf, type, name):
+                zeroconf.get_service_info(type, name)
+                service_added.set()
+
+            def remove_service(self, zeroconf, type, name):
+                service_removed.set()
+
+        zeroconf_browser = Zeroconf()
+        zeroconf_browser.add_service_listener(type_, MyListener())
+
+        properties = dict(
+            prop_none=None,
+            prop_string=b'a_prop',
+            prop_float=1.0,
+            prop_blank=b'a blanked string',
+            prop_true=1,
+            prop_false=0,
+        )
+
+        zeroconf_registrar = Zeroconf()
+        desc = {'path': '/~paulsm/'}
+        desc.update(properties)
+        info = ServiceInfo(
+            type_, registration_name,
+            socket.inet_aton("10.0.1.2"), 80, 0, 0,
+            desc, "ash-2.local.")
+        zeroconf_registrar.register_service(info)
+
+        try:
+            service_added.wait(1)
+            assert service_added.is_set()
+
+            # short pause to allow multicast timers to expire
+            time.sleep(2)
+
+            # clear the answer cache to force query
+            for record in zeroconf_browser.cache.entries():
+                zeroconf_browser.cache.remove(record)
+
+            # get service info without answer cache
+            info = zeroconf_browser.get_service_info(type_, registration_name)
+
+            assert info.properties[b'prop_none'] is False
+            assert info.properties[b'prop_string'] == properties['prop_string']
+            assert info.properties[b'prop_float'] is False
+            assert info.properties[b'prop_blank'] == properties['prop_blank']
+            assert info.properties[b'prop_true'] is True
+            assert info.properties[b'prop_false'] is False
+
+            zeroconf_registrar.unregister_service(info)
+            service_removed.wait(1)
+            assert service_removed.is_set()
+        finally:
+            zeroconf_registrar.close()
+            zeroconf_browser.close()
+
+
 def test_integration():
     service_added = Event()
     service_removed = Event()
@@ -177,9 +256,8 @@ def test_integration():
     try:
         service_added.wait(1)
         assert service_added.is_set()
-        zeroconf_registrar.unregister_service(info)
-        service_removed.wait(1)
-        assert service_removed.is_set()
+        # Don't remove service, allow close() to cleanup
+
     finally:
         zeroconf_registrar.close()
         browser.cancel()

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1080,6 +1080,7 @@ class ServiceInfo(object):
             self.server = server
         else:
             self.server = name
+        self._properties = {}
         self._set_properties(properties)
 
     @property


### PR DESCRIPTION
#### Fix ability for a cache lookup to match properly

When querying for a service type, the response is processed.  During the
processing, an info lookup is performed.  If the info is not found in
the cache, then a query is sent.  Trouble is that the info requested is
present in the same packet that triggered the lookup, and a query is not
necessary.  But two problems caused the cache lookup to fail.

1) The info was not yet in the cache.  The call back was fired before
all answers in the packet were cached.

2) The test for a cache hit did not work, because the cache hit test
uses a DNSEntry as the comparison object.  But some of the objects in
the cache are descendents of DNSEntry and have their own \__eq__()
defined which accesses fields only present on the descendent.  Thus the
test can NEVER work since the descendent's \__eq__() will be used.

Also continuing the theme of some other recent pull requests, add three
_GLOBAL_DONE tests to avoid doing work after the attempted stop, and
thus avoid generating (harmless, but annoying) exceptions during
shutdown