### PR TITLE
examples: Add an example of resolving a known service by service name

### DIFF
--- a/examples/resolver.py
+++ b/examples/resolver.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+""" Example of resolving a service with a known name """
+
+import logging
+import sys
+
+from zeroconf import ServiceInfo, Zeroconf
+
+TYPE = '_test._tcp.local.'
+NAME = 'My Service Name'
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    if len(sys.argv) > 1:
+        assert sys.argv[1:] == ['--debug']
+        logging.getLogger('zeroconf').setLevel(logging.DEBUG)
+
+    zeroconf = Zeroconf()
+
+    try:
+        print(zeroconf.get_service_info(TYPE, NAME + '.' + TYPE))
+    finally:
+        zeroconf.close()


### PR DESCRIPTION
It isn't immediately obvious how to use python-zeroconf to resolve a service knowing its name and type in advance (as opposed to browsing for all services of a given type). This example does that.

To use:
* `avahi-publish-service -s 'My Service Name' _test._tcp 0`
* `./examples/resolver.py` should print a `ServiceInfo`
* Kill the `avahi-publish-service` process
* `./examples/resolver.py` should print `None`

Signed-off-by: Simon McVittie <smcv@collabora.com>