### PR TITLE
Make Mypy happy

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -2036,7 +2036,7 @@ def ip_to_index(adapters: List[Any], ip: str) -> int:
         for adapter_ip in adapter.ips:
             # IPv6 addresses are represented as tuples
             if isinstance(adapter_ip.ip, tuple) and ipaddress.ip_address(adapter_ip.ip[0]) == ipaddr:
-                return adapter.index
+                return cast(int, adapter.index)
 
     raise RuntimeError('No adapter found for IP address %s' % ip)
 


### PR DESCRIPTION
Otherwise it'd complain:

    % make mypy
    mypy examples/*.py zeroconf/*.py
    zeroconf/__init__.py:2039: error: Returning Any from function declared to return "int"
    Found 1 error in 1 file (checked 6 source files)
    make: *** [mypy] Error 1