### PR TITLE
Fix resetting of TTL

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -498,12 +498,14 @@ class DNSRecord(DNSEntry):
         return self._stale_time <= now
 
     def reset_ttl(self, other: 'DNSRecord') -> None:
-        """Sets this record's TTL, created time and expiration times
-        to that of another record."""
+        """Sets this record's TTL and created time to that of
+        another record."""
         self.created = other.created
-        self.ttl = other.ttl       
-        self._expiration_time = other._expiration_time
-        self._stale_time = other._stale_time
+        self.ttl = other.ttl
+
+        """ reset expiration times """
+        self._expiration_time = self.get_expiration_time(100)
+        self._stale_time = self.get_expiration_time(50)
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Abstract method"""

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -498,14 +498,12 @@ class DNSRecord(DNSEntry):
         return self._stale_time <= now
 
     def reset_ttl(self, other: 'DNSRecord') -> None:
-        """Sets this record's TTL and created time to that of
-        another record."""
+        """Sets this record's TTL, created time and expiration times
+        to that of another record."""
         self.created = other.created
         self.ttl = other.ttl
-
-        """ reset expiration times """
-        self._expiration_time = self.get_expiration_time(100)
-        self._stale_time = self.get_expiration_time(50)
+        self._expiration_time = other._expiration_time
+        self._stale_time = other._stale_time
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Abstract method"""

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -498,14 +498,12 @@ class DNSRecord(DNSEntry):
         return self._stale_time <= now
 
     def reset_ttl(self, other: 'DNSRecord') -> None:
-        """Sets this record's TTL and created time to that of
-        another record."""
+        """Sets this record's TTL, created time and expiration times
+        to that of another record."""
         self.created = other.created
-        self.ttl = other.ttl
-
-        """ reset expiration times """
-        self._expiration_time = self.get_expiration_time(100)
-        self._stale_time = self.get_expiration_time(50)
+        self.ttl = other.ttl       
+        self._expiration_time = other._expiration_time
+        self._stale_time = other._stale_time
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Abstract method"""

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -501,7 +501,7 @@ class DNSRecord(DNSEntry):
         """Sets this record's TTL, created time and expiration times
         to that of another record."""
         self.created = other.created
-        self.ttl = other.ttl       
+        self.ttl = other.ttl
         self._expiration_time = other._expiration_time
         self._stale_time = other._stale_time
 

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -502,8 +502,6 @@ class DNSRecord(DNSEntry):
         another record."""
         self.created = other.created
         self.ttl = other.ttl
-
-        """ reset expiration times """
         self._expiration_time = self.get_expiration_time(100)
         self._stale_time = self.get_expiration_time(50)
 

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -501,7 +501,7 @@ class DNSRecord(DNSEntry):
         """Sets this record's TTL, created time and expiration times
         to that of another record."""
         self.created = other.created
-        self.ttl = other.ttl
+        self.ttl = other.ttl       
         self._expiration_time = other._expiration_time
         self._stale_time = other._stale_time
 

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -498,12 +498,14 @@ class DNSRecord(DNSEntry):
         return self._stale_time <= now
 
     def reset_ttl(self, other: 'DNSRecord') -> None:
-        """Sets this record's TTL, created time and expiration times
-        to that of another record."""
+        """Sets this record's TTL and created time to that of
+        another record."""
         self.created = other.created
         self.ttl = other.ttl
