### PR TITLE
Match default TTLs to those specified in RFC 6762

### DIFF
--- a/test_zeroconf.py
+++ b/test_zeroconf.py
@@ -59,7 +59,7 @@ class TestDunder(unittest.TestCase):
 
     def test_dns_pointer_repr(self):
         pointer = r.DNSPointer(
-            'irrelevant', r._TYPE_PTR, r._CLASS_IN, r._DNS_TTL, '123')
+            'irrelevant', r._TYPE_PTR, r._CLASS_IN, r._DNS_HOST_TTL, '123')
         repr(pointer)
 
     def test_dns_address_repr(self):
@@ -74,11 +74,11 @@ class TestDunder(unittest.TestCase):
 
     def test_dns_service_repr(self):
         service = r.DNSService(
-            'irrelevant', r._TYPE_SRV, r._CLASS_IN, r._DNS_TTL, 0, 0, 80, b'a')
+            'irrelevant', r._TYPE_SRV, r._CLASS_IN, r._DNS_HOST_TTL, 0, 0, 80, b'a')
         repr(service)
 
     def test_dns_record_abc(self):
-        record = r.DNSRecord('irrelevant', r._TYPE_SRV, r._CLASS_IN, r._DNS_TTL)
+        record = r.DNSRecord('irrelevant', r._TYPE_SRV, r._CLASS_IN, r._DNS_HOST_TTL)
         self.assertRaises(r.AbstractMethodException, record.__eq__, record)
         self.assertRaises(r.AbstractMethodException, record.write, None)
 
@@ -134,7 +134,7 @@ class PacketGeneration(unittest.TestCase):
     def test_parse_own_packet_response(self):
         generated = r.DNSOutgoing(r._FLAGS_QR_RESPONSE)
         generated.add_answer_at_time(r.DNSService(
-            "æøå.local.", r._TYPE_SRV, r._CLASS_IN, r._DNS_TTL, 0, 0, 80, "foo.local."), 0)
+            "æøå.local.", r._TYPE_SRV, r._CLASS_IN, r._DNS_HOST_TTL, 0, 0, 80, "foo.local."), 0)
         parsed = r.DNSIncoming(generated.packet())
         self.assertEqual(len(generated.answers), 1)
         self.assertEqual(len(generated.answers), len(parsed.answers))
@@ -153,11 +153,11 @@ class PacketGeneration(unittest.TestCase):
         question = r.DNSQuestion("testname.local.", r._TYPE_SRV, r._CLASS_IN)
         query_generated.add_question(question)
         answer1 = r.DNSService(
-            "testname1.local.", r._TYPE_SRV, r._CLASS_IN, r._DNS_TTL, 0, 0, 80, "foo.local.")
+            "testname1.local.", r._TYPE_SRV, r._CLASS_IN, r._DNS_HOST_TTL, 0, 0, 80, "foo.local.")
         staleanswer2 = r.DNSService(
-            "testname2.local.", r._TYPE_SRV, r._CLASS_IN, r._DNS_TTL/2, 0, 0, 80, "foo.local.")
+            "testname2.local.", r._TYPE_SRV, r._CLASS_IN, r._DNS_HOST_TTL/2, 0, 0, 80, "foo.local.")
         answer2 = r.DNSService(
-            "testname2.local.", r._TYPE_SRV, r._CLASS_IN, r._DNS_TTL, 0, 0, 80, "foo.local.")
+            "testname2.local.", r._TYPE_SRV, r._CLASS_IN, r._DNS_HOST_TTL, 0, 0, 80, "foo.local.")
         query_generated.add_answer_at_time(answer1, 0)
         query_generated.add_answer_at_time(staleanswer2, 0)
         query = r.DNSIncoming(query_generated.packet())
@@ -441,10 +441,10 @@ class Names(unittest.TestCase):
         out = r.DNSOutgoing(r._FLAGS_QR_RESPONSE | r._FLAGS_AA)
         out.add_answer_at_time(
             r.DNSPointer(type_, r._TYPE_PTR, r._CLASS_IN,
-                         r._DNS_TTL, name), 0)
+                         r._DNS_HOST_TTL, name), 0)
         out.add_answer_at_time(
             r.DNSService(type_, r._TYPE_SRV, r._CLASS_IN,
-                         r._DNS_TTL, 0, 0, 80,
+                         r._DNS_HOST_TTL, 0, 0, 80,
                          name), 0)
         zc.send(out)
 
@@ -609,7 +609,7 @@ class TestRegistrar(unittest.TestCase):
         setattr(zc, "send", send)
 
         # register service with default TTL
-        expected_ttl = r._DNS_TTL
+        expected_ttl = r._DNS_HOST_TTL
         zc.register_service(info)
         assert nbr_answers == 12 and nbr_additionals == 0 and nbr_authorities == 3
         nbr_answers = nbr_additionals = nbr_authorities = 0
@@ -631,8 +631,8 @@ class TestRegistrar(unittest.TestCase):
         nbr_answers = nbr_additionals = nbr_authorities = 0
 
         # register service with custom TTL
