### PR TITLE
Handle DNSIncoming exceptions

### DIFF
--- a/test_zeroconf.py
+++ b/test_zeroconf.py
@@ -16,6 +16,7 @@ from six.moves import xrange
 
 import zeroconf as r
 from zeroconf import (
+    DNSAddress,
     DNSHinfo,
     DNSText,
     ServiceBrowser,
@@ -228,6 +229,31 @@ class Exceptions(unittest.TestCase):
         for name in good_names_to_try:
             r.service_type_name(name)
 
+class TestDnsIncoming(unittest.TestCase):
+
+    def test_incoming_exception_handling(self):
+        generated = r.DNSOutgoing(0)
+        packet = list(generated.packet())
+        packet.insert(8, 'deadbeef')
+        packet = ''.join(packet)
+        parsed = r.DNSIncoming(packet)
+        parsed = r.DNSIncoming(packet)
+        assert parsed.valid is False
+
+    def test_incoming_unknown_type(self):
+        generated = r.DNSOutgoing(0)
+        answer = r.DNSAddress('', r._TYPE_SOA, r._CLASS_IN, 1, '')
+        generated.add_additional_answer(answer)
+        packet = generated.packet()
+        parsed = r.DNSIncoming(packet)
+        assert len(parsed.answers) == 0
+        assert parsed.is_query() != parsed.is_response()
+
+    def test_incoming_ipv6(self):
+        # ::TODO:: could use a test here if we add IPV6 record handling
+        # ie: _TYPE_AAAA
+        pass
+
 
 class ServiceTypesQuery(unittest.TestCase):
 
@@ -273,7 +299,7 @@ class ServiceTypesQuery(unittest.TestCase):
 
         try:
             service_types = ZeroconfServiceTypes.find(timeout=0.5)
-            print(service_types)
+            # print(service_types)
             assert discovery_type in service_types
             service_types = ZeroconfServiceTypes.find(
                 zc=zeroconf_registrar, timeout=0.5)

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -30,6 +30,7 @@ import re
 import select
 import socket
 import struct
+import sys
 import threading
 import time
 from functools import reduce
@@ -260,23 +261,23 @@ class Error(Exception):
     pass
 
 
-class NonLocalNameException(Exception):
+class IncomingDecodeError(Error):
     pass
 
 
-class NonUniqueNameException(Exception):
+class NonUniqueNameException(Error):
     pass
 
 
-class NamePartTooLongException(Exception):
+class NamePartTooLongException(Error):
     pass
 
 
-class AbstractMethodException(Exception):
+class AbstractMethodException(Error):
     pass
 
 
-class BadTypeInNameException(Exception):
+class BadTypeInNameException(Error):
     pass
 
 # implementation classes
@@ -545,6 +546,8 @@ class DNSIncoming(object):
 
     """Object representation of an incoming DNS packet"""
 
+    _seen_exceptions = {}
+
     def __init__(self, data):
         """Constructor from string holding bytes of packet"""
         self.offset = 0
@@ -557,10 +560,25 @@ class DNSIncoming(object):
         self.num_answers = 0
         self.num_authorities = 0
         self.num_additionals = 0
+        self.valid = False
 
-        self.read_header()
-        self.read_questions()
-        self.read_others()
+        try:
+            self.read_header()
+            self.read_questions()
+            self.read_others()
+            self.valid = True
+
+        except (IndexError, struct.error, IncomingDecodeError) as exc:
+            # log the packet and the exception
+            exc_info = sys.exc_info()
+            exc_str = str(exc_info[1])
+            if exc_str not in self._seen_exceptions:
+                self._seen_exceptions[exc_str] = exc_info
+                logger = log.warn
+            else:
+                logger = log.debug
+            logger('Choked at offset %d while unpacking %r', self.offset, data)
+            logger('Exception occurred:', exc_info=exc_info)
 
     def unpack(self, format_):
         length = struct.calcsize(format_)
@@ -583,9 +601,9 @@ class DNSIncoming(object):
             question = DNSQuestion(name, type_, class_)
             self.questions.append(question)
 
-    def read_int(self):
-        """Reads an integer from the packet"""
-        return self.unpack(b'!I')[0]
+    # def read_int(self):
+    #     """Reads an integer from the packet"""
+    #     return self.unpack(b'!I')[0]
 
     def read_character_string(self):
         """Reads a character string from the packet"""
@@ -675,12 +693,11 @@ class DNSIncoming(object):
                     next_ = off + 1
                 off = ((length & 0x3F) << 8) | indexbytes(self.data, off)
                 if off >= first:
-                    # TODO raise more specific exception
-                    raise Exception("Bad domain name (circular) at %s" % (off,))
+                    raise IncomingDecodeError(
+                        "Bad domain name (circular) at %s" % (off,))
                 first = off
             else:
-                # TODO raise more specific exception
-                raise Exception("Bad domain name at %s" % (off,))
+                raise IncomingDecodeError("Bad domain name at %s" % (off,))
 
         if next_ >= 0:
             self.offset = next_
@@ -986,17 +1003,20 @@ class Listener(object):
 
         self.data = data
         msg = DNSIncoming(data)
-        if msg.is_query():
+        if not msg.valid:
+            pass
+
+        elif msg.is_query():
             # Always multicast responses
-            #
             if port == _MDNS_PORT:
                 self.zc.handle_query(msg, _MDNS_ADDR, _MDNS_PORT)
+
             # If it's not a multicast query, reply via unicast
             # and multicast
-            #
             elif port == _DNS_PORT:
                 self.zc.handle_query(msg, addr, port)
                 self.zc.handle_query(msg, _MDNS_ADDR, _MDNS_PORT)
+
         else:
             self.zc.handle_response(msg)
 


### PR DESCRIPTION
This fixes a regression from removal of some overly broad exception
handling in 0.17.6.  This change adds an explicit handler for
DNSIncoming().  Will also log at warn level the first time it sees a
particular parsing exception.

Also make all test cases localhost only.

This addresses #63 and #65