### PR TITLE
Modified ServiceInfo's __init__ properties' default value.

### DIFF
--- a/test_zeroconf.py
+++ b/test_zeroconf.py
@@ -90,6 +90,18 @@ class TestDunder(unittest.TestCase):
         assert not info != info
         repr(info)
 
+    def test_service_info_text_properties_not_given(self):
+        type_ = "_test-srvc-type._tcp.local."
+        name = "xxxyyy"
+        registration_name = "%s.%s" % (name, type_)
+        info = ServiceInfo(
+            type_=type_, name=registration_name,
+            address=socket.inet_aton("10.0.1.2"),
+            port=80, server="ash-2.local.")
+
+        assert isinstance(info.text, bytes)
+        repr(info)
+
     def test_dns_outgoing_repr(self):
         dns_outgoing = r.DNSOutgoing(r._FLAGS_QR_QUERY)
         repr(dns_outgoing)

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1390,7 +1390,7 @@ class ServiceInfo(RecordUpdateListener):
     """Service information"""
 
     def __init__(self, type_: str, name: str, address: bytes = None, port: int = None, weight: int = 0,
-                 priority: int = 0, properties=None, server: str = None) -> None:
+                 priority: int = 0, properties=b'', server: str = None) -> None:
         """Create a service description.
 
         type_: fully qualified service type name


### PR DESCRIPTION
This request targets a modification of the default value of the argument `properties` of `ServiceInfo`'s `__init__()`. The default value on the current commit (51a6f70) is `None`. The suggested modification changes this value to `b''`.

Looking at the code, if `properties` is a dictionary, the function `_set_properties()` will create a byte array with the user's properties; if properties is a byte array, it just sets the property. As it is, an because `properties` is not mandatory, if a user does not specify the argument, an exception (`AssertionError`) is thrown. Changing the default value to a byte array, which avoids the conversion to byte array, solves this problem. With this modification, it is possible to instantiate ServiceInfo on the following three ways - the last is not possible in the aforementioned commit.

    ServiceInfo("_http._tcp.local.",
                "super service 01._http._tcp.local.",
                socket.inet_aton("127.0.0.1"), 6776, 0, 0,
                {}, "server.local.")

    ServiceInfo(type_="_http._tcp.local.",
                name="super service 02._http._tcp.local.",
                address=socket.inet_aton("127.0.0.1"), port=6773, weight=0, priority=0,
                properties={}, server="server.local.")

    ServiceInfo(type_="_http._tcp.local.",
                name="super service 03._http._tcp.local.",
                address=socket.inet_aton("127.0.0.1"),
                server="server.local.")

These changes don't break the unit tests.