### PR TITLE
Fix compatibility with JmDNS

### DIFF
--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1652,9 +1652,9 @@ class Zeroconf(object):
                                                     _TYPE_TXT, _CLASS_IN | _CLASS_UNIQUE,
                                                     _DNS_TTL, service.text))
                     if question.type == _TYPE_SRV:
-                        out.add_additional_answer(DNSAddress(service.server,
-                                                             _TYPE_A, _CLASS_IN | _CLASS_UNIQUE,
-                                                             _DNS_TTL, service.address))
+                        out.add_answer(msg, DNSAddress(service.server,
+                                                       _TYPE_A, _CLASS_IN | _CLASS_UNIQUE,
+                                                       _DNS_TTL, service.address))
                 except Exception as e:  # TODO stop catching all Exceptions
                     log.exception('Unknown error, possibly benign: %r', e)
 


### PR DESCRIPTION
In my tests, JmDNS drops the response when the DNSAddress is added to the additionals.  Since additionals is supposed to be used for optional records, it seems more appropriate to move the DNS record to the normal answers.