### PR TITLE
Fix flake8 E741 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(join(PROJECT_ROOT, 'README.rst'), encoding='utf-8') as f:
     readme = f.read()
 
 version = (
-    [l for l in open(join(PROJECT_ROOT, 'zeroconf', '__init__.py')) if '__version__' in l][0]
+    [ln for ln in open(join(PROJECT_ROOT, 'zeroconf', '__init__.py')) if '__version__' in ln][0]
     .split('=')[-1]
     .strip()
     .strip('\'"')


### PR DESCRIPTION
The CI was hitting on the `l` variable per
https://www.flake8rules.com/rules/E741.html