### PR TITLE
Add support for MyListener call getting updates to service TXT records

### DIFF
--- a/test_zeroconf.py
+++ b/test_zeroconf.py
@@ -807,6 +807,84 @@ class ListenerTest(unittest.TestCase):
             zeroconf_browser.remove_service_listener(listener)
             zeroconf_browser.close()
 
+    def test_integration_with_listener_class_with_update(self):
+
+        service_added = Event()
+        service_removed = Event()
+        service_updated = Event()
+
+        subtype_name = "My special Subtype"
+        type_ = "_http._tcp.local."
+        subtype = subtype_name + "._sub." + type_
+        name = "xxxyyyæøå"
+        registration_name = "%s.%s" % (name, type_)
+
+        class MyListener(r.ServiceListener):
+            def add_service(self, zeroconf, type, name):
+                zeroconf.get_service_info(type, name)
+                service_added.set()
+
+            def remove_service(self, zeroconf, type, name):
+                service_removed.set()
+
+            def update_service(self, zeroconf, type, name):
+                service_updated.set()
+
+        listener = MyListener()
+        zeroconf_browser = Zeroconf(interfaces=['127.0.0.1'])
+        zeroconf_browser.add_service_listener(subtype, listener)
+
+        properties = dict(
+            prop_none=None,
+            prop_string=b'a_prop',
+            prop_float=1.0,
+            prop_blank=b'a blanked string',
+            prop_true=1,
+            prop_false=0,
+        )
+
+        zeroconf_registrar = Zeroconf(interfaces=['127.0.0.1'])
+        desc = {'path': '/~paulsm/'}  # type: r.ServicePropertiesType
+        desc.update(properties)
+        info_service = ServiceInfo(
+            subtype, registration_name,
+            socket.inet_aton("10.0.1.2"), 80, 0, 0,
+            desc, "ash-2.local.")
+        zeroconf_registrar.register_service(info_service)
+
+        try:
+            service_added.wait(1)
+            assert service_added.is_set()
+
+            # short pause to allow multicast timers to expire
+            time.sleep(2)
+
+            # clear the answer cache to force query
+            for record in zeroconf_browser.cache.entries():
+                zeroconf_browser.cache.remove(record)
+
+            # get service info without answer cache
+            info = zeroconf_browser.get_service_info(type_, registration_name)
+            assert info is not None
+            assert info.properties[b'prop_none'] is False
+            assert info.properties[b'prop_string'] == properties['prop_string']
+            assert info.properties[b'prop_float'] is False
+            assert info.properties[b'prop_blank'] == properties['prop_blank']
+            assert info.properties[b'prop_true'] is True
+            assert info.properties[b'prop_false'] is False
+
+            info = zeroconf_browser.get_service_info(subtype, registration_name)
+            assert info is not None
+            assert info.properties[b'prop_none'] is False
+
+            zeroconf_registrar.unregister_service(info_service)
+            service_removed.wait(1)
+            assert service_removed.is_set()
+        finally:
+            zeroconf_registrar.close()
+            zeroconf_browser.remove_service_listener(listener)
+            zeroconf_browser.close()
+
 
 def test_backoff():
     got_query = Event()

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -38,7 +38,7 @@ import ifaddr
 
 __author__ = 'Paul Scott-Murphy, William McBrine'
 __maintainer__ = 'Jakub Stasiak <jakub@stasiak.at>'
-__version__ = '0.21.3'
+__version__ = '0.22.0'
 __license__ = 'LGPL'
 
 
@@ -169,6 +169,7 @@ class InterfaceChoice(enum.Enum):
 class ServiceStateChange(enum.Enum):
     Added = 1
     Removed = 2
+    Updated = 3
 
 
 # utility functions
@@ -1267,6 +1268,8 @@ class ServiceListener:
     def remove_service(self, zc, type_, name) -> None:
         raise NotImplementedError()
 
+    def update_service(self, zc, type_, name) -> None:
+        raise NotImplementedError()
 
 class ServiceBrowser(RecordUpdateListener, threading.Thread):
 
@@ -1312,6 +1315,9 @@ class ServiceBrowser(RecordUpdateListener, threading.Thread):
                     listener.add_service(*args)
                 elif state_change is ServiceStateChange.Removed:
                     listener.remove_service(*args)
+                elif state_change is ServiceStateChange.Updated:
+                    if hasattr(listener, 'update_service'):
+                        listener.update_service(*args)
                 else:
                     raise NotImplementedError(state_change)
             handlers.append(on_change)
@@ -1360,6 +1366,12 @@ class ServiceBrowser(RecordUpdateListener, threading.Thread):
             expires = record.get_expiration_time(75)
             if expires < self.next_time:
                 self.next_time = expires
+
+        elif record.type == _TYPE_TXT and record.name == self.type:
+            assert isinstance(record, DNSText)
+            expired = record.is_expired(now)
+            if not expired:
+                enqueue_callback(ServiceStateChange.Updated, record.name) # New
 
     def cancel(self):
         self.done = True
@@ -2031,9 +2043,12 @@ class Zeroconf(QuietLogger):
                         entry.reset_ttl(record)
             else:
                 self.cache.add(record)
+                if record.type == _TYPE_TXT:
+                    self.update_record(now, record)
 
         for record in msg.answers:
-            self.update_record(now, record)
+            if record.type == _TYPE_PTR:
+                self.update_record(now, record)
 
     def handle_query(self, msg: DNSIncoming, addr: str, port: int) -> None:
         """Deal with incoming query packets.  Provides a response if

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1371,7 +1371,7 @@ class ServiceBrowser(RecordUpdateListener, threading.Thread):
             assert isinstance(record, DNSText)
             expired = record.is_expired(now)
             if not expired:
-                enqueue_callback(ServiceStateChange.Updated, record.name) # New
+                enqueue_callback(ServiceStateChange.Updated, record.name)
 
     def cancel(self):
         self.done = True


### PR DESCRIPTION
At the moment, the implementation supports notification to the  ServiceListener class for additions and removals of service, but for service updates to the TXT record, the client must poll the ServiceInfo class. This draft PR provides a mechanism to have a callback on the ServiceListener class be invoked when the TXT record changes.

I fully expect that there may be a better way of doing this or indeed a way of doing it with the existing implementation and would be grateful to be corrected on my use. 