### PR TITLE
First stab at supporting listening on IPv6 interfaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
     - if [[ "${TRAVIS_PYTHON_VERSION}" != "pypy"* ]] ; then pip install mypy ; fi
     - if [[ "${TRAVIS_PYTHON_VERSION}" != *"3.5"* ]] ; then pip install black ; fi
 script:
-    - make ci
+    # no IPv6 support in Travis :(
+    - make TEST_ARGS='-a "!IPv6"' ci
 after_success:
     - coveralls

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 MAX_LINE_LENGTH=110
 PYTHON_IMPLEMENTATION:=$(shell python -c "import sys;import platform;sys.stdout.write(platform.python_implementation())")
 PYTHON_VERSION:=$(shell python -c "import sys;sys.stdout.write('%d.%d' % sys.version_info[:2])")
+TEST_ARGS=
 
 LINT_TARGETS:=flake8
 
@@ -39,10 +40,10 @@ mypy:
 	mypy examples/*.py test_zeroconf.py zeroconf.py
 
 test:
-	nosetests -v
+	nosetests -v $(TEST_ARGS)
 
 test_coverage:
-	nosetests -v --with-coverage --cover-package=zeroconf
+	nosetests -v --with-coverage --cover-package=zeroconf $(TEST_ARGS)
 
 autopep8:
 	autopep8 --max-line-length=$(MAX_LINE_LENGTH) -i examples *.py

--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,18 @@ Status
 There are some people using this package. I don't actively use it and as such
 any help I can offer with regard to any issues is very limited.
 
+IPv6 support
+------------
+
+IPv6 support is relatively new and currently limited, specifically:
+* `InterfaceChoice.All` is an alias for `InterfaceChoice.Default` on non-POSIX
+  systems.
+* On Windows specific interfaces can only be requested as interface indexes,
+  not as IP addresses.
+* Dual-stack IPv6 sockets are used, which may not be supported everywhere (some
+  BSD variants do not have them).
+* Listening on localhost (`::1`) does not work. Help with understanding why is
+  appreciated.
 
 How to get python-zeroconf?
 ===========================

--- a/examples/browser.py
+++ b/examples/browser.py
@@ -2,13 +2,13 @@
 
 """ Example of browsing for a service (in this case, HTTP) """
 
+import argparse
 import logging
 import socket
-import sys
 from time import sleep
 from typing import cast
 
-from zeroconf import ServiceBrowser, ServiceStateChange, Zeroconf
+from zeroconf import IpVersion, ServiceBrowser, ServiceStateChange, Zeroconf
 
 
 def on_service_state_change(
@@ -36,11 +36,24 @@ def on_service_state_change(
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
-    if len(sys.argv) > 1:
-        assert sys.argv[1:] == ['--debug']
-        logging.getLogger('zeroconf').setLevel(logging.DEBUG)
 
-    zeroconf = Zeroconf()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--debug', action='store_true')
+    version_group = parser.add_mutually_exclusive_group()
+    version_group.add_argument('--v6', action='store_true')
+    version_group.add_argument('--v6-only', action='store_true')
+    args = parser.parse_args()
+
+    if args.debug:
+        logging.getLogger('zeroconf').setLevel(logging.DEBUG)
+    if args.v6:
+        ip_version = IpVersion.All
+    elif args.v6_only:
+        ip_version = IpVersion.V6Only
+    else:
+        ip_version = IpVersion.V4Only
+
+    zeroconf = Zeroconf(ip_version=ip_version)
     print("\nBrowsing services, press Ctrl-C to exit...\n")
     browser = ServiceBrowser(zeroconf, "_http._tcp.local.", handlers=[on_service_state_change])
 

--- a/examples/registration.py
+++ b/examples/registration.py
@@ -2,18 +2,31 @@
 
 """ Example of announcing a service (in this case, a fake HTTP server) """
 
+import argparse
 import logging
 import socket
-import sys
 from time import sleep
 
-from zeroconf import ServiceInfo, Zeroconf
+from zeroconf import IpVersion, ServiceInfo, Zeroconf
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
-    if len(sys.argv) > 1:
-        assert sys.argv[1:] == ['--debug']
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--debug', action='store_true')
+    version_group = parser.add_mutually_exclusive_group()
+    version_group.add_argument('--v6', action='store_true')
+    version_group.add_argument('--v6-only', action='store_true')
+    args = parser.parse_args()
+
+    if args.debug:
         logging.getLogger('zeroconf').setLevel(logging.DEBUG)
+    if args.v6:
+        ip_version = IpVersion.All
+    elif args.v6_only:
+        ip_version = IpVersion.V6Only
+    else:
+        ip_version = IpVersion.V4Only
 
     desc = {'path': '/~paulsm/'}
 
@@ -26,7 +39,7 @@ if __name__ == '__main__':
         server="ash-2.local.",
     )
 
-    zeroconf = Zeroconf()
+    zeroconf = Zeroconf(ip_version=ip_version)
     print("Registration of a service, press Ctrl-C to exit...")
     zeroconf.register_service(info)
     try:


### PR DESCRIPTION
This change adds basic support for listening on IPv6 interfaces.
Some limitations exist for non-POSIX platforms, pending fixes in
Python and in the ifaddr library. Also dual V4-V6 sockets may not
work on all BSD platforms. As a result, V4-only is used by default.