### PR TITLE
Remove initial delay before querying for service info

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1890,7 +1890,7 @@ class ServiceInfo(RecordUpdateListener):
         """
         now = current_time_millis()
         delay = _LISTENER_TIME
-        next_ = now + delay
+        next_ = now
         last = now + timeout
 
         record_types_for_check_cache = [(_TYPE_SRV, _CLASS_IN), (_TYPE_TXT, _CLASS_IN)]


### PR DESCRIPTION
As discussed here: https://github.com/jstasiak/python-zeroconf/pull/292#discussion_r471787269