### PR TITLE
Bugfix: Flush outdated cache entries when incoming record is unique.

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1412,7 +1412,7 @@ class ServiceBrowser(RecordUpdateListener, threading.Thread):
             if expires < self.next_time:
                 self.next_time = expires
 
-        elif record.type == _TYPE_TXT and record.name == self.type:
+        elif record.type == _TYPE_TXT and record.name.endswith(self.type):
             assert isinstance(record, DNSText)
             expired = record.is_expired(now)
             if not expired:

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -2356,22 +2356,23 @@ class Zeroconf(QuietLogger):
         are held in the cache, and listeners are notified."""
         now = current_time_millis()
         for record in msg.answers:
-            expired = record.is_expired(now)
-            if record in self.cache.entries():
-                if expired:
-                    self.cache.remove(record)
-                else:
-                    entry = self.cache.get(record)
-                    if entry is not None:
-                        entry.reset_ttl(record)
-            else:
-                self.cache.add(record)
-                if record.type == _TYPE_TXT:
-                    self.update_record(now, record)
+            if record.unique:  # https://tools.ietf.org/html/rfc6762#section-10.2
+                for entry in self.cache.entries():
+                    if DNSEntry.__eq__(entry, record) and (record.created - entry.created > 1000):
+                        self.cache.remove(entry)
 
-        for record in msg.answers:
-            if record.type != _TYPE_TXT:
+            expired = record.is_expired(now)
+            entry = self.cache.get(record)
+            if not expired:
+                if entry is not None:
+                    entry.reset_ttl(record)
+                else:
+                    self.cache.add(record)
                 self.update_record(now, record)
+            else:
+                if entry is not None:
+                    self.update_record(now, record)
+                    self.cache.remove(entry)
 
     def handle_query(self, msg: DNSIncoming, addr: Optional[str], port: int) -> None:
         """Deal with incoming query packets.  Provides a response if


### PR DESCRIPTION
According to [RFC 6762 10.2](https://tools.ietf.org/html/rfc6762#section-10.2). Announcements to Flush Outdated Cache Entries, when the incoming record's cache-flush bit is set (record.unique == True in this module), "Instead of merging this new record additively into the cache in addition to any previous records with the same name, rrtype, and rrclass, all old records with that name, rrtype, and rrclass that were received more than one second ago are declared invalid, and marked to expire from the cache in one second."