### PR TITLE
inet_ntoa is not handling ipv6

### DIFF
--- a/examples/browser.py
+++ b/examples/browser.py
@@ -19,7 +19,7 @@ def on_service_state_change(
     if state_change is ServiceStateChange.Added:
         info = zeroconf.get_service_info(service_type, name)
         if info:
-            addresses = ["%s:%d" % (socket.inet_ntoa(addr), cast(int, info.port)) for addr in info.addresses]
+            addresses = ["%s:%d" % (socket.inet_ntoa(addr), cast(int, info.port)) for addr in info.addresses_by_version(IPVersion.V4Only)]
             print("  Addresses: %s" % ", ".join(addresses))
             print("  Weight: %d, priority: %d" % (info.weight, info.priority))
             print("  Server: %s" % (info.server,))


### PR DESCRIPTION
When calling info.addresses and the device contains an ipv6 address, than you get a exception.

Using info.addresses_by_version(IPVersion.V4Only) we make sure that no ipv6 address is returned