### PR TITLE
DNS Record to_string cleanup and ttl update fix

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -502,6 +502,8 @@ class DNSRecord(DNSEntry):
         another record."""
         self.created = other.created
         self.ttl = other.ttl
+        self._expiration_time = self.get_expiration_time(100)
+        self._stale_time = self.get_expiration_time(50)
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Abstract method"""

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -420,7 +420,7 @@ class DNSEntry:
             result += ","
         result += self.name
         if other is not None:
-            result += ",%s]" % cast(Any, other)
+            result += "]=%s" % cast(Any, other)
         else:
             result += "]"
         return result
@@ -509,7 +509,7 @@ class DNSRecord(DNSEntry):
 
     def to_string(self, other: Union[bytes, str]) -> str:
         """String representation with additional information"""
-        arg = "%s/%s,%s" % (self.ttl, self.get_remaining_ttl(current_time_millis()), cast(Any, other))
+        arg = "%s/%s,%s" % (self.ttl, int(self.get_remaining_ttl(current_time_millis())), cast(Any, other))
         return DNSEntry.entry_to_string(self, "record", arg)
 
 
@@ -538,9 +538,9 @@ class DNSAddress(DNSRecord):
     def __repr__(self) -> str:
         """String representation"""
         try:
-            return str(socket.inet_ntoa(self.address))
+            return self.to_string(str(socket.inet_ntoa(self.address)))
         except Exception:  # TODO stop catching all Exceptions
-            return str(self.address)
+            return self.to_string(str(self.address))
 
 
 class DNSHinfo(DNSRecord):
@@ -580,7 +580,7 @@ class DNSHinfo(DNSRecord):
 
     def __repr__(self) -> str:
         """String representation"""
-        return self.cpu + " " + self.os
+        return self.to_string(self.cpu + " " + self.os)
 
 
 class DNSPointer(DNSRecord):


### PR DESCRIPTION

1) Change DNSRecord.to_string() to separate the record portion from record data portion.

2) Correct come DNSRecord subclasses to use DNSRecord.to_string() instead of raw data response

3) Corrected DNSRecord.reset_ttl() to calculate _expiration_time and _stale_time.  Prior to this patch, ttl updates were performed but the the expiration/stale times were not updating, resulting in the record always expiring and being re-added.