-        self._expiration_time = other._expiration_time
-        self._stale_time = other._stale_time
+
+        """ reset expiration times """
+        self._expiration_time = self.get_expiration_time(100)
+        self._stale_time = self.get_expiration_time(50)
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Abstract method"""

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -503,6 +503,10 @@ class DNSRecord(DNSEntry):
         self.created = other.created
         self.ttl = other.ttl
 
+        """ reset expiration times """
+        self._expiration_time = self.get_expiration_time(100)
+        self._stale_time = self.get_expiration_time(50)
+
     def write(self, out: 'DNSOutgoing') -> None:
         """Abstract method"""
         raise AbstractMethodException

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -20,8 +20,8 @@ from nose.plugins.attrib import attr
 # ensure I can find this package even when it hasn't been installed (for development purposes)
 sys.path.insert(0, '..')
 
-import zeroconf as r # noqa: E402
-from zeroconf import ( # noqa: E402
+import zeroconf as r  # noqa: E402
+from zeroconf import (  # noqa: E402
     DNSHinfo,
     DNSText,
     ServiceBrowser,

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -16,6 +16,10 @@ from typing import cast
 
 from nose.plugins.attrib import attr
 
+# ensure I can find this package even when it hasn't been installed (for development purposes)
+import sys
+sys.path.insert(0,'..')
+
 import zeroconf as r
 from zeroconf import (
     DNSHinfo,
@@ -78,6 +82,15 @@ class TestDunder(unittest.TestCase):
         record = r.DNSRecord('irrelevant', r._TYPE_SRV, r._CLASS_IN, r._DNS_HOST_TTL)
         self.assertRaises(r.AbstractMethodException, record.__eq__, record)
         self.assertRaises(r.AbstractMethodException, record.write, None)
+
+    def test_dns_record_reset_ttl(self):
+        record = r.DNSRecord('irrelevant', r._TYPE_SRV, r._CLASS_IN, r._DNS_HOST_TTL)
+        record2 = r.DNSRecord('irrelevant', r._TYPE_SRV, r._CLASS_IN, r._DNS_HOST_TTL)
+        record.reset_ttl(record2)
+        assert record.ttl == record2.ttl
+        assert record.created == record2.created
+        assert record._expiration_time == record2._expiration_time
+        assert record._stale_time == record2._stale_time
 
     def test_service_info_dunder(self):
         type_ = "_test-srvc-type._tcp.local."
@@ -1353,3 +1366,6 @@ def test_ptr_optimization():
 
     # unregister
     zc.unregister_service(info)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -85,15 +85,13 @@ class TestDunder(unittest.TestCase):
 
     def test_dns_record_reset_ttl(self):
         record = r.DNSRecord('irrelevant', r._TYPE_SRV, r._CLASS_IN, r._DNS_HOST_TTL)
-        
         time.sleep(1)
-
         record2 = r.DNSRecord('irrelevant', r._TYPE_SRV, r._CLASS_IN, r._DNS_HOST_TTL)
 
         assert record.created != record2.created
         assert record._expiration_time != record2._expiration_time
         assert record._stale_time != record2._stale_time
-        
+
         record.reset_ttl(record2)
 
         assert record.ttl == record2.ttl

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -8,6 +8,7 @@ import copy
 import logging
 import socket
 import struct
+import sys
 import time
 import unittest
 from threading import Event
@@ -17,11 +18,10 @@ from typing import cast
 from nose.plugins.attrib import attr
 
 # ensure I can find this package even when it hasn't been installed (for development purposes)
-import sys
-sys.path.insert(0,'..')
+sys.path.insert(0, '..')
 
-import zeroconf as r
-from zeroconf import (
+import zeroconf as r # noqa: E402
+from zeroconf import ( # noqa: E402
     DNSHinfo,
     DNSText,
     ServiceBrowser,
@@ -1366,6 +1366,7 @@ def test_ptr_optimization():
 
     # unregister
     zc.unregister_service(info)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -1368,7 +1368,3 @@ def test_ptr_optimization():
 
     # unregister
     zc.unregister_service(info)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -85,8 +85,17 @@ class TestDunder(unittest.TestCase):
 
     def test_dns_record_reset_ttl(self):
         record = r.DNSRecord('irrelevant', r._TYPE_SRV, r._CLASS_IN, r._DNS_HOST_TTL)
+        
+        time.sleep(1)
+
         record2 = r.DNSRecord('irrelevant', r._TYPE_SRV, r._CLASS_IN, r._DNS_HOST_TTL)
+
+        assert record.created != record2.created
+        assert record._expiration_time != record2._expiration_time
+        assert record._stale_time != record2._stale_time
+        
         record.reset_ttl(record2)
+
         assert record.ttl == record2.ttl
         assert record.created == record2.created
         assert record._expiration_time == record2._expiration_time

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -17,11 +17,8 @@ from typing import cast
 
 from nose.plugins.attrib import attr
 
-# ensure I can find this package even when it hasn't been installed (for development purposes)
-sys.path.insert(0, '..')
-
-import zeroconf as r  # noqa: E402
-from zeroconf import (  # noqa: E402
+import zeroconf as r
+from zeroconf import (
     DNSHinfo,
     DNSText,
     ServiceBrowser,
@@ -87,17 +84,16 @@ class TestDunder(unittest.TestCase):
         record = r.DNSRecord('irrelevant', r._TYPE_SRV, r._CLASS_IN, r._DNS_HOST_TTL)
         time.sleep(1)
         record2 = r.DNSRecord('irrelevant', r._TYPE_SRV, r._CLASS_IN, r._DNS_HOST_TTL)
+        now = r.current_time_millis()
 
         assert record.created != record2.created
-        assert record._expiration_time != record2._expiration_time
-        assert record._stale_time != record2._stale_time
+        assert record.get_remaining_ttl(now) != record2.get_remaining_ttl(now)
 
         record.reset_ttl(record2)
 
         assert record.ttl == record2.ttl
         assert record.created == record2.created
-        assert record._expiration_time == record2._expiration_time
-        assert record._stale_time == record2._stale_time
+        assert record.get_remaining_ttl(now) == record2.get_remaining_ttl(now)
 
     def test_service_info_dunder(self):
         type_ = "_test-srvc-type._tcp.local."
@@ -1373,7 +1369,3 @@ def test_ptr_optimization():
 
     # unregister
     zc.unregister_service(info)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -8,7 +8,6 @@ import copy
 import logging
 import socket
 import struct
-import sys
 import time
 import unittest
 from threading import Event
@@ -1369,3 +1368,7 @@ def test_ptr_optimization():
 
     # unregister
     zc.unregister_service(info)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Previously the reset_ttl method changed the time created and the TTL value, but did not change the expiration time or stale times. As a result a record would expire even when this method had been called.