### PR TITLE
Ensure all listeners are cleaned up on ServiceBrowser cancelation

### DIFF
--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -861,20 +861,6 @@ class TestDNSCache(unittest.TestCase):
         cache.remove(record2)
         assert 'a' not in cache.cache
 
-    def test_cache_empty_multiple_calls_does_not_throw(self):
-        record1 = r.DNSAddress('a', r._TYPE_SOA, r._CLASS_IN, 1, b'a')
-        record2 = r.DNSAddress('a', r._TYPE_SOA, r._CLASS_IN, 1, b'b')
-        cache = r.DNSCache()
-        cache.add(record1)
-        cache.add(record2)
-        assert 'a' in cache.cache
-        cache.remove(record1)
-        cache.remove(record2)
-        # Ensure multiple removes does not throw
-        cache.remove(record1)
-        cache.remove(record2)
-        assert 'a' not in cache.cache
-
 
 class ServiceTypesQuery(unittest.TestCase):
     def test_integration_with_listener(self):


### PR DESCRIPTION

Sorry I missed this in the original submission #249. 🙊 

When creating listeners for a ServiceBrowser with multiple types
they would not all be removed on cancelation. This led
to a build up of stale listeners when ServiceBrowsers were
frequently added and removed.