### PR TITLE
Warn on every call to missing update_service() listener method

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1451,6 +1451,12 @@ class ServiceBrowser(RecordUpdateListener, threading.Thread):
                 elif state_change is ServiceStateChange.Updated:
                     if hasattr(listener, 'update_service'):
                         listener.update_service(*args)
+                    else:
+                        warnings.warn(
+                            "%r has no update_service method. Provide one (it can be empty if you "
+                            "don't care about the updates), it'll become mandatory." % (listener,),
+                            FutureWarning,
+                        )
                 else:
                     raise NotImplementedError(state_change)
 


### PR DESCRIPTION
This is in order to provide visibility to the library users that this method exists - without it the client code may be missing data.