### PR TITLE
Add new records first in cache entry instead of last

### DIFF
--- a/test_zeroconf.py
+++ b/test_zeroconf.py
@@ -497,6 +497,19 @@ class TestDnsIncoming(unittest.TestCase):
         pass
 
 
+class TestDNSCache(unittest.TestCase):
+
+    def test_order(self):
+        record1 = r.DNSAddress('a', r._TYPE_SOA, r._CLASS_IN, 1, b'a')
+        record2 = r.DNSAddress('a', r._TYPE_SOA, r._CLASS_IN, 1, b'b')
+        cache = r.DNSCache()
+        cache.add(record1)
+        cache.add(record2)
+        entry = r.DNSEntry('a', r._TYPE_SOA, r._CLASS_IN)
+        cached_record = cache.get(entry)
+        self.assertEqual(cached_record, record2)
+
+
 class ServiceTypesQuery(unittest.TestCase):
 
     def test_integration_with_listener(self):

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1014,7 +1014,8 @@ class DNSCache(object):
 
     def add(self, entry):
         """Adds an entry"""
-        self.cache.setdefault(entry.key, []).append(entry)
+        # Insert first in list so get returns newest entry
+        self.cache.setdefault(entry.key, []).insert(0, entry)
 
     def remove(self, entry):
         """Removes an entry"""


### PR DESCRIPTION
Add new records first in cache entry to make DNSCache.get return the newest record instead of the oldest.
This means updates, for example IP address changes, do not need to wait for expiry of old records.