### PR TITLE
Make AAAA records work (closes #52)

### DIFF
--- a/examples/self_test.py
+++ b/examples/self_test.py
@@ -18,10 +18,13 @@ if __name__ == '__main__':
     r = Zeroconf()
     print("1. Testing registration of a service...")
     desc = {'version': '0.10', 'a': 'test value', 'b': 'another value'}
+    addresses = [socket.inet_aton("127.0.0.1")]
+    if socket.has_ipv6:
+        addresses.append(socket.inet_pton(socket.AF_INET6, '::1'))
     info = ServiceInfo(
         "_http._tcp.local.",
         "My Service Name._http._tcp.local.",
-        addresses=[socket.inet_aton("127.0.0.1")],
+        addresses=addresses,
         port=1234,
         properties=desc,
     )

--- a/test_zeroconf.py
+++ b/test_zeroconf.py
@@ -1067,6 +1067,14 @@ def test_multiple_addresses():
 
     assert info.addresses == [address, address]
 
+    if socket.has_ipv6:
+        address_v6 = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
+        info = ServiceInfo(type_, registration_name, [address, address_v6], 80, 0, 0, desc, "ash-2.local.")
+        assert info.addresses == [address, address_v6]
+        assert info.addresses_by_version(r.IPVersion.All) == [address, address_v6]
+        assert info.addresses_by_version(r.IPVersion.V4Only) == [address]
+        assert info.addresses_by_version(r.IPVersion.V6Only) == [address_v6]
+
 
 def test_ptr_optimization():
 

--- a/test_zeroconf.py
+++ b/test_zeroconf.py
@@ -563,8 +563,9 @@ class TestDnsIncoming(unittest.TestCase):
         generated.add_additional_answer(answer)
         packet = generated.packet()
         parsed = r.DNSIncoming(packet)
-        answer = parsed.answers[0]
-        assert answer.address == packed
+        record = parsed.answers[0]
+        assert isinstance(record, r.DNSAddress)
+        assert record.address == packed
 
 
 class TestRegistrar(unittest.TestCase):
@@ -696,7 +697,7 @@ class ServiceTypesQuery(unittest.TestCase):
             zeroconf_registrar.close()
 
     @unittest.skipIf(not socket.has_ipv6, 'Requires IPv6')
-    def test_integration_with_listener_AAAA(self):
+    def test_integration_with_listener_v6_records(self):
 
         type_ = "_test-srvc-type._tcp.local."
         name = "xxxyyy"

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1607,7 +1607,7 @@ class ServiceInfo(RecordUpdateListener):
     def update_record(self, zc: 'Zeroconf', now: float, record: DNSRecord) -> None:
         """Updates service information from a DNS record"""
         if record is not None and not record.is_expired(now):
-            if record.type == _TYPE_A:
+            if record.type in [_TYPE_A, _TYPE_AAAA]:
                 assert isinstance(record, DNSAddress)
                 # if record.name == self.name:
                 if record.name == self.server:
@@ -1622,6 +1622,7 @@ class ServiceInfo(RecordUpdateListener):
                     self.priority = record.priority
                     # self.address = None
                     self.update_record(zc, now, zc.cache.get_by_details(self.server, _TYPE_A, _CLASS_IN))
+                    self.update_record(zc, now, zc.cache.get_by_details(self.server, _TYPE_AAAA, _CLASS_IN))
             elif record.type == _TYPE_TXT:
                 assert isinstance(record, DNSText)
                 if record.name == self.name:
@@ -1639,6 +1640,7 @@ class ServiceInfo(RecordUpdateListener):
         record_types_for_check_cache = [(_TYPE_SRV, _CLASS_IN), (_TYPE_TXT, _CLASS_IN)]
         if self.server is not None:
             record_types_for_check_cache.append((_TYPE_A, _CLASS_IN))
+            record_types_for_check_cache.append((_TYPE_AAAA, _CLASS_IN))
         for record_type in record_types_for_check_cache:
             cached = zc.cache.get_by_details(self.name, *record_type)
             if cached:


### PR DESCRIPTION
This PR incorporates changes from the earlier PR #179 (thanks to Mikael Pahmp), adding tests and a few more fixes to make AAAA records work in practice.

Note that changing `addresses` to container IPv6 addresses may be considered a breaking change, for example, for consumers that unconditionally apply `inet_aton` to them. I'm introducing a new function to be able to retries only addresses from one family.