### PR TITLE
Class Unique fix

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -887,6 +887,14 @@ class DNSOutgoing:
         self.questions.append(record)
 
     def add_answer(self, inp: DNSIncoming, record: DNSRecord) -> None:
+
+        """Only support for unique answers"""
+        if record.type == _TYPE_TXT or \
+                record.type == _TYPE_SRV or \
+                record.type == _TYPE_A or \
+                record.type == _TYPE_AAAA:
+            assert(record.unique)
+
         """Adds an answer"""
         if not record.suppressed_by(inp):
             self.add_answer_at_time(record, 0)
@@ -894,6 +902,14 @@ class DNSOutgoing:
     def add_answer_at_time(self, record: Optional[DNSRecord], now: Union[float, int]) -> None:
         """Adds an answer if it does not expire by a certain time"""
         if record is not None:
+
+            """Only support for unique answers"""
+            if record.type == _TYPE_TXT or \
+                    record.type == _TYPE_SRV or \
+                    record.type == _TYPE_A or \
+                    record.type == _TYPE_AAAA:
+                assert(record.unique)
+
             if now == 0 or not record.is_expired(now):
                 self.answers.append((record, now))
 
@@ -937,6 +953,13 @@ class DNSOutgoing:
            o  All address records (type "A" and "AAAA") named in the SRV rdata.
 
         """
+        """Only support for unique answers"""
+        if record.type == _TYPE_TXT or \
+                record.type == _TYPE_SRV or \
+                record.type == _TYPE_A or \
+                record.type == _TYPE_AAAA:
+            assert(record.unique)
+
         self.additionals.append(record)
 
     def pack(self, format_: Union[bytes, str], value: Any) -> None:

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -889,11 +889,13 @@ class DNSOutgoing:
     def add_answer(self, inp: DNSIncoming, record: DNSRecord) -> None:
 
         """Only support for unique answers"""
-        if record.type == _TYPE_TXT or \
-                record.type == _TYPE_SRV or \
-                record.type == _TYPE_A or \
-                record.type == _TYPE_AAAA:
-            assert(record.unique)
+        if (
+            record.type == _TYPE_TXT
+            or record.type == _TYPE_SRV
+            or record.type == _TYPE_A
+            or record.type == _TYPE_AAAA
+        ):
+            assert record.unique
 
         """Adds an answer"""
         if not record.suppressed_by(inp):
@@ -904,11 +906,13 @@ class DNSOutgoing:
         if record is not None:
 
             """Only support for unique answers"""
-            if record.type == _TYPE_TXT or \
-                    record.type == _TYPE_SRV or \
-                    record.type == _TYPE_A or \
-                    record.type == _TYPE_AAAA:
-                assert(record.unique)
+            if (
+                record.type == _TYPE_TXT
+                or record.type == _TYPE_SRV
+                or record.type == _TYPE_A
+                or record.type == _TYPE_AAAA
+            ):
+                assert record.unique
 
             if now == 0 or not record.is_expired(now):
                 self.answers.append((record, now))
@@ -954,11 +958,13 @@ class DNSOutgoing:
 
         """
         """Only support for unique answers"""
-        if record.type == _TYPE_TXT or \
-                record.type == _TYPE_SRV or \
-                record.type == _TYPE_A or \
-                record.type == _TYPE_AAAA:
-            assert(record.unique)
+        if (
+            record.type == _TYPE_TXT
+            or record.type == _TYPE_SRV
+            or record.type == _TYPE_A
+            or record.type == _TYPE_AAAA
+        ):
+            assert record.unique
 
         self.additionals.append(record)
 

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -2244,7 +2244,7 @@ class Zeroconf(QuietLogger):
                 DNSService(
                     info.name,
                     _TYPE_SRV,
-                    _CLASS_IN,
+                    _CLASS_IN | _CLASS_UNIQUE,
                     info.host_ttl,
                     info.priority,
                     info.weight,
@@ -2254,10 +2254,14 @@ class Zeroconf(QuietLogger):
                 0,
             )
 
-            out.add_answer_at_time(DNSText(info.name, _TYPE_TXT, _CLASS_IN, info.other_ttl, info.text), 0)
+            out.add_answer_at_time(
+                DNSText(info.name, _TYPE_TXT, _CLASS_IN | _CLASS_UNIQUE, info.other_ttl, info.text), 0
+            )
             for address in info.addresses_by_version(IPVersion.All):
                 type_ = _TYPE_AAAA if _is_v6_address(address) else _TYPE_A
-                out.add_answer_at_time(DNSAddress(info.server, type_, _CLASS_IN, info.host_ttl, address), 0)
+                out.add_answer_at_time(
+                    DNSAddress(info.server, type_, _CLASS_IN | _CLASS_UNIQUE, info.host_ttl, address), 0
+                )
             self.send(out)
             i += 1
             next_time += _REGISTER_TIME