-        expected_ttl = r._DNS_TTL * 2
-        assert expected_ttl != r._DNS_TTL
+        expected_ttl = r._DNS_HOST_TTL * 2
+        assert expected_ttl != r._DNS_HOST_TTL
         zc.register_service(info, ttl=expected_ttl)
         assert nbr_answers == 12 and nbr_additionals == 0 and nbr_authorities == 3
         nbr_answers = nbr_additionals = nbr_authorities = 0
@@ -894,7 +894,7 @@ def test_integration():
         """Current system time in milliseconds"""
         return time.time() * 1000 + time_offset * 1000
 
-    expected_ttl = r._DNS_TTL
+    expected_ttl = r._DNS_HOST_TTL
 
     nbr_answers = 0
 

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -74,7 +74,8 @@ _BROWSER_BACKOFF_LIMIT = 3600  # s
 _MDNS_ADDR = '224.0.0.251'
 _MDNS_PORT = 5353
 _DNS_PORT = 53
-_DNS_TTL = 120  # two minutes default TTL as recommended by RFC6762
+_DNS_HOST_TTL = 120  # two minute for host records (A, SRV etc) as-per RFC6762
+_DNS_OTHER_TTL = 4500  # 75 minutes for non-host records (PTR, TXT etc) as-per RFC6762
 
 _MAX_MSG_TYPICAL = 1460  # unused
 _MAX_MSG_ABSOLUTE = 8966
@@ -1835,7 +1836,7 @@ class Zeroconf(QuietLogger):
             self.remove_service_listener(listener)
 
     def register_service(
-        self, info: ServiceInfo, ttl: int = _DNS_TTL, allow_name_change: bool = False,
+        self, info: ServiceInfo, ttl: int = _DNS_HOST_TTL, allow_name_change: bool = False,
     ) -> None:
         """Registers service information to the network with a default TTL
         of 60 seconds.  Zeroconf will then respond to requests for
@@ -2048,7 +2049,7 @@ class Zeroconf(QuietLogger):
                             out = DNSOutgoing(_FLAGS_QR_RESPONSE | _FLAGS_AA)
                         out.add_answer(msg, DNSPointer(
                             "_services._dns-sd._udp.local.", _TYPE_PTR,
-                            _CLASS_IN, _DNS_TTL, stype))
+                            _CLASS_IN, _DNS_OTHER_TTL, stype))
                 for service in self.services.values():
                     if question.name == service.type:
                         if out is None:

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1400,7 +1400,8 @@ class ServiceInfo(RecordUpdateListener):
     """Service information"""
 
     def __init__(self, type_: str, name: str, address: Optional[bytes] = None, port: Optional[int] = None,
-                 weight: int = 0, priority: int = 0, properties=b'', server: Optional[str] = None) -> None:
+                 weight: int = 0, priority: int = 0, properties=b'', server: Optional[str] = None,
+                 host_ttl: int = _DNS_HOST_TTL, other_ttl: int = _DNS_OTHER_TTL) -> None:
         """Create a service description.
 
         type_: fully qualified service type name
@@ -1411,7 +1412,9 @@ class ServiceInfo(RecordUpdateListener):
         priority: priority of the service
         properties: dictionary of properties (or a string holding the
                     bytes for the text field)
-        server: fully qualified name for service host (defaults to name)"""
+        server: fully qualified name for service host (defaults to name)
+        host_ttl: ttl used for A/SRV records
+        other_ttl: ttl used for PTR/TXT records"""
 
         if not type_.endswith(service_type_name(name, allow_underscores=True)):
             raise BadTypeInNameException
@@ -1427,8 +1430,8 @@ class ServiceInfo(RecordUpdateListener):
             self.server = name
         self._properties = {}  # type: ServicePropertiesType
         self._set_properties(properties)
-        self.host_ttl = _DNS_HOST_TTL
-        self.other_ttl = _DNS_OTHER_TTL
+        self.host_ttl = host_ttl
+        self.other_ttl = other_ttl
 
     @property
     def properties(self) -> ServicePropertiesType:
@@ -1842,6 +1845,8 @@ class Zeroconf(QuietLogger):
         service.  The name of the service may be changed if needed to make
         it unique on the network."""
         if ttl is not None:
+            # ttl argument is used to maintain backward compatibility
+            # Setting TTLs via ServiceInfo is preferred
             info.host_ttl = ttl
             info.other_ttl = ttl
         self.check_service(info, allow_name_change)


### PR DESCRIPTION
This PR aims to bring the default TTLs for DNS record types into line with RFC 6762.

Whilst there are two default TTLs dependent on the record type, there is only one argument to `register_service`, so I've tried to maintain the existing behaviour to avoid breaking the interface. If it is seen as useful or important to be able to set these TTLs independently then the final commit adds new arguments to the `ServiceInfo` constructor for this purpose. I'd be happy to remove the final commit if there isn't seen to be a great deal of value in that flexibility.

I hope this is useful, and I'd be interested in any feedback on the approach.