### PR TITLE
Updated DNS entries so all subclasses of DNSRecord use to_string for __repr__

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -420,7 +420,7 @@ class DNSEntry:
             result += ","
         result += self.name
         if other is not None:
-            result += ",%s]" % cast(Any, other)
+            result += "]=%s" % cast(Any, other)
         else:
             result += "]"
         return result
@@ -509,7 +509,7 @@ class DNSRecord(DNSEntry):
 
     def to_string(self, other: Union[bytes, str]) -> str:
         """String representation with additional information"""
-        arg = "%s/%s,%s" % (self.ttl, self.get_remaining_ttl(current_time_millis()), cast(Any, other))
+        arg = "%s/%s,%s" % (self.ttl, int(self.get_remaining_ttl(current_time_millis())), cast(Any, other))
         return DNSEntry.entry_to_string(self, "record", arg)
 
 
@@ -538,9 +538,9 @@ class DNSAddress(DNSRecord):
     def __repr__(self) -> str:
         """String representation"""
         try:
-            return str(socket.inet_ntoa(self.address))
+            return self.to_string(str(socket.inet_ntoa(self.address)))
         except Exception:  # TODO stop catching all Exceptions
-            return str(self.address)
+            return self.to_string(str(self.address))
 
 
 class DNSHinfo(DNSRecord):
@@ -580,7 +580,7 @@ class DNSHinfo(DNSRecord):
 
     def __repr__(self) -> str:
         """String representation"""
-        return self.cpu + " " + self.os
+        return self.to_string(self.cpu + " " + self.os)
 
 
 class DNSPointer(DNSRecord):


### PR DESCRIPTION
Cleaned up output of cache dumps with:

- All records based on DNSRecord now properly use to_string in __repr__, some were only dumping the answer without the question (inconsistent).

before:
 record[txt,in-unique,AD-R02-3._netaudio-cmc._udp.local.]=4500/3177,b'\x13id=000'...,
 record[txt,in-unique,04@AD-R02-3._netaudio-chan._udp.local.]=4500/4377,b'\ttxtver'...,
172.30.11.164,
 record[txt,in-unique,Iyo1616M-145b50._netaudio-arc._udp.local.]=4500/3177,b'\x10arcp_v'...,
 record[txt,in-unique,Iyo1616M-145b50._netaudio-dbc._udp.local.]=4500/4377,b'\x00',

after:
 record[txt,in-unique,AD-R02-3._netaudio-cmc._udp.local.]=4500/3177,b'\x13id=000'...,
 record[txt,in-unique,04@AD-R02-3._netaudio-chan._udp.local.]=4500/4377,b'\ttxtver'...,
 record[a,in-unique,Iyo1616M-145b50.local.]=120/88,172.30.11.164,
 record[txt,in-unique,Iyo1616M-145b50._netaudio-arc._udp.local.]=4500/3177,b'\x10arcp_v'...,
 record[txt,in-unique,Iyo1616M-145b50._netaudio-dbc._udp.local.]=4500/4377,b'\x00',

- Cleaned up output of ttl remaining to be whole seconds only (prior included 8 digits of accuracy)
- Cleaned up format to cleanly separate [question]=ttl,answer
