### PR TITLE
Fix service removal packets not being sent on shutdown

### DIFF
--- a/test_zeroconf.py
+++ b/test_zeroconf.py
@@ -955,5 +955,7 @@ def test_integration():
 
     finally:
         zeroconf_registrar.close()
+        service_removed.wait(1)
+        assert service_removed.is_set()
         browser.cancel()
         zeroconf_browser.close()

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -2121,10 +2121,10 @@ class Zeroconf(QuietLogger):
         """Ends the background threads, and prevent this instance from
         servicing further queries."""
         if not self._GLOBAL_DONE:
-            self._GLOBAL_DONE = True
             # remove service listeners
             self.remove_all_service_listeners()
             self.unregister_all_services()
+            self._GLOBAL_DONE = True
 
             # shutdown recv socket and thread
             if not self.unicast:


### PR DESCRIPTION
This resolves a bug in the shutdown behaviour which fails to send out service removals if services haven't been explicitly removed before a call to `close()`.