### PR TITLE
Fix flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
     - pip install -r requirements-dev.txt
 script:
     - make test_coverage
+    - flake8 --version
     - make flake8
 after_success:
     - coveralls

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,4 +10,4 @@ flake8-import-order>=0.4.0, <0.6.0
 netifaces!=0.10.5
 nose
 pep8==1.5.7
-pep8-naming
+pep8-naming!=0.6.0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 from io import open
-
 from os.path import abspath, dirname, join
 
 from setuptools import setup

--- a/test_zeroconf.py
+++ b/test_zeroconf.py
@@ -8,9 +8,9 @@ import copy
 import logging
 import socket
 import struct
-from threading import Event
 import time
 import unittest
+from threading import Event
 
 
 import zeroconf as r

--- a/test_zeroconf.py
+++ b/test_zeroconf.py
@@ -8,9 +8,10 @@ import copy
 import logging
 import socket
 import struct
+from threading import Event
 import time
 import unittest
-from threading import Event
+
 
 import zeroconf as r
 from zeroconf import (

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -22,7 +22,6 @@
 
 import enum
 import errno
-from functools import reduce
 import logging
 import re
 import select
@@ -31,6 +30,7 @@ import struct
 import sys
 import threading
 import time
+from functools import reduce
 
 import netifaces
 

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -22,6 +22,7 @@
 
 import enum
 import errno
+from functools import reduce
 import logging
 import re
 import select
@@ -30,7 +31,6 @@ import struct
 import sys
 import threading
 import time
-from functools import reduce
 
 import netifaces
 


### PR DESCRIPTION
This makes flake8 happy so the build can pass again.

The reason I added `flake8 --version` to the tests is because my version of flake8 expects the imports in a different order.
This way I could install the same version as you and therefore make sure everything passes.

`pep8-naming` in particular is crashing on version `0.6.0` so I had to black list it.
That's a trick I learned from the author of `catt`

