### PR TITLE
Add support for multiple addresses when publishing a service

### DIFF
--- a/examples/browser.py
+++ b/examples/browser.py
@@ -19,7 +19,9 @@ def on_service_state_change(
     if state_change is ServiceStateChange.Added:
         info = zeroconf.get_service_info(service_type, name)
         if info:
-            print("  Address: %s:%d" % (socket.inet_ntoa(cast(bytes, info.address)), cast(int, info.port)))
+            print(
+                "  Address: %s:%d" % (socket.inet_ntoa(info.addresses[0]), cast(int, info.port))
+            )
             print("  Weight: %d, priority: %d" % (info.weight, info.priority))
             print("  Server: %s" % (info.server,))
             if info.properties:

--- a/examples/browser.py
+++ b/examples/browser.py
@@ -19,9 +19,11 @@ def on_service_state_change(
     if state_change is ServiceStateChange.Added:
         info = zeroconf.get_service_info(service_type, name)
         if info:
-            print(
-                "  Address: %s:%d" % (socket.inet_ntoa(info.addresses[0]), cast(int, info.port))
-            )
+            addresses = [
+                "%s:%d" % (socket.inet_ntoa(addr), cast(int, info.port))
+                for addr in info.addresses
+            ]
+            print("  Addresses: %s" % ", ".join(addresses))
             print("  Weight: %d, priority: %d" % (info.weight, info.priority))
             print("  Server: %s" % (info.server,))
             if info.properties:

--- a/examples/browser.py
+++ b/examples/browser.py
@@ -19,10 +19,7 @@ def on_service_state_change(
     if state_change is ServiceStateChange.Added:
         info = zeroconf.get_service_info(service_type, name)
         if info:
-            addresses = [
-                "%s:%d" % (socket.inet_ntoa(addr), cast(int, info.port))
-                for addr in info.addresses
-            ]
+            addresses = ["%s:%d" % (socket.inet_ntoa(addr), cast(int, info.port)) for addr in info.addresses]
             print("  Addresses: %s" % ", ".join(addresses))
             print("  Weight: %d, priority: %d" % (info.weight, info.priority))
             print("  Server: %s" % (info.server,))

--- a/examples/registration.py
+++ b/examples/registration.py
@@ -20,12 +20,10 @@ if __name__ == '__main__':
     info = ServiceInfo(
         "_http._tcp.local.",
         "Paul's Test Web Site._http._tcp.local.",
-        socket.inet_aton("127.0.0.1"),
-        80,
-        0,
-        0,
-        desc,
-        "ash-2.local.",
+        addresses=[socket.inet_aton("127.0.0.1")],
+        port=80,
+        properties=desc,
+        server="ash-2.local.",
     )
 
     zeroconf = Zeroconf()

--- a/examples/self_test.py
+++ b/examples/self_test.py
@@ -21,11 +21,9 @@ if __name__ == '__main__':
     info = ServiceInfo(
         "_http._tcp.local.",
         "My Service Name._http._tcp.local.",
-        socket.inet_aton("127.0.0.1"),
-        1234,
-        0,
-        0,
-        desc,
+        addresses=[socket.inet_aton("127.0.0.1")],
+        port=1234,
+        properties=desc,
     )
     print("   Registering service...")
     r.register_service(info)

--- a/test_zeroconf.py
+++ b/test_zeroconf.py
@@ -969,8 +969,20 @@ def test_multiple_addresses():
     # Old way
     info = ServiceInfo(type_, registration_name, address, 80, 0, 0, desc, "ash-2.local.")
 
-    assert not hasattr(info, "address")
+    assert info.address == address
     assert info.addresses == [address]
+
+    # Updating works
+    address2 = socket.inet_aton("10.0.1.3")
+    info.address = address2
+
+    assert info.address == address2
+    assert info.addresses == [address2]
+
+    info.address = None
+
+    assert info.address is None
+    assert info.addresses == []
 
     # Compatibility way
     info = ServiceInfo(type_, registration_name, [address, address], 80, 0, 0, desc, "ash-2.local.")

--- a/test_zeroconf.py
+++ b/test_zeroconf.py
@@ -958,3 +958,28 @@ def test_integration():
         assert service_removed.is_set()
         browser.cancel()
         zeroconf_browser.close()
+
+
+def test_multiple_addresses():
+    type_ = "_http._tcp.local."
+    registration_name = "xxxyyy.%s" % type_
+    desc = {'path': '/~paulsm/'}
+    address = socket.inet_aton("10.0.1.2")
+
+    # Old way
+    info = ServiceInfo(type_, registration_name, address, 80, 0, 0, desc, "ash-2.local.")
+
+    assert not hasattr(info, "address")
+    assert info.addresses == [address]
+
+    # Compatibility way
+    info = ServiceInfo(type_, registration_name, [address, address], 80, 0, 0, desc, "ash-2.local.")
+
+    assert info.addresses == [address, address]
+
+    # New kwarg way
+    info = ServiceInfo(
+        type_, registration_name, None, 80, 0, 0, desc, "ash-2.local.", addresses=[address, address]
+    )
+
+    assert info.addresses == [address, address]

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1430,6 +1430,9 @@ class ServiceInfo(RecordUpdateListener):
 
     """Service information"""
 
+    # FIXME(dtantsur): black 19.3b0 produces code that is not valid syntax on
+    # Python 3.5: https://github.com/python/black/issues/759
+    # fmt: off
     def __init__(
         self,
         type_: str,
@@ -1491,6 +1494,7 @@ class ServiceInfo(RecordUpdateListener):
         self._set_properties(properties)
         self.host_ttl = host_ttl
         self.other_ttl = other_ttl
+    # fmt: on
 
     @property
     def address(self):


### PR DESCRIPTION
This is a rebased and fixed version of PR #27, which also adds compatibility shim for ServiceInfo.address and does a proper deprecation for it.