### PR TITLE
Fix UnboundLocalError for count after loop

### DIFF
--- a/zeroconf.py
+++ b/zeroconf.py
@@ -941,7 +941,7 @@ class DNSOutgoing:
             if sub_name in self.names:
                 break
         else:
-            count += 1
+            count = len(name_suffices)
 
         # note the new names we are saving into the packet
         for suffix in name_suffices[:count]:


### PR DESCRIPTION
This code throws an `UnboundLocalError` as `count` doesn't exist in the `else` branch of the for loop. The else branch happens if the break condition is never met, therefore the equivalent (and more straightforward/less clever) statement is to set it to `len(name_suffices)`.