### PR TITLE
Remove uniqueness assertions

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -902,10 +902,6 @@ class DNSOutgoing:
     def add_answer_at_time(self, record: Optional[DNSRecord], now: Union[float, int]) -> None:
         """Adds an answer if it does not expire by a certain time"""
         if record is not None:
-
-            if self.is_type_unique(record.type):
-                assert record.unique
-
             if now == 0 or not record.is_expired(now):
                 self.answers.append((record, now))
 
@@ -949,9 +945,6 @@ class DNSOutgoing:
            o  All address records (type "A" and "AAAA") named in the SRV rdata.
 
         """
-        if self.is_type_unique(record.type):
-            assert record.unique
-
         self.additionals.append(record)
 
     def pack(self, format_: Union[bytes, str], value: Any) -> None:


### PR DESCRIPTION
The assertions, added in [1] and modified in [2] introduced a
regression. When browsing in the presence of devices advertising SRV
records not marked as unique there would be an undesired crash (from [3]):

    Exception in thread zeroconf-ServiceBrowser__hap._tcp.local.:
    Traceback (most recent call last):
      File "/usr/lib/python3.7/threading.py", line 917, in _bootstrap_inner
        self.run()
      File "/home/pi/homekit-debugging/venv/lib/python3.7/site-packages/zeroconf/__init__.py", line 1504, in run
        handler(self.zc)
      File "/home/pi/homekit-debugging/venv/lib/python3.7/site-packages/zeroconf/__init__.py", line 1444, in <lambda>
        zeroconf=zeroconf, service_type=self.type, name=name, state_change=state_change
      File "/home/pi/homekit-debugging/venv/lib/python3.7/site-packages/zeroconf/__init__.py", line 1322, in fire
        h(**kwargs)
      File "browser.py", line 20, in on_service_state_change
        info = zeroconf.get_service_info(service_type, name)
      File "/home/pi/homekit-debugging/venv/lib/python3.7/site-packages/zeroconf/__init__.py", line 2191, in get_service_info
        if info.request(self, timeout):
      File "/home/pi/homekit-debugging/venv/lib/python3.7/site-packages/zeroconf/__init__.py", line 1762, in request
        out.add_answer_at_time(zc.cache.get_by_details(self.name, _TYPE_SRV, _CLASS_IN), now)
      File "/home/pi/homekit-debugging/venv/lib/python3.7/site-packages/zeroconf/__init__.py", line 907, in add_answer_at_time
        assert record.unique
    AssertionError

The intention is to bring those assertions back in a way that only
enforces uniqueness when sending records, not when receiving them.

[1] bef8f593ae82 ("Ensure all TXT, SRV, A records are unique")
[2] 5e4f496778d9 ("Refactor out unique assertion")
[3] https://github.com/jstasiak/python-zeroconf/issues/236