### PR TITLE
Updated DNS_TTL to one minute to match other references

### DIFF
--- a/zeroconf.py
+++ b/zeroconf.py
@@ -80,7 +80,7 @@ _BROWSER_TIME = 500
 _MDNS_ADDR = '224.0.0.251'
 _MDNS_PORT = 5353
 _DNS_PORT = 53
-_DNS_TTL = 60 * 60  # one hour default TTL
+_DNS_TTL = 60  # one minute default TTL
 
 _MAX_MSG_TYPICAL = 1460  # unused
 _MAX_MSG_ABSOLUTE = 8966


### PR DESCRIPTION
Default DNS_TTL Value stated it was one hour, then later was said to be one minute. Changed default to be one minute to match later reference in register_service function.