### PR TITLE
Added select.error handling to detect closed sockets in Engine.run

### DIFF
--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1115,10 +1115,10 @@ class Engine(threading.Thread):
                             if reader:
                                 reader.handle_read(socket_)
 
-                except socket.error as e:
+                except (select.error, socket.error) as e:
                     # If the socket was closed by another thread, during
                     # shutdown, ignore it and exit
-                    if e.errno != socket.EBADF or not self.zc.done:
+                    if e[0] != socket.EBADF or not self.zc.done:
                         raise
 
     def add_reader(self, reader, socket_):


### PR DESCRIPTION
When closing a zeroconf object, many times an error will be thrown. This error can be seen when running the registration.py example.

$ python examples/registration.py
Registration of a service, press Ctrl-C to exit...
^C
Unregistering...
Exception in thread zeroconf-Engine:
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.12_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/local/lib/python2.7/site-packages/zeroconf.py", line 946, in run
    rr, wr, er = select.select(rs, [], [], self.timeout)
error: (9, 'Bad file descriptor')
