### PR TITLE
Fix Travis CI flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - "2.6"
     - "2.7"
     - "3.3"
     - "3.4"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ env:
 	cp requirements-dev.txt ./env/requirements.built
 
 flake8:
-	flake8 --max-line-length=$(MAX_LINE_LENGTH) --import-order-style=google examples *.py
+	flake8 --max-line-length=$(MAX_LINE_LENGTH) --import-order-style=smarkets examples *.py
 
 test:
 	nosetests -v

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ env:
 	cp requirements-dev.txt ./env/requirements.built
 
 flake8:
-	flake8 --max-line-length=$(MAX_LINE_LENGTH) examples *.py
+	flake8 --max-line-length=$(MAX_LINE_LENGTH) --import-order-style=google examples *.py
 
 test:
 	nosetests -v

--- a/README.rst
+++ b/README.rst
@@ -3,14 +3,14 @@ python-zeroconf
 
 .. image:: https://travis-ci.org/jstasiak/python-zeroconf.svg?branch=master
     :target: https://travis-ci.org/jstasiak/python-zeroconf
-    
+
 .. image:: https://img.shields.io/pypi/v/zeroconf.svg
     :target: https://pypi.python.org/pypi/zeroconf
 
 .. image:: https://img.shields.io/coveralls/jstasiak/python-zeroconf.svg
     :target: https://coveralls.io/r/jstasiak/python-zeroconf
 
-    
+
 This is fork of pyzeroconf, Multicast DNS Service Discovery for Python,
 originally by Paul Scott-Murphy (https://github.com/paulsm/pyzeroconf),
 modified by William McBrine (https://github.com/wmcbrine/pyzeroconf).
@@ -21,7 +21,7 @@ The original William McBrine's fork note::
     (and therefore HME/VLC), Network Remote, Remote Proxy, and pyTivo.
     Before this, I was tracking the changes for zeroconf.py in three
     separate repos. I figured I should have an authoritative source.
-    
+
     Although I make changes based on my experience with TiVos, I expect that
     they're generally applicable. This version also includes patches found
     on the now-defunct (?) Launchpad repo of pyzeroconf, and elsewhere
@@ -43,7 +43,7 @@ Compared to some other Zeroconf/Bonjour/Avahi Python packages, python-zeroconf:
 Python compatibility
 --------------------
 
-* CPython 2.6, 2.7, 3.3+
+* CPython 2.7, 3.3+
 * PyPy 2.2+ (possibly 1.9-2.1 as well)
 * PyPy3 2.4+
 
@@ -84,18 +84,18 @@ Here's an example of browsing for a service:
 
     from six.moves import input
     from zeroconf import ServiceBrowser, Zeroconf
-    
-    
+
+
     class MyListener(object):
-    
+
         def remove_service(self, zeroconf, type, name):
             print("Service %s removed" % (name,))
-    
+
         def add_service(self, zeroconf, type, name):
             info = zeroconf.get_service_info(type, name)
             print("Service %s added, service info: %s" % (name, info))
-    
-    
+
+
     zeroconf = Zeroconf()
     listener = MyListener()
     browser = ServiceBrowser(zeroconf, "_http._tcp.local.", listener)
@@ -269,7 +269,7 @@ Changelog
   - better TXT record parsing
   - server is now separate from name
   - can cancel a service browser
-  
+
 * modified some unit tests to accommodate these changes
 
 0.09

--- a/examples/browser.py
+++ b/examples/browser.py
@@ -30,6 +30,7 @@ def on_service_state_change(zeroconf, service_type, name, state_change):
             print("  No info")
         print('\n')
 
+
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
     if len(sys.argv) > 1:

--- a/examples/old_browser.py
+++ b/examples/old_browser.py
@@ -35,6 +35,7 @@ class MyListener(object):
             print("  No info")
         print('\n')
 
+
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
     if len(sys.argv) > 1:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,7 @@ coverage
 enum34
 flake8
 flake8-blind-except
-# Upper bound because of https://github.com/public/flake8-import-order/issues/42
-flake8-import-order>=0.4.0, <0.6.0
+flake8-import-order>=0.4.0
 mock
 netifaces
 nose

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         'Topic :: Software Development :: Libraries',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -45,14 +45,7 @@ __version__ = '0.17.7.dev'
 __license__ = 'LGPL'
 
 
-try:
-    NullHandler = logging.NullHandler
-except AttributeError:
-    # Python 2.6 fallback
-    class NullHandler(logging.Handler):
-
-        def emit(self, record):
-            pass
+NullHandler = logging.NullHandler
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
Fixes #92.

#93 is a quick-fix alternative.

* flake8_import_order-0.5.3 doesn't work with flake8 3.2.1, so don't pin flake8-import-order <0.6.0
* Use smarkets style for flake8_import_order. More info: https://github.com/PyCQA/flake8-import-order#configuration
* Latest flake8 doesn't support Python 2.6, so drop support for it. CPython 2.6 itself hasn't been supported since 2013. https://en.wikipedia.org/wiki/CPython#Version_history
   * Alternatively, if you still want to support Python 2.6, then a separate requirements-dev.txt can be maintained for 2.6 and installed only for that version.