### PR TITLE
Add support for passing text addresses to ServiceInfo

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -218,6 +218,12 @@ def _is_v6_address(addr: bytes) -> bool:
     return len(addr) == 16
 
 
+def _encode_address(address: str) -> bytes:
+    is_ipv6 = ':' in address
+    address_family = socket.AF_INET6 if is_ipv6 else socket.AF_INET
+    return socket.inet_pton(address_family, address)
+
+
 def service_type_name(type_: str, *, allow_underscores: bool = False) -> str:
     """
     Validate a fully qualified service name, instance or subtype. [rfc6763]
@@ -1608,8 +1614,8 @@ class ServiceInfo(RecordUpdateListener):
     * server: fully qualified name for service host (defaults to name)
     * host_ttl: ttl used for A/SRV records
     * other_ttl: ttl used for PTR/TXT records
-    * addresses: List of IP addresses as unsigned short (IPv4) or unsigned 128 bit number (IPv6),
-      network byte order
+    * addresses and parsed_addresses: List of IP addresses (either as bytes, network byte order, or in parsed
+      form as text; at most one of those parameters can be provided)
 
     """
 
@@ -1630,14 +1636,20 @@ class ServiceInfo(RecordUpdateListener):
         host_ttl: int = _DNS_HOST_TTL,
         other_ttl: int = _DNS_OTHER_TTL,
         *,
-        addresses: Optional[List[bytes]] = None
+        addresses: Optional[List[bytes]] = None,
+        parsed_addresses: Optional[List[str]] = None
     ) -> None:
+        # Accept both none, or one, but not both.
+        if addresses is not None and parsed_addresses is not None:
+            raise TypeError("addresses and parsed_addresses cannot be provided together")
         if not type_.endswith(service_type_name(name, allow_underscores=True)):
             raise BadTypeInNameException
         self.type = type_
         self.name = name
         if addresses is not None:
             self._addresses = addresses
+        elif parsed_addresses is not None:
+            self._addresses = [_encode_address(a) for a in parsed_addresses]
         else:
             self._addresses = []
         # This results in an ugly error when registering, better check now

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -1480,19 +1480,44 @@ def test_multiple_addresses():
 
     assert info.addresses == [address, address]
 
+    info = ServiceInfo(
+        type_,
+        registration_name,
+        80,
+        0,
+        0,
+        desc,
+        "ash-2.local.",
+        parsed_addresses=[address_parsed, address_parsed],
+    )
+    assert info.addresses == [address, address]
+
     if socket.has_ipv6 and not os.environ.get('SKIP_IPV6'):
         address_v6_parsed = "2001:db8::1"
         address_v6 = socket.inet_pton(socket.AF_INET6, address_v6_parsed)
-        info = ServiceInfo(
-            type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[address, address_v6],
-        )
-        assert info.addresses == [address]
-        assert info.addresses_by_version(r.IPVersion.All) == [address, address_v6]
-        assert info.addresses_by_version(r.IPVersion.V4Only) == [address]
-        assert info.addresses_by_version(r.IPVersion.V6Only) == [address_v6]
-        assert info.parsed_addresses() == [address_parsed, address_v6_parsed]
-        assert info.parsed_addresses(r.IPVersion.V4Only) == [address_parsed]
-        assert info.parsed_addresses(r.IPVersion.V6Only) == [address_v6_parsed]
+        infos = [
+            ServiceInfo(
+                type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[address, address_v6],
+            ),
+            ServiceInfo(
+                type_,
+                registration_name,
+                80,
+                0,
+                0,
+                desc,
+                "ash-2.local.",
+                parsed_addresses=[address_parsed, address_v6_parsed],
+            ),
+        ]
+        for info in infos:
+            assert info.addresses == [address]
+            assert info.addresses_by_version(r.IPVersion.All) == [address, address_v6]
+            assert info.addresses_by_version(r.IPVersion.V4Only) == [address]
+            assert info.addresses_by_version(r.IPVersion.V6Only) == [address_v6]
+            assert info.parsed_addresses() == [address_parsed, address_v6_parsed]
+            assert info.parsed_addresses(r.IPVersion.V4Only) == [address_parsed]
+            assert info.parsed_addresses(r.IPVersion.V6Only) == [address_v6_parsed]
 
 
 def test_ptr_optimization():


### PR DESCRIPTION
Not sure if parsed_addresses is the best way to name the parameter, but
we already have a parsed_addresses property so for the sake of
consistency let's stick to that.