### PR TITLE
Switch to pytest for test running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ install:
         pip install black ; fi
 script:
     # no IPv6 support in Travis :(
-    - make TEST_ARGS='-a "!IPv6"' ci
+    - SKIP_IPV6=1 make ci
 after_success:
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
     - "pypy3.5"
     - "pypy3"
 install:
-    - pip install -r requirements-dev.txt
+    - pip install --upgrade -r requirements-dev.txt
     # mypy can't be installed on pypy
     - if [[ "${TRAVIS_PYTHON_VERSION}" != "pypy"* ]] ; then pip install mypy ; fi
     - if [[ "${TRAVIS_PYTHON_VERSION}" != *"3.5"* && "${TRAVIS_PYTHON_VERSION}" != "pypy"* ]] ; then

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 MAX_LINE_LENGTH=110
 PYTHON_IMPLEMENTATION:=$(shell python -c "import sys;import platform;sys.stdout.write(platform.python_implementation())")
 PYTHON_VERSION:=$(shell python -c "import sys;sys.stdout.write('%d.%d' % sys.version_info[:2])")
-TEST_ARGS=
 
 LINT_TARGETS:=flake8
 
@@ -40,10 +39,10 @@ mypy:
 	mypy examples/*.py zeroconf/*.py
 
 test:
-	nosetests -v $(TEST_ARGS)
+	pytest -v
 
 test_coverage:
-	nosetests -v --with-coverage --cover-package=zeroconf $(TEST_ARGS)
+	pytest -v --cov=zeroconf --cov-branch --cov-report html --cov-report term-missing
 
 autopep8:
 	autopep8 --max-line-length=$(MAX_LINE_LENGTH) -i setup.py examples zeroconf

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ mypy:
 	mypy examples/*.py zeroconf/*.py
 
 test:
-	PYTHONPATH=.:$(PYTHONPATH) pytest -v zeroconf/test.py
+	pytest -v zeroconf/test.py
 
 test_coverage:
-	PYTHONPATH=.:$(PYTHONPATH) pytest -v --cov=zeroconf --cov-branch --cov-report html --cov-report term-missing zeroconf/test.py
+	pytest -v --cov=zeroconf --cov-branch --cov-report html --cov-report term-missing zeroconf/test.py
 
 autopep8:
 	autopep8 --max-line-length=$(MAX_LINE_LENGTH) -i setup.py examples zeroconf

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ mypy:
 	mypy examples/*.py zeroconf/*.py
 
 test:
-	pytest -v
+	PYTHONPATH=.:$(PYTHONPATH) pytest -v
 
 test_coverage:
-	pytest -v --cov=zeroconf --cov-branch --cov-report html --cov-report term-missing
+	PYTHONPATH=.:$(PYTHONPATH) pytest -v --cov=zeroconf --cov-branch --cov-report html --cov-report term-missing
 
 autopep8:
 	autopep8 --max-line-length=$(MAX_LINE_LENGTH) -i setup.py examples zeroconf

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ mypy:
 	mypy examples/*.py zeroconf/*.py
 
 test:
-	PYTHONPATH=.:$(PYTHONPATH) pytest -v
+	PYTHONPATH=.:$(PYTHONPATH) pytest -v zeroconf/test.py
 
 test_coverage:
-	PYTHONPATH=.:$(PYTHONPATH) pytest -v --cov=zeroconf --cov-branch --cov-report html --cov-report term-missing
+	PYTHONPATH=.:$(PYTHONPATH) pytest -v --cov=zeroconf --cov-branch --cov-report html --cov-report term-missing zeroconf/test.py
 
 autopep8:
 	autopep8 --max-line-length=$(MAX_LINE_LENGTH) -i setup.py examples zeroconf

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,5 @@ coverage
 flake8>=3.6.0
 flake8-import-order
 ifaddr
-nose
 pep8-naming!=0.6.0
+pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ flake8-import-order
 ifaddr
 pep8-naming!=0.6.0
 pytest
+pytest-cov

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -1015,9 +1015,7 @@ class ListenerTest(unittest.TestCase):
             assert info.properties[b'prop_true'] == b'1'
             assert info.properties[b'prop_false'] == b'0'
             assert info.addresses == addresses[:1]  # no V6 by default
-            # This needs to be stored in a variable for pytest to show the contents in case of failure
-            all_addresses = info.addresses_by_version(r.IPVersion.All)
-            assert all_addresses == addresses
+            assert info.addresses_by_version(r.IPVersion.All) == addresses
 
             info = zeroconf_browser.get_service_info(subtype, registration_name)
             assert info is not None

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -1015,7 +1015,9 @@ class ListenerTest(unittest.TestCase):
             assert info.properties[b'prop_true'] == b'1'
             assert info.properties[b'prop_false'] == b'0'
             assert info.addresses == addresses[:1]  # no V6 by default
-            assert info.addresses_by_version(r.IPVersion.All) == addresses
+            # This needs to be stored in a variable for pytest to show the contents in case of failure
+            all_addresses = info.addresses_by_version(r.IPVersion.All)
+            assert all_addresses == addresses
 
             info = zeroconf_browser.get_service_info(subtype, registration_name)
             assert info is not None


### PR DESCRIPTION
Nose is dead for all intents and purposes (last release in 2015) and
pytest provide a very valuable feature of printing relevant extra
information in case of assertion failure (from[1]):

    ================================= FAILURES =================================
    _______________________________ test_answer ________________________________

        def test_answer():
    >       assert func(3) == 5
    E       assert 4 == 5
    E        +  where 4 = func(3)

    test_sample.py:6: AssertionError
    ========================= short test summary info ==========================
    FAILED test_sample.py::test_answer - assert 4 == 5
    ============================ 1 failed in 0.12s =============================

This should be helpful in debugging tests intermittently failing on
PyPy.

Several TestCase.assertEqual() calls have been replaced by plain
assertions now that that method no longer provides anything we can't get
without it. Few assertions have been modified to not explicitly provide
extra information in case of failure – pytest will provide this
automatically.

[1] https://docs.pytest.org/en/latest/getting-started.html#create-your-first-test