### PR TITLE
Duplicate updates fix

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -2434,8 +2434,15 @@ class Zeroconf(QuietLogger):
         are held in the cache, and listeners are notified."""
         now = current_time_millis()
         for record in msg.answers:
+
+            updated = True
+
             if record.unique:  # https://tools.ietf.org/html/rfc6762#section-10.2
                 for entry in self.cache.entries():
+
+                    if entry == record:
+                        updated = False
+
                     if DNSEntry.__eq__(entry, record) and (record.created - entry.created > 1000):
                         self.cache.remove(entry)
 
@@ -2446,7 +2453,8 @@ class Zeroconf(QuietLogger):
                     maybe_entry.reset_ttl(record)
                 else:
                     self.cache.add(record)
-                self.update_record(now, record)
+                if updated:
+                    self.update_record(now, record)
             else:
                 if maybe_entry is not None:
                     self.update_record(now, record)

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -882,21 +882,15 @@ class DNSOutgoing:
         init = 0
         finished = 1
 
+    @staticmethod
+    def is_type_unique(type_: int) -> bool:
+        return type_ == _TYPE_TXT or type_ == _TYPE_SRV or type_ == _TYPE_A or type_ == _TYPE_AAAA
+
     def add_question(self, record: DNSQuestion) -> None:
         """Adds a question"""
         self.questions.append(record)
 
     def add_answer(self, inp: DNSIncoming, record: DNSRecord) -> None:
-
-        """Only support for unique answers"""
-        if (
-            record.type == _TYPE_TXT
-            or record.type == _TYPE_SRV
-            or record.type == _TYPE_A
-            or record.type == _TYPE_AAAA
-        ):
-            assert record.unique
-
         """Adds an answer"""
         if not record.suppressed_by(inp):
             self.add_answer_at_time(record, 0)
@@ -905,13 +899,7 @@ class DNSOutgoing:
         """Adds an answer if it does not expire by a certain time"""
         if record is not None:
 
-            """Only support for unique answers"""
-            if (
-                record.type == _TYPE_TXT
-                or record.type == _TYPE_SRV
-                or record.type == _TYPE_A
-                or record.type == _TYPE_AAAA
-            ):
+            if self.is_type_unique(record.type):
                 assert record.unique
 
             if now == 0 or not record.is_expired(now):
@@ -957,13 +945,7 @@ class DNSOutgoing:
            o  All address records (type "A" and "AAAA") named in the SRV rdata.
 
         """
-        """Only support for unique answers"""
-        if (
-            record.type == _TYPE_TXT
-            or record.type == _TYPE_SRV
-            or record.type == _TYPE_A
-            or record.type == _TYPE_AAAA
-        ):
+        if self.is_type_unique(record.type):
             assert record.unique
 
         self.additionals.append(record)

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -1115,6 +1115,7 @@ class TestServiceBrowser(unittest.TestCase):
             service_updated_event.clear()
             service_text = b'path=/~humingchun/'
             zeroconf.handle_response(mock_incoming_msg(r.ServiceStateChange.Updated))
+            zeroconf.handle_response(mock_incoming_msg(r.ServiceStateChange.Updated))
             service_updated_event.wait(1)
             assert service_added is True
             assert service_updated_count == 2


### PR DESCRIPTION
The prior code used to send updates even when the new record was identical to the old.

This resulted in duplicate update messages when there was in fact no update (apart from TTL refresh)