### PR TITLE
Rework exposing IPv6 addresses on ServiceInfo

### DIFF
--- a/examples/self_test.py
+++ b/examples/self_test.py
@@ -19,8 +19,10 @@ if __name__ == '__main__':
     print("1. Testing registration of a service...")
     desc = {'version': '0.10', 'a': 'test value', 'b': 'another value'}
     addresses = [socket.inet_aton("127.0.0.1")]
+    expected = {'127.0.0.1'}
     if socket.has_ipv6:
         addresses.append(socket.inet_pton(socket.AF_INET6, '::1'))
+        expected.add('::1')
     info = ServiceInfo(
         "_http._tcp.local.",
         "My Service Name._http._tcp.local.",
@@ -37,6 +39,7 @@ if __name__ == '__main__':
     print("3. Testing query of own service...")
     queried_info = r.get_service_info("_http._tcp.local.", "My Service Name._http._tcp.local.")
     assert queried_info
+    assert set(queried_info.parsed_addresses()) == expected
     print("   Getting self: %s" % (queried_info,))
     print("   Query done.")
     print("4. Testing unregister of service information...")


### PR DESCRIPTION
* Return backward compatibility for ServiceInfo.addresses by making
  it return V4 addresses only
* Add ServiceInfo.parsed_addresses for convenient access to addresses
* Raise TypeError if addresses are not provided as bytes (otherwise
  an ugly assertion error is raised when sending)
* Add more IPv6 unit tests