### PR TITLE
Do not convert empty strings in TXT records to bool

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1655,20 +1655,12 @@ class ServiceInfo(RecordUpdateListener):
                 if isinstance(key, str):
                     key = key.encode('utf-8')
 
-                if value is None:
-                    suffix = b''
-                elif isinstance(value, str):
-                    suffix = value.encode('utf-8')
-                elif isinstance(value, bytes):
-                    suffix = value
-                elif isinstance(value, int):
-                    if value:
-                        suffix = b'true'
-                    else:
-                        suffix = b'false'
-                else:
-                    suffix = b''
-                list_.append(b'='.join((key, suffix)))
+                record = key
+                if value is not None:
+                    if not isinstance(value, bytes):
+                        value = str(value).encode('utf-8')
+                    record += b'=' + value
+                list_.append(record)
             for item in list_:
                 result = b''.join((result, int2byte(len(item)), item))
             self.text = result

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1695,12 +1695,7 @@ class ServiceInfo(RecordUpdateListener):
             except ValueError:
                 # No equals sign at all
                 key = s
-                value = False
-            else:
-                if value == b'true':
-                    value = True
-                elif value == b'false':
-                    value = False
+                value = None
 
             # Only update non-existent properties
             if key and result.get(key) is None:

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1683,7 +1683,7 @@ class ServiceInfo(RecordUpdateListener):
         for s in strs:
             parts = s.split(b'=', 1)
             try:
-                key, value = parts  # type: Tuple[bytes, Union[bool, bytes]]
+                key, value = parts  # type: Tuple[bytes, Optional[bytes]]
             except ValueError:
                 # No equals sign at all
                 key = s

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1699,7 +1699,7 @@ class ServiceInfo(RecordUpdateListener):
             else:
                 if value == b'true':
                     value = True
-                elif value == b'false' or not value:
+                elif value == b'false':
                     value = False
 
             # Only update non-existent properties

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -985,19 +985,19 @@ class ListenerTest(unittest.TestCase):
             # get service info without answer cache
             info = zeroconf_browser.get_service_info(type_, registration_name)
             assert info is not None
-            assert info.properties[b'prop_none'] == b''
+            assert info.properties[b'prop_none'] is None
             assert info.properties[b'prop_string'] == properties['prop_string']
-            assert info.properties[b'prop_float'] == b''
+            assert info.properties[b'prop_float'] == b'1.0'
             assert info.properties[b'prop_blank'] == properties['prop_blank']
-            assert info.properties[b'prop_true'] is True
-            assert info.properties[b'prop_false'] is False
+            assert info.properties[b'prop_true'] == b'1'
+            assert info.properties[b'prop_false'] == b'0'
             assert info.addresses == addresses[:1]  # no V6 by default
             all_addresses = info.addresses_by_version(r.IPVersion.All)
             assert all_addresses == addresses, all_addresses
 
             info = zeroconf_browser.get_service_info(subtype, registration_name)
             assert info is not None
-            assert info.properties[b'prop_none'] == b''
+            assert info.properties[b'prop_none'] is None
 
             # test TXT record update
             sublistener = MySubListener()

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -985,9 +985,9 @@ class ListenerTest(unittest.TestCase):
             # get service info without answer cache
             info = zeroconf_browser.get_service_info(type_, registration_name)
             assert info is not None
-            assert info.properties[b'prop_none'] is False
+            assert info.properties[b'prop_none'] == b''
             assert info.properties[b'prop_string'] == properties['prop_string']
-            assert info.properties[b'prop_float'] is False
+            assert info.properties[b'prop_float'] == b''
             assert info.properties[b'prop_blank'] == properties['prop_blank']
             assert info.properties[b'prop_true'] is True
             assert info.properties[b'prop_false'] is False
@@ -997,7 +997,7 @@ class ListenerTest(unittest.TestCase):
 
             info = zeroconf_browser.get_service_info(subtype, registration_name)
             assert info is not None
-            assert info.properties[b'prop_none'] is False
+            assert info.properties[b'prop_none'] == b''
 
             # test TXT record update
             sublistener = MySubListener()


### PR DESCRIPTION
It's been wrong since the first commit. Empty strings are just empty strings.