### PR TITLE
Use equality comparison instead of identity comparison for ints

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -2064,7 +2064,7 @@ def new_socket(
             if not err.errno == errno.ENOPROTOOPT:
                 raise
 
-    if port is _MDNS_PORT:
+    if port == _MDNS_PORT:
         ttl = struct.pack(b'B', 255)
         loop = struct.pack(b'B', 1)
         if ip_version != IPVersion.V6Only:


### PR DESCRIPTION
Integers aren't guaranteed to have the same identity even though they
may be equal.