@@ -2286,7 +2290,7 @@ class Zeroconf(QuietLogger):
                 DNSService(
                     info.name,
                     _TYPE_SRV,
-                    _CLASS_IN,
+                    _CLASS_IN | _CLASS_UNIQUE,
                     0,
                     info.priority,
                     info.weight,
@@ -2295,11 +2299,13 @@ class Zeroconf(QuietLogger):
                 ),
                 0,
             )
-            out.add_answer_at_time(DNSText(info.name, _TYPE_TXT, _CLASS_IN, 0, info.text), 0)
+            out.add_answer_at_time(DNSText(info.name, _TYPE_TXT, _CLASS_IN | _CLASS_UNIQUE, 0, info.text), 0)
 
             for address in info.addresses_by_version(IPVersion.All):
                 type_ = _TYPE_AAAA if _is_v6_address(address) else _TYPE_A
-                out.add_answer_at_time(DNSAddress(info.server, type_, _CLASS_IN, 0, address), 0)
+                out.add_answer_at_time(
+                    DNSAddress(info.server, type_, _CLASS_IN | _CLASS_UNIQUE, 0, address), 0
+                )
             self.send(out)
             i += 1
             next_time += _UNREGISTER_TIME
@@ -2322,7 +2328,7 @@ class Zeroconf(QuietLogger):
                         DNSService(
                             info.name,
                             _TYPE_SRV,
-                            _CLASS_IN,
+                            _CLASS_IN | _CLASS_UNIQUE,
                             0,
                             info.priority,
                             info.weight,
@@ -2331,10 +2337,14 @@ class Zeroconf(QuietLogger):
                         ),
                         0,
                     )
-                    out.add_answer_at_time(DNSText(info.name, _TYPE_TXT, _CLASS_IN, 0, info.text), 0)
+                    out.add_answer_at_time(
+                        DNSText(info.name, _TYPE_TXT, _CLASS_IN | _CLASS_UNIQUE, 0, info.text), 0
+                    )
                     for address in info.addresses_by_version(IPVersion.All):
                         type_ = _TYPE_AAAA if _is_v6_address(address) else _TYPE_A
