### PR TITLE
Refresh ServiceBrowser entries already when 'stale'

### DIFF
--- a/test_zeroconf.py
+++ b/test_zeroconf.py
@@ -631,6 +631,8 @@ class ListenerTest(unittest.TestCase):
 def test_integration():
     service_added = Event()
     service_removed = Event()
+    unexpected_ttl = Event()
+    got_query = Event()
 
     type_ = "_http._tcp.local."
     registration_name = "xxxyyy.%s" % type_
@@ -643,6 +645,42 @@ def test_integration():
                 service_removed.set()
 
     zeroconf_browser = Zeroconf(interfaces=['127.0.0.1'])
+
+    # we are going to monkey patch the zeroconf send to check packet sizes
+    old_send = zeroconf_browser.send
+
+    time_offset = 0
+
+    def current_time_millis():
+        """Current system time in milliseconds"""
+        return time.time() * 1000 + time_offset * 1000
+
+    expected_ttl = r._DNS_TTL
+
+    # needs to be a list so that we can modify it in our phony send
+    nbr_queries = [0, None]
+
+    def send(out, addr=r._MDNS_ADDR, port=r._MDNS_PORT):
+        """Sends an outgoing packet."""
+        pout = r.DNSIncoming(out.packet())
+
+        for answer in pout.answers:
+            nbr_queries[0] += 1
+            if not answer.ttl > expected_ttl / 2:
+                unexpected_ttl.set()
+
+        got_query.set()
+        old_send(out, addr=addr, port=port)
+
+    # monkey patch the zeroconf send
+    zeroconf_browser.send = send
+
+    # monkey patch the zeroconf current_time_millis
+    r.current_time_millis = current_time_millis
+
+    service_added = Event()
+    service_removed = Event()
+
     browser = ServiceBrowser(zeroconf_browser, type_, [on_service_state_change])
 
     zeroconf_registrar = Zeroconf(interfaces=['127.0.0.1'])
@@ -656,6 +694,16 @@ def test_integration():
     try:
         service_added.wait(1)
         assert service_added.is_set()
+
+        sleep_count = 0
+        while nbr_queries[0] < 50:
+            time_offset += expected_ttl / 4
+            zeroconf_browser.notify_all()
+            sleep_count += 1
+            got_query.wait(1)
+            got_query.clear()
+        assert not unexpected_ttl.is_set()
+
         # Don't remove service, allow close() to cleanup
 
     finally:

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1322,7 +1322,7 @@ class ServiceBrowser(threading.Thread):
                 out = DNSOutgoing(_FLAGS_QR_QUERY)
                 out.add_question(DNSQuestion(self.type, _TYPE_PTR, _CLASS_IN))
                 for record in self.services.values():
-                    if not record.is_expired(now):
+                    if not record.is_stale(now):
                         out.add_answer_at_time(record, now)
 
                 self.zc.send(out)


### PR DESCRIPTION
User of ServiceBrowser will get 'Removed' followed by 'Added' callback because the ServiceBrowser does not refresh the entries until they have already expired.
Change this undesirable behavior by updating entries already when they are 'stale' instead of waiting for the entry to expire.