### PR TITLE
Update Engine to immediately notify its worker thread

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1234,18 +1234,17 @@ class Engine(threading.Thread):
                     # shutdown, ignore it and exit
                     if e.args[0] not in (errno.EBADF, errno.ENOTCONN) or not self.zc.done:
                         raise
-        try:
-            self.socketpair[0].close()
-            self.socketpair[1].close()
-        except socket.error:
-            pass
+        self.socketpair[0].close()
+        self.socketpair[1].close()
 
     def _notify(self) -> None:
         self.condition.notify()
         try:
             self.socketpair[1].send(b'x')
         except socket.error:
-            pass
+            # The socketpair may already be closed during shutdown, ignore it
+            if not self.zc.done:
+                raise
 
     def add_reader(self, reader: 'Listener', socket_: socket.socket) -> None:
         with self.condition:

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1212,7 +1212,7 @@ class Engine(threading.Thread):
     def run(self) -> None:
         while not self.zc.done:
             with self.condition:
-                rs = self.readers.keys()
+                rs = list(self.readers.keys())  # type: List[Union[socket.socket, int]]
                 if len(rs) == 0:
                     # No sockets to manage, but we wait for the timeout
                     # or addition of a socket
@@ -1221,7 +1221,7 @@ class Engine(threading.Thread):
             if len(rs) != 0:
                 try:
                     if os.name == 'posix':
-                        rs = list(rs) + [self.pipe[0]]
+                        rs = rs + [self.pipe[0]]
                     rr, wr, er = select.select(cast(Sequence[Any], rs), [], [], self.timeout)
                     if not self.zc.done:
                         for socket_ in rr:

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1234,6 +1234,11 @@ class Engine(threading.Thread):
                     # shutdown, ignore it and exit
                     if e.args[0] not in (errno.EBADF, errno.ENOTCONN) or not self.zc.done:
                         raise
+        try:
+            self.socketpair[0].close()
+            self.socketpair[1].close()
+        except socket.error:
+            pass
 
     def _notify(self) -> None:
         self.condition.notify()

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1242,7 +1242,10 @@ class Engine(threading.Thread):
 
     def _notify(self) -> None:
         self.condition.notify()
-        self.socketpair[1].send(b'x')
+        try:
+            self.socketpair[1].send(b'x')
+        except socket.error:
+            pass
 
     def add_reader(self, reader: 'Listener', socket_: socket.socket) -> None:
         with self.condition:

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1230,7 +1230,10 @@ class Engine(threading.Thread):
 
                         if os.name == 'posix' and self.pipe in rr:
                             # Clear the pipe's buffer
-                            os.read(self.pipe[0], 1)
+                            try:
+                                os.read(self.pipe[0], 1)
+                            except Exception:
+                                self.log_exception_warning()
 
                 except (select.error, socket.error) as e:
                     # If the socket was closed by another thread, during

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1232,8 +1232,8 @@ class Engine(threading.Thread):
                             # Clear the pipe's buffer
                             try:
                                 os.read(self.pipe[0], 1)
-                            except Exception:
-                                self.log_exception_warning()
+                            except os.error:
+                                pass
 
                 except (select.error, socket.error) as e:
                     # If the socket was closed by another thread, during

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1206,7 +1206,6 @@ class Engine(threading.Thread):
         # The pipe will be used for fast notify the thread, but can't select() a pipe in windows
         if os.name == 'posix':
             self.pipe = os.pipe()
-            os.set_blocking(self.pipe[0], False)
         self.start()
 
     def run(self) -> None:
@@ -1229,13 +1228,10 @@ class Engine(threading.Thread):
                             if reader:
                                 reader.handle_read(socket_)
 
-                        # Try clearing the pipe's buffer
-                        if os.name == 'posix':
+                        if os.name == 'posix' and self.pipe in rr:
+                            # Clear the pipe's buffer
                             os.read(self.pipe[0], 1)
 
-                except (BlockingIOError):
-                    # No data in the pipe's buffer
-                    pass
                 except (select.error, socket.error) as e:
                     # If the socket was closed by another thread, during
                     # shutdown, ignore it and exit


### PR DESCRIPTION
Update `Engine` such that the thread is immediately notified. This gets rid of the 5s hang on `Zeroconf.close()`.