### PR TITLE
Give threads unique names

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1221,7 +1221,7 @@ class Engine(threading.Thread):
         self.condition = threading.Condition()
         self.socketpair = socket.socketpair()
         self.start()
-        self.name = "zeroconf-Engine-%s" % self.native_id if hasattr(self, 'native_id') else self.ident
+        self.name = "zeroconf-Engine-%s" % self.native_id if hasattr(self, 'native_id') else self.ident  # type: ignore
 
     def run(self) -> None:
         while not self.zc.done:
@@ -1329,7 +1329,7 @@ class Reaper(threading.Thread):
         self.daemon = True
         self.zc = zc
         self.start()
-        self.name = "zeroconf-Reaper_%u" % self.native_id if hasattr(self, 'native_id') else self.ident
+        self.name = "zeroconf-Reaper_%u" % self.native_id if hasattr(self, 'native_id') else self.ident  # type: ignore
 
     def run(self) -> None:
         while True:
@@ -1463,8 +1463,8 @@ class ServiceBrowser(RecordUpdateListener, threading.Thread):
 
         self.start()
         self.name = "zeroconf-ServiceBrowser_%s_%u" % (
-            '-'.join(self.types),
-            self.native_id if hasattr(self, 'native_id') else self.ident,
+            '-'.join(self.types),  # type: ignore
+            self.native_id if hasattr(self, 'native_id') else self.ident,  # type: ignore
         )
 
     @property

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1213,7 +1213,7 @@ class Engine(threading.Thread):
     """
 
     def __init__(self, zc: 'Zeroconf') -> None:
-        threading.Thread.__init__(self, name='zeroconf-Engine')
+        threading.Thread.__init__(self)
         self.daemon = True
         self.zc = zc
         self.readers = {}  # type: Dict[socket.socket, Listener]
@@ -1221,6 +1221,7 @@ class Engine(threading.Thread):
         self.condition = threading.Condition()
         self.socketpair = socket.socketpair()
         self.start()
+        self.name = f"zeroconf-Engine-{self.native_id if hasattr(self, 'native_id') else self.ident}"
 
     def run(self) -> None:
         while not self.zc.done:
@@ -1324,10 +1325,11 @@ class Reaper(threading.Thread):
     have expired."""
 
     def __init__(self, zc: 'Zeroconf') -> None:
-        threading.Thread.__init__(self, name='zeroconf-Reaper')
+        threading.Thread.__init__(self)
         self.daemon = True
         self.zc = zc
         self.start()
+        self.name = f"zeroconf-Reaper_{self.native_id if hasattr(self, 'native_id') else self.ident}"
 
     def run(self) -> None:
         while True:
@@ -1411,7 +1413,7 @@ class ServiceBrowser(RecordUpdateListener, threading.Thread):
         for check_type_ in self.types:
             if not check_type_.endswith(service_type_name(check_type_, allow_underscores=True)):
                 raise BadTypeInNameException
-        threading.Thread.__init__(self, name='zeroconf-ServiceBrowser_' + '-'.join(self.types))
+        threading.Thread.__init__(self)
         self.daemon = True
         self.zc = zc
         self.addr = addr
@@ -1460,6 +1462,7 @@ class ServiceBrowser(RecordUpdateListener, threading.Thread):
             self.service_state_changed.register_handler(h)
 
         self.start()
+        self.name = f"zeroconf-ServiceBrowser_{'-'.join(self.types)}_{self.native_id if hasattr(self, 'native_id') else self.ident}"
 
     @property
     def service_state_changed(self) -> SignalRegistrationInterface:

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1221,7 +1221,7 @@ class Engine(threading.Thread):
         self.condition = threading.Condition()
         self.socketpair = socket.socketpair()
         self.start()
-        self.name = f"zeroconf-Engine-{self.native_id if hasattr(self, 'native_id') else self.ident}"
+        self.name = "zeroconf-Engine-%s" % self.native_id if hasattr(self, 'native_id') else self.ident
 
     def run(self) -> None:
         while not self.zc.done:
@@ -1329,7 +1329,7 @@ class Reaper(threading.Thread):
         self.daemon = True
         self.zc = zc
         self.start()
-        self.name = f"zeroconf-Reaper_{self.native_id if hasattr(self, 'native_id') else self.ident}"
+        self.name = "zeroconf-Reaper_%u" % self.native_id if hasattr(self, 'native_id') else self.ident
 
     def run(self) -> None:
         while True:
@@ -1462,7 +1462,10 @@ class ServiceBrowser(RecordUpdateListener, threading.Thread):
             self.service_state_changed.register_handler(h)
 
         self.start()
-        self.name = f"zeroconf-ServiceBrowser_{'-'.join(self.types)}_{self.native_id if hasattr(self, 'native_id') else self.ident}"
+        self.name = "zeroconf-ServiceBrowser_%s_%u" % (
+            '-'.join(self.types),
+            self.native_id if hasattr(self, 'native_id') else self.ident,
+        )
 
     @property
     def service_state_changed(self) -> SignalRegistrationInterface:

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1221,9 +1221,7 @@ class Engine(threading.Thread):
         self.condition = threading.Condition()
         self.socketpair = socket.socketpair()
         self.start()
-        self.name = "zeroconf-Engine-%s" % (
-            self.native_id if hasattr(self, 'native_id') else self.ident  # type: ignore
-        )
+        self.name = "zeroconf-Engine-%s" % (getattr(self, 'native_id', self.ident),)
 
     def run(self) -> None:
         while not self.zc.done:
@@ -1331,9 +1329,7 @@ class Reaper(threading.Thread):
         self.daemon = True
         self.zc = zc
         self.start()
-        self.name = "zeroconf-Reaper_%u" % (
-            self.native_id if hasattr(self, 'native_id') else self.ident  # type: ignore
-        )
+        self.name = "zeroconf-Reaper_%s" % (getattr(self, 'native_id', self.ident),)
 
     def run(self) -> None:
         while True:
@@ -1466,9 +1462,9 @@ class ServiceBrowser(RecordUpdateListener, threading.Thread):
             self.service_state_changed.register_handler(h)
 
         self.start()
-        self.name = "zeroconf-ServiceBrowser_%s_%u" % (
-            '-'.join(self.types),  # type: ignore
-            self.native_id if hasattr(self, 'native_id') else self.ident,  # type: ignore
+        self.name = "zeroconf-ServiceBrowser_%s_%s" % (
+            '-'.join(self.types),
+            getattr(self, 'native_id', self.ident),
         )
 
     @property

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1221,7 +1221,9 @@ class Engine(threading.Thread):
         self.condition = threading.Condition()
         self.socketpair = socket.socketpair()
         self.start()
-        self.name = "zeroconf-Engine-%s" % self.native_id if hasattr(self, 'native_id') else self.ident  # type: ignore
+        self.name = "zeroconf-Engine-%s" % (
+            self.native_id if hasattr(self, 'native_id') else self.ident  # type: ignore
+        )
 
     def run(self) -> None:
         while not self.zc.done:
@@ -1329,7 +1331,9 @@ class Reaper(threading.Thread):
         self.daemon = True
         self.zc = zc
         self.start()
-        self.name = "zeroconf-Reaper_%u" % self.native_id if hasattr(self, 'native_id') else self.ident  # type: ignore
+        self.name = "zeroconf-Reaper_%u" % (
+            self.native_id if hasattr(self, 'native_id') else self.ident  # type: ignore
+        )
 
     def run(self) -> None:
         while True:


### PR DESCRIPTION
Give threads unique names to improve log clarity when there are multiple zeroconf instances or multiple service browsers for the same type.