### PR TITLE
Makefile: be specific which files to check with black

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ flake8:
 
 .PHONY: black_check
 black_check:
-	black --check .
+	black --check *.py examples
 
 mypy:
 	mypy examples/*.py test_zeroconf.py zeroconf.py


### PR DESCRIPTION
Otherwise black tries to check the "env" directory, which fails.