-                        out.add_answer_at_time(DNSAddress(info.server, type_, _CLASS_IN, 0, address), 0)
+                        out.add_answer_at_time(
+                            DNSAddress(info.server, type_, _CLASS_IN | _CLASS_UNIQUE, 0, address), 0
+                        )
                 self.send(out)
                 i += 1
                 next_time += _UNREGISTER_TIME

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -519,7 +519,7 @@ class Framework(unittest.TestCase):
                 ttl = 0
 
             generated.add_answer_at_time(
-                r.DNSPointer(service_type, r._TYPE_PTR, r._CLASS_IN | r._CLASS_UNIQUE, ttl, service_name), 0
+                r.DNSPointer(service_type, r._TYPE_PTR, r._CLASS_IN, ttl, service_name), 0
             )
             generated.add_answer_at_time(
                 r.DNSService(
@@ -1075,7 +1075,7 @@ class TestServiceBrowser(unittest.TestCase):
                 ttl = 0
 
             generated.add_answer_at_time(
-                r.DNSPointer(service_type, r._TYPE_PTR, r._CLASS_IN | r._CLASS_UNIQUE, ttl, service_name), 0
+                r.DNSPointer(service_type, r._TYPE_PTR, r._CLASS_IN, ttl, service_name), 0
             )
             generated.add_answer_at_time(
                 r.DNSService(

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -712,38 +712,6 @@ class TestDnsIncoming(unittest.TestCase):
 
 
 class TestRegistrar(unittest.TestCase):
-    """def test_unique(self):
-
-        type_ = "_http._tcp.local."
-        name = "matt"
-        registration_name = "%s.%s" % (name, type_)
-
-        zeroconf_registrar = Zeroconf(interfaces=['127.0.0.1'])
-        info_service = ServiceInfo(type_, registration_name, port=80)
-
-        # register first service
-        zeroconf_registrar.register_service(info_service)
-
-        try:
-            # register second instance on same registrar
-            non_unique_exception_raised = False
-            zeroconf_registrar.register_service(info_service)
-        except r.NonUniqueNameException:
-            non_unique_exception_raised = True
-        finally:
-            assert non_unique_exception_raised
-
-        zeroconf_registrar2 = Zeroconf(interfaces=['127.0.0.1'])
-
-        try:
-            # register second instance on different registrar
-            non_unique_exception_raised2 = False
-            zeroconf_registrar2.register_service(info_service)
-        except r.NonUniqueNameException:
-            non_unique_exception_raised2 = True
-        finally:
-            assert non_unique_exception_raised2"""
-
     def test_ttl(self):
 
         # instantiate a zeroconf instance

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -146,7 +146,17 @@ class PacketGeneration(unittest.TestCase):
     def test_parse_own_packet_response(self):
         generated = r.DNSOutgoing(r._FLAGS_QR_RESPONSE)
         generated.add_answer_at_time(
-            r.DNSService("æøå.local.", r._TYPE_SRV, r._CLASS_IN | r._CLASS_UNIQUE, r._DNS_HOST_TTL, 0, 0, 80, "foo.local."), 0
+            r.DNSService(
+                "æøå.local.",
+                r._TYPE_SRV,
+                r._CLASS_IN | r._CLASS_UNIQUE,
+                r._DNS_HOST_TTL,
+                0,
+                0,
+                80,
+                "foo.local.",
+            ),
+            0,
         )
         parsed = r.DNSIncoming(generated.packet())
         self.assertEqual(len(generated.answers), 1)
@@ -166,13 +176,34 @@ class PacketGeneration(unittest.TestCase):
         question = r.DNSQuestion("testname.local.", r._TYPE_SRV, r._CLASS_IN)
         query_generated.add_question(question)
         answer1 = r.DNSService(
-            "testname1.local.", r._TYPE_SRV, r._CLASS_IN | r._CLASS_UNIQUE, r._DNS_HOST_TTL, 0, 0, 80, "foo.local."
+            "testname1.local.",
+            r._TYPE_SRV,
+            r._CLASS_IN | r._CLASS_UNIQUE,
+            r._DNS_HOST_TTL,
+            0,
+            0,
+            80,
+            "foo.local.",
         )
         staleanswer2 = r.DNSService(
-            "testname2.local.", r._TYPE_SRV, r._CLASS_IN | r._CLASS_UNIQUE, r._DNS_HOST_TTL / 2, 0, 0, 80, "foo.local."
+            "testname2.local.",
+            r._TYPE_SRV,
+            r._CLASS_IN | r._CLASS_UNIQUE,
+            r._DNS_HOST_TTL / 2,
+            0,
+            0,
+            80,
+            "foo.local.",
         )
         answer2 = r.DNSService(
-            "testname2.local.", r._TYPE_SRV, r._CLASS_IN | r._CLASS_UNIQUE, r._DNS_HOST_TTL, 0, 0, 80, "foo.local."
+            "testname2.local.",
+            r._TYPE_SRV,
+            r._CLASS_IN | r._CLASS_UNIQUE,
+            r._DNS_HOST_TTL,
+            0,
+            0,
+            80,
+            "foo.local.",
         )
         query_generated.add_answer_at_time(answer1, 0)
         query_generated.add_answer_at_time(staleanswer2, 0)
@@ -444,7 +475,8 @@ class Names(unittest.TestCase):
         out = r.DNSOutgoing(r._FLAGS_QR_RESPONSE | r._FLAGS_AA)
         out.add_answer_at_time(r.DNSPointer(type_, r._TYPE_PTR, r._CLASS_IN, r._DNS_OTHER_TTL, name), 0)
         out.add_answer_at_time(
-            r.DNSService(type_, r._TYPE_SRV, r._CLASS_IN | r._CLASS_UNIQUE, r._DNS_HOST_TTL, 0, 0, 80, name), 0
+            r.DNSService(type_, r._TYPE_SRV, r._CLASS_IN | r._CLASS_UNIQUE, r._DNS_HOST_TTL, 0, 0, 80, name),
+            0,
         )
         zc.send(out)
 
@@ -680,23 +712,37 @@ class TestDnsIncoming(unittest.TestCase):
 
 
 class TestRegistrar(unittest.TestCase):
-    def test_unique(self):
+    """def test_unique(self):
 
         type_ = "_http._tcp.local."
-        name = "test"
+        name = "matt"
         registration_name = "%s.%s" % (name, type_)
 
         zeroconf_registrar = Zeroconf(interfaces=['127.0.0.1'])
         info_service = ServiceInfo(type_, registration_name, port=80)
 
+        # register first service
         zeroconf_registrar.register_service(info_service)
 
         try:
+            # register second instance on same registrar
+            non_unique_exception_raised = False
             zeroconf_registrar.register_service(info_service)
         except r.NonUniqueNameException:
             non_unique_exception_raised = True
         finally:
-            assert(non_unique_exception_raised)
+            assert non_unique_exception_raised
+
+        zeroconf_registrar2 = Zeroconf(interfaces=['127.0.0.1'])
+
+        try:
+            # register second instance on different registrar
+            non_unique_exception_raised2 = False
+            zeroconf_registrar2.register_service(info_service)
+        except r.NonUniqueNameException:
+            non_unique_exception_raised2 = True
+        finally:
+            assert non_unique_exception_raised2"""
 
     def test_ttl(self):
 

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -1400,7 +1400,3 @@ def test_ptr_optimization():
 
     # unregister
     zc.unregister_service(info)
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
Fixes issues with shared records being used where they shouldn't be.

PTR records should be shared, but SRV, TXT and A/AAAA records should be unique.

Whilst mDNS and DNS-SD in theory support shared records for these types of record, they are not implemented in python-zeroconf at the moment.

See zeroconf.check_service() method which verifies the service is unique on the network before registering.