### PR TITLE
Bringing back compatibility with python 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import sys
 from io import open
 from os.path import abspath, dirname, join
 
@@ -14,12 +13,6 @@ version = (
     .split('=')[-1]
     .strip().strip('\'"')
 )
-
-install_requires = [
-    'ifaddr'
-]
-if sys.version_info[:2] < (3, 5):
-    install_requires.append('typing')
 
 setup(
     name='zeroconf',
@@ -53,5 +46,8 @@ setup(
         'Bonjour', 'Avahi', 'Zeroconf', 'Multicast DNS', 'Service Discovery',
         'mDNS',
     ],
-    install_requires=install_requires,
+    install_requires=[
+        'ifaddr',
+        'typing;python<"3.5"'
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ version = (
     .strip().strip('\'"')
 )
 
-install_requires=[
+install_requires = [
     'ifaddr'
 ]
 if sys.version_info[:2] < (3, 5):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from io import open
 from os.path import abspath, dirname, join
+import sys
 
 from setuptools import setup
 
@@ -13,6 +14,12 @@ version = (
     .split('=')[-1]
     .strip().strip('\'"')
 )
+
+install_requires=[
+    'ifaddr'
+]
+if sys.version_info[:2] < (3, 5):
+    install_requires.append('typing')
 
 setup(
     name='zeroconf',
@@ -46,7 +53,5 @@ setup(
         'Bonjour', 'Avahi', 'Zeroconf', 'Multicast DNS', 'Service Discovery',
         'mDNS',
     ],
-    install_requires=[
-        'ifaddr'
-    ],
+    install_requires=install_requires,
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
+import sys
 from io import open
 from os.path import abspath, dirname, join
-import sys
 
 from setuptools import setup
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     ],
     install_requires=[
         'ifaddr',
-        'typing;python<"3.5"'
+        'typing;python_version<"3.5"'
     ],
 )

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -39,7 +39,7 @@ import ifaddr
 
 __author__ = 'Paul Scott-Murphy, William McBrine'
 __maintainer__ = 'Jakub Stasiak <jakub@stasiak.at>'
-__version__ = '0.21.0'
+__version__ = '0.21.1'
 __license__ = 'LGPL'
 
 

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -39,7 +39,7 @@ import ifaddr
 
 __author__ = 'Paul Scott-Murphy, William McBrine'
 __maintainer__ = 'Jakub Stasiak <jakub@stasiak.at>'
-__version__ = '0.21.1'
+__version__ = '0.21.0'
 __license__ = 'LGPL'
 
 


### PR DESCRIPTION
The latest release of zeroconf in PyPI (0.21.0) breaks compatibility with python 3.4 due to an unstated dependency on the ``typing`` package. This patch adds that dependency and issues a new minor version of zeroconf.