### PR TITLE
Fix UTF-8 multibyte name compression

### DIFF
--- a/test_zeroconf.py
+++ b/test_zeroconf.py
@@ -323,7 +323,7 @@ class Names(unittest.TestCase):
         # now that we have a long packet in our possession, let's verify the
         # exception handling.
         out = longest_packet[1]
-        out.data.append(b'\0' * 1000)
+        out.data.append(b'\0' * (r._MAX_MSG_MACOS - longest_packet[0]))
 
         # mock the zeroconf logger and check for the correct logging backoff
         call_counts = mocked_log_warn.call_count, mocked_log_debug.call_count

--- a/test_zeroconf.py
+++ b/test_zeroconf.py
@@ -115,6 +115,14 @@ class PacketGeneration(unittest.TestCase):
                                              r._CLASS_IN))
         r.DNSIncoming(generated.packet())
 
+    def test_parse_own_packet_response(self):
+        generated = r.DNSOutgoing(r._FLAGS_QR_RESPONSE)
+        generated.add_answer_at_time(r.DNSService(
+            "æøå.local.", r._TYPE_SRV, r._CLASS_IN, r._DNS_TTL, 0, 0, 80, "foo.local."), 0)
+        parsed = r.DNSIncoming(generated.packet())
+        self.assertEqual(len(generated.answers), 1)
+        self.assertEqual(len(generated.answers), len(parsed.answers))
+
     def test_match_question(self):
         generated = r.DNSOutgoing(r._FLAGS_QR_QUERY)
         question = r.DNSQuestion("testname.local.", r._TYPE_SRV, r._CLASS_IN)
@@ -705,7 +713,7 @@ class ListenerTest(unittest.TestCase):
         subtype_name = "My special Subtype"
         type_ = "_http._tcp.local."
         subtype = subtype_name + "._sub." + type_
-        name = "xxxyyy"
+        name = "xxxyyyæøå"
         registration_name = "%s.%s" % (name, type_)
 
         class MyListener:

--- a/test_zeroconf.py
+++ b/test_zeroconf.py
@@ -223,7 +223,7 @@ class PacketForm(unittest.TestCase):
     def test_numbers_questions(self):
         generated = r.DNSOutgoing(r._FLAGS_QR_RESPONSE)
         question = r.DNSQuestion("testname.local.", r._TYPE_SRV, r._CLASS_IN)
-        for i in range(10):
+        for _ in range(10):
             generated.add_question(question)
         bytes = generated.packet()
         (num_questions, num_answers, num_authorities,
@@ -575,7 +575,7 @@ class TestRegistrar(unittest.TestCase):
 
         def send(out, addr=r._MDNS_ADDR, port=r._MDNS_PORT):
             """Sends an outgoing packet."""
-            for answer, time_ in out.answers:
+            for answer, _ in out.answers:
                 nbr_answers[0] += 1
                 assert answer.ttl == expected_ttl
             for answer in out.additionals:

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -669,7 +669,7 @@ class DNSIncoming(QuietLogger):
 
     def read_questions(self):
         """Reads questions section of packet"""
-        for i in range(self.num_questions):
+        for _ in range(self.num_questions):
             name = self.read_name()
             type_, class_ = self.unpack(b'!HH')
 
@@ -700,7 +700,7 @@ class DNSIncoming(QuietLogger):
         """Reads the answers, authorities and additionals section of the
         packet"""
         n = self.num_answers + self.num_authorities + self.num_additionals
-        for i in range(n):
+        for _ in range(n):
             domain = self.read_name()
             type_, class_, ttl, length = self.unpack(b'!HHiH')
 
@@ -1132,7 +1132,7 @@ class Engine(threading.Thread):
 
             if len(rs) != 0:
                 try:
-                    rr, wr, er = select.select(rs, [], [], self.timeout)
+                    rr, _, _ = select.select(rs, [], [], self.timeout)
                     if not self.zc.done:
                         for socket_ in rr:
                             reader = self.readers.get(socket_)
@@ -2079,7 +2079,7 @@ class Zeroconf(QuietLogger):
             else:
                 if bytes_sent != len(packet):
                     self.log_warning_once(
-                        '!!! sent %d out of %d bytes to %r' % (
+                        '!!! sent %d out of %d bytes' % (
                             bytes_sent, len(packet)), s)
 
     def close(self):

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -75,7 +75,7 @@ _DNS_TTL = 120  # two minutes default TTL as recommended by RFC6762
 
 _MAX_MSG_TYPICAL = 1460  # unused
 _MAX_MSG_ABSOLUTE = 8966
-_MAX_MSG_MACOS = 9216 # macOS default max UDP datagram size
+_MAX_MSG_MACOS = 9216  # macOS default max UDP datagram size
 
 _FLAGS_QR_MASK = 0x8000  # query response mask
 _FLAGS_QR_QUERY = 0x0000  # query
@@ -1583,6 +1583,7 @@ class ZeroconfServiceTypes:
     """
     Return all of the advertised services on any local networks
     """
+
     def __init__(self):
         self.found_services = set()
 

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -75,6 +75,7 @@ _DNS_TTL = 120  # two minutes default TTL as recommended by RFC6762
 
 _MAX_MSG_TYPICAL = 1460  # unused
 _MAX_MSG_ABSOLUTE = 8966
+_MAX_MSG_MACOS = 9216 # macOS default max UDP datagram size
 
 _FLAGS_QR_MASK = 0x8000  # query response mask
 _FLAGS_QR_QUERY = 0x0000  # query

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -944,8 +944,9 @@ class DNSOutgoing:
             count = len(name_suffices)
 
         # note the new names we are saving into the packet
+        name_length = len(name.encode('utf-8'))
         for suffix in name_suffices[:count]:
-            self.names[suffix] = self.size + len(name) - len(suffix) - 1
+            self.names[suffix] = self.size + name_length - len(suffix.encode('utf-8')) - 1
 
         # write the new names out.
         for part in parts[:count]:


### PR DESCRIPTION
The indexes were off resulting in malformed packets. Also fixed tests on macOS and a few linter issues.