### PR TITLE
Test with PyPy 3.5 5.10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
-    - "pypy3.5-5.8.0"
+    - "pypy3.5-5.10.1"
 matrix:
     fast_finish: true
     include:


### PR DESCRIPTION
The latest currently easily available on Travis.

(Build failure is unrelated, fixed by #147.)