### PR TITLE
Fixed reset_ttl to correctly calculate expiration and stale time

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -502,6 +502,8 @@ class DNSRecord(DNSEntry):
         another record."""
         self.created = other.created
         self.ttl = other.ttl
+        self._expiration_time = self.get_expiration_time(100)
+        self._stale_time = self.get_expiration_time(50)
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Abstract method"""


### PR DESCRIPTION
When the ttl is being reset from an update, the pre-calculated expiration and stale times were not being updated.