### PR TITLE
Fix race condition where a listener gets a message before the lock is created.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(join(PROJECT_ROOT, 'README.rst'), encoding='utf-8') as f:
     readme = f.read()
 
 version = (
-    [l for l in open(join(PROJECT_ROOT, 'zeroconf', '__init__.py')) if '__version__' in l][0]
+    [ln for ln in open(join(PROJECT_ROOT, 'zeroconf', '__init__.py')) if '__version__' in ln][0]
     .split('=')[-1]
     .strip()
     .strip('\'"')

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -2208,6 +2208,11 @@ class Zeroconf(QuietLogger):
 
         self.condition = threading.Condition()
 
+        # Ensure we create the lock before
+        # we add the listener as we could get
+        # a message before the lock is created.
+        self._handlers_lock = threading.Lock()  # ensure we process a full message in one go
+
         self.engine = Engine(self)
         self.listener = Listener(self)
         if not unicast:
@@ -2218,8 +2223,6 @@ class Zeroconf(QuietLogger):
         self.reaper = Reaper(self)
 
         self.debug = None  # type: Optional[DNSOutgoing]
-
-        self._handlers_lock = threading.Lock()  # ensure we process a full message in one go
 
     @property
     def done(self) -> bool:


### PR DESCRIPTION
Reported to Home Assistant here
https://github.com/home-assistant/core/issues/35832

I was able to replicate with ~200 restarts.
Fixes
```
Exception in thread zeroconf-Engine:
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.7/site-packages/zeroconf/__init__.py", line 1228, in run
    reader.handle_read(socket_)
  File "/usr/local/lib/python3.7/site-packages/zeroconf/__init__.py", line 1301, in handle_read
    self.zc.handle_response(msg)
  File "/usr/local/lib/python3.7/site-packages/zeroconf/__init__.py", line 2501, in handle_response
    with self._handlers_lock:
AttributeError: 'Zeroconf' object has no attribute '_handlers_lock'
```