### PR TITLE
Don't call callbacks whend holding _handlers_lock

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1579,12 +1579,12 @@ class ServiceBrowser(RecordUpdateListener, threading.Thread):
             if len(self._handlers_to_call) > 0 and not self.zc.done:
                 with self.zc._handlers_lock:
                     (name, service_type_state_change) = self._handlers_to_call.popitem(False)
-                    self._service_state_changed.fire(
-                        zeroconf=self.zc,
-                        service_type=service_type_state_change[0],
-                        name=name,
-                        state_change=service_type_state_change[1],
-                    )
+                self._service_state_changed.fire(
+                    zeroconf=self.zc,
+                    service_type=service_type_state_change[0],
+                    name=name,
+                    state_change=service_type_state_change[1],
+                )
 
 
 class ServiceInfo(RecordUpdateListener):


### PR DESCRIPTION
Don't hold `_handlers_lock` when calling the service callbacks.

Closes #255 

Background:
#239 adds the lock `_handlers_lock`:
https://github.com/jstasiak/python-zeroconf/blob/552a030eb592a0c07feaa7a01ece1464da4b1d0b/zeroconf/__init__.py#L2209

Which is used in the engine thread:
https://github.com/jstasiak/python-zeroconf/blob/552a030eb592a0c07feaa7a01ece1464da4b1d0b/zeroconf/__init__.py#L2484-L2489

And also by the service browser when issuing the state change callbacks:
https://github.com/jstasiak/python-zeroconf/blob/552a030eb592a0c07feaa7a01ece1464da4b1d0b/zeroconf/__init__.py#L1541-L1546

Both pychromecast and Home Assistant calls `Zeroconf.get_service_info` from the service callbacks which means the lock may be held for several seconds which will starve the engine thread.