### PR TITLE
Fix representation of IPv6 DNSAddress

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -540,8 +540,9 @@ class DNSAddress(DNSRecord):
     def __repr__(self) -> str:
         """String representation"""
         try:
-            return self.to_string(str(
-                socket.inet_ntop(socket.AF_INET6 if _is_v6_address(self.address) else socket.AF_INET, self.address)
+            return self.to_string(socket.inet_ntop(
+                socket.AF_INET6 if _is_v6_address(self.address) else socket.AF_INET,
+                self.address
             ))
         except Exception:  # TODO stop catching all Exceptions
             return self.to_string(str(self.address))

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -540,10 +540,11 @@ class DNSAddress(DNSRecord):
     def __repr__(self) -> str:
         """String representation"""
         try:
-            return self.to_string(socket.inet_ntop(
-                socket.AF_INET6 if _is_v6_address(self.address) else socket.AF_INET,
-                self.address
-            ))
+            return self.to_string(
+                socket.inet_ntop(
+                    socket.AF_INET6 if _is_v6_address(self.address) else socket.AF_INET, self.address
+                )
+            )
         except Exception:  # TODO stop catching all Exceptions
             return self.to_string(str(self.address))
 

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -540,7 +540,9 @@ class DNSAddress(DNSRecord):
     def __repr__(self) -> str:
         """String representation"""
         try:
-            return self.to_string(str(socket.inet_ntoa(self.address)))
+            return self.to_string(str(
+                socket.inet_ntop(socket.AF_INET6 if _is_v6_address(self.address) else socket.AF_INET, self.address)
+            ))
         except Exception:  # TODO stop catching all Exceptions
             return self.to_string(str(self.address))
 

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -63,7 +63,19 @@ class TestDunder(unittest.TestCase):
 
     def test_dns_address_repr(self):
         address = r.DNSAddress('irrelevant', r._TYPE_SOA, r._CLASS_IN, 1, b'a')
-        repr(address)
+        assert repr(address).endswith("b'a'")
+
+        address_ipv4 = r.DNSAddress(
+            'irrelevant', r._TYPE_SOA, r._CLASS_IN, 1,
+            socket.inet_pton(socket.AF_INET, '127.0.0.1')
+        )
+        assert repr(address_ipv4).endswith('127.0.0.1')
+
+        address_ipv6 = r.DNSAddress(
+            'irrelevant', r._TYPE_SOA, r._CLASS_IN, 1,
+            socket.inet_pton(socket.AF_INET6, '::1')
+        )
+        assert repr(address_ipv6).endswith('::1')
 
     def test_dns_question_repr(self):
         question = r.DNSQuestion('irrelevant', r._TYPE_SRV, r._CLASS_IN | r._CLASS_UNIQUE)

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -66,14 +66,12 @@ class TestDunder(unittest.TestCase):
         assert repr(address).endswith("b'a'")
 
         address_ipv4 = r.DNSAddress(
-            'irrelevant', r._TYPE_SOA, r._CLASS_IN, 1,
-            socket.inet_pton(socket.AF_INET, '127.0.0.1')
+            'irrelevant', r._TYPE_SOA, r._CLASS_IN, 1, socket.inet_pton(socket.AF_INET, '127.0.0.1')
         )
         assert repr(address_ipv4).endswith('127.0.0.1')
 
         address_ipv6 = r.DNSAddress(
-            'irrelevant', r._TYPE_SOA, r._CLASS_IN, 1,
-            socket.inet_pton(socket.AF_INET6, '::1')
+            'irrelevant', r._TYPE_SOA, r._CLASS_IN, 1, socket.inet_pton(socket.AF_INET6, '::1')
         )
         assert repr(address_ipv6).endswith('::1')
 


### PR DESCRIPTION
This PR fixes the representation of DNSAddress instances that have an IPv6 address. Previously, the repr of such instances would contain a string of the packed bytearray. 

This is mostly a cosmetic change. It replaces the last occurrence of `socket.ntoa()` with `socket.ntop()`. 