### PR TITLE
Fix name change

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ The easiest way to install python-zeroconf is using pip::
 How do I use it?
 ================
 
-Here's an example:
+Here's an example of browsing for a service:
 
 .. code-block:: python
 
@@ -121,6 +121,20 @@ See examples directory for more.
 
 Changelog
 =========
+
+0.17.7.dev
+------
+
+* Better Handling of DNS Incoming Packets parsing exceptions
+* Many exceptions will now log a warning the first time they are seen
+* Catch and log sendto() errors
+* Greatly improve handling of oversized packets including:
+
+  - Implement name compression per RFC1035
+  - Limit size of generated packets to 9000 bytes as per RFC6762
+  - Better handle over sized incoming packets
+
+* Increased test coverage to 94%
 
 0.17.6
 ------

--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,7 @@ Changelog
 * Better Handling of DNS Incoming Packets parsing exceptions
 * Many exceptions will now log a warning the first time they are seen
 * Catch and log sendto() errors
+* Fix/Implement duplicate name change
 * Greatly improve handling of oversized packets including:
 
   - Implement name compression per RFC1035

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],

--- a/test_zeroconf.py
+++ b/test_zeroconf.py
@@ -91,6 +91,10 @@ class TestDunder(unittest.TestCase):
         assert not info != info
         repr(info)
 
+    def test_dns_outgoing_repr(self):
+        dns_outgoing = r.DNSOutgoing(r._FLAGS_QR_QUERY)
+        repr(dns_outgoing)
+
 
 class PacketGeneration(unittest.TestCase):
 
@@ -356,7 +360,9 @@ class Names(unittest.TestCase):
 class Framework(unittest.TestCase):
 
     def test_launch_and_close(self):
-        rv = r.Zeroconf(interfaces=['127.0.0.1'])
+        rv = r.Zeroconf(interfaces=r.InterfaceChoice.All)
+        rv.close()
+        rv = r.Zeroconf(interfaces=r.InterfaceChoice.Default)
         rv.close()
 
 


### PR DESCRIPTION
This addresses issue #29.  It fixes / implements auto name changing for service advertisement when the service name is already present on the network.

In addition some documentation for DNS Additional Record Generation is added.