### PR TITLE
Add additional recommended records to PTR responses

### DIFF
--- a/zeroconf.py
+++ b/zeroconf.py
@@ -2338,6 +2338,40 @@ class Zeroconf(QuietLogger):
                             msg,
                             DNSPointer(service.type, _TYPE_PTR, _CLASS_IN, service.other_ttl, service.name),
                         )
+
+                        # Add recommended additional answers according to
+                        # https://tools.ietf.org/html/rfc6763#section-12.1.
+                        out.add_additional_answer(
+                            DNSService(
+                                service.name,
+                                _TYPE_SRV,
+                                _CLASS_IN | _CLASS_UNIQUE,
+                                service.host_ttl,
+                                service.priority,
+                                service.weight,
+                                service.port,
+                                service.server,
+                            ),
+                        )
+                        out.add_additional_answer(
+                            DNSText(
+                                service.name,
+                                _TYPE_TXT,
+                                _CLASS_IN | _CLASS_UNIQUE,
+                                service.other_ttl,
+                                service.text,
+                            ),
+                        )
+                        for address in service.addresses:
+                            out.add_additional_answer(
+                                DNSAddress(
+                                    service.server,
+                                    _TYPE_A,
+                                    _CLASS_IN | _CLASS_UNIQUE,
+                                    service.host_ttl,
+                                    address,
+                                )
+                            )
             else:
                 try:
                     if out is None:

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -2351,7 +2351,7 @@ class Zeroconf(QuietLogger):
                                 service.weight,
                                 service.port,
                                 service.server,
-                            ),
+                            )
                         )
                         out.add_additional_answer(
                             DNSText(
@@ -2360,7 +2360,7 @@ class Zeroconf(QuietLogger):
                                 _CLASS_IN | _CLASS_UNIQUE,
                                 service.other_ttl,
                                 service.text,
-                            ),
+                            )
                         )
                         for address in service.addresses:
                             out.add_additional_answer(


### PR DESCRIPTION
RFC6763 indicates a server should include the SRV/TXT/A/AAAA records
when responding to a PTR record request.  This optimization ensures
the client doesn't have to then query for these additional records.

It has been observed that when multiple Windows 10 machines are monitoring
for the same service, this unoptimized response to the PTR record
request can cause extremely high CPU usage in both the DHCP Client
& Device Association service (I suspect due to all clients having to
then sending/receiving the additional queries/responses).