### PR TITLE
Some code fixes to make sure IPv6 addresses are recorded and returned…

### DIFF
--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1607,7 +1607,7 @@ class ServiceInfo(RecordUpdateListener):
     def update_record(self, zc: 'Zeroconf', now: float, record: DNSRecord) -> None:
         """Updates service information from a DNS record"""
         if record is not None and not record.is_expired(now):
-            if record.type == _TYPE_A:
+            if record.type in [_TYPE_A, _TYPE_AAAA]:
                 assert isinstance(record, DNSAddress)
                 # if record.name == self.name:
                 if record.name == self.server:
@@ -1622,6 +1622,7 @@ class ServiceInfo(RecordUpdateListener):
                     self.priority = record.priority
                     # self.address = None
                     self.update_record(zc, now, zc.cache.get_by_details(self.server, _TYPE_A, _CLASS_IN))
+                    self.update_record(zc, now, zc.cache.get_by_details(self.server, _TYPE_AAAA, _CLASS_IN))
             elif record.type == _TYPE_TXT:
                 assert isinstance(record, DNSText)
                 if record.name == self.name:
@@ -1639,6 +1640,7 @@ class ServiceInfo(RecordUpdateListener):
         record_types_for_check_cache = [(_TYPE_SRV, _CLASS_IN), (_TYPE_TXT, _CLASS_IN)]
         if self.server is not None:
             record_types_for_check_cache.append((_TYPE_A, _CLASS_IN))
+            record_types_for_check_cache.append((_TYPE_AAAA, _CLASS_IN))
         for record_type in record_types_for_check_cache:
             cached = zc.cache.get_by_details(self.name, *record_type)
             if cached:


### PR DESCRIPTION
… when browsing.

With these changes I could successfully find services with either ip_version=IpVersion.All, V4Only or V6Only. The returned service info would contain all the address records found in the service reponses.

(Great library, by the way!)