### PR TITLE
Do not exclude interfaces with host-only netmasks from InterfaceChoice.All

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1867,14 +1867,7 @@ class ZeroconfServiceTypes(ServiceListener):
 
 
 def get_all_addresses() -> List[str]:
-    return list(
-        set(
-            addr.ip
-            for iface in ifaddr.get_adapters()
-            for addr in iface.ips
-            if addr.is_IPv4
-        )
-    )
+    return list(set(addr.ip for iface in ifaddr.get_adapters() for addr in iface.ips if addr.is_IPv4))
 
 
 def get_all_addresses_v6() -> List[int]:

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1872,7 +1872,7 @@ def get_all_addresses() -> List[str]:
             addr.ip
             for iface in ifaddr.get_adapters()
             for addr in iface.ips
-            if addr.is_IPv4 and addr.network_prefix != 32  # Host only netmask 255.255.255.255
+            if addr.is_IPv4
         )
     )
 


### PR DESCRIPTION
Host-only netmasks do not forbid multicast.

Tested on Debian 10 running in Qubes and on Ubuntu 18.04.

Fixes #221.