### PR TITLE
Reduce frequency of Reaper and avoid copying the cache when possible

### DIFF
--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -884,6 +884,54 @@ class TestDNSCache(unittest.TestCase):
         assert 'a' not in cache.cache
 
 
+class TestReaper(unittest.TestCase):
+    def test_reaper(self):
+        zeroconf = Zeroconf(interfaces=['127.0.0.1'])
+        original_entries = zeroconf.cache.entries()
+        record_with_10s_ttl = r.DNSAddress('a', r._TYPE_SOA, r._CLASS_IN, 10, b'a')
+        record_with_1s_ttl = r.DNSAddress('a', r._TYPE_SOA, r._CLASS_IN, 1, b'b')
+        zeroconf.cache.add(record_with_10s_ttl)
+        zeroconf.cache.add(record_with_1s_ttl)
+        entries_with_cache = zeroconf.cache.entries()
+        time.sleep(1.05)
+        zeroconf.notify_reaper()
+        time.sleep(0.05)
+        entries = zeroconf.cache.entries()
+
+        try:
+            iterable_entries = list(zeroconf.cache.iterable_entries())
+        finally:
+            zeroconf.close()
+
+        assert entries != original_entries
+        assert entries_with_cache != original_entries
+        assert record_with_10s_ttl in entries
+        assert record_with_1s_ttl not in entries
+        assert record_with_10s_ttl in iterable_entries
+        assert record_with_1s_ttl not in iterable_entries
+
+    def test_reaper_with_dict_change_during_iteration(self):
+        zeroconf = Zeroconf(interfaces=['127.0.0.1'])
+        original_entries = zeroconf.cache.entries()
+        record_with_10s_ttl = r.DNSAddress('a', r._TYPE_SOA, r._CLASS_IN, 10, b'a')
+        record_with_1s_ttl = r.DNSAddress('a', r._TYPE_SOA, r._CLASS_IN, 1, b'b')
+        zeroconf.cache.add(record_with_10s_ttl)
+        zeroconf.cache.add(record_with_1s_ttl)
+        entries_with_cache = zeroconf.cache.entries()
+        with unittest.mock.patch("zeroconf.DNSCache.iterable_entries", side_effect=RuntimeError):
+            time.sleep(1.05)
+            zeroconf.notify_reaper()
+            time.sleep(0.05)
+
+        entries = zeroconf.cache.entries()
+        zeroconf.close()
+
+        assert entries != original_entries
+        assert entries_with_cache != original_entries
+        assert record_with_10s_ttl in entries
+        assert record_with_1s_ttl not in entries
+
+
 class ServiceTypesQuery(unittest.TestCase):
     def test_integration_with_listener(self):
 


### PR DESCRIPTION
Avoid copying the entires cache and reduce frequency of Reaper

The cache reaper was running at least every 10 seconds, making
a copy of the cache, and iterated all the entries to
check if they were expired so they could be removed.

In practice the reaper was actually running much more frequently
because it used self.zc.wait which would unblock any time
a record was updated, a listener was added, or when a
listener was removed.

This change ensures the reaper frequency is only every 10s, and
will first attempt to iterate the cache before falling back to
making a copy.

Previously it made sense to expire the cache more frequently
because we had places were we frequently had to enumerate
all the cache entries. With #247 and #232 we no longer
have to account for this concern.

On a mostly idle RPi running HomeAssistant and a busy
network the total time spent reaping the cache was
more than the total time spent processing the mDNS traffic.

Top 10 functions, idle RPi (before)

```
  %Own   %Total  OwnTime  TotalTime  Function (filename:line)
  0.00%   0.00%    2.69s     2.69s   handle_read (zeroconf/__init__.py:1367)   <== Incoming mDNS
  0.00%   0.00%    1.51s     2.98s   run (zeroconf/__init__.py:1431)           <== Reaper
  0.00%   0.00%    1.42s     1.42s   is_expired (zeroconf/__init__.py:502)     <== Reaper
  0.00%   0.00%    1.12s     1.12s   entries (zeroconf/__init__.py:1274)       <== Reaper
  0.00%   0.00%   0.620s    0.620s   do_execute (sqlalchemy/engine/default.py:593)
  0.00%   0.00%   0.620s    0.620s   read_utf (zeroconf/__init__.py:837)
  0.00%   0.00%   0.610s    0.610s   do_commit (sqlalchemy/engine/default.py:546)
  0.00%   0.00%   0.540s     1.16s   read_name (zeroconf/__init__.py:853)
  0.00%   0.00%   0.380s    0.380s   do_close (sqlalchemy/engine/default.py:549)
  0.00%   0.00%   0.340s    0.340s   write (asyncio/selector_events.py:908)
```

After this change, the Reaper code paths do not show up in the top
10 function sample.

```
  %Own   %Total  OwnTime  TotalTime  Function (filename:line)
  4.00%   4.00%    2.72s     2.72s   handle_read (zeroconf/__init__.py:1378)     <== Incoming mDNS
  4.00%   4.00%    1.81s     1.81s   read_utf (zeroconf/__init__.py:837)
  1.00%   5.00%    1.68s     3.51s   read_name (zeroconf/__init__.py:853)
  0.00%   0.00%    1.32s     1.32s   do_execute (sqlalchemy/engine/default.py:593)
  0.00%   0.00%   0.960s    0.960s   readinto (socket.py:669)
  0.00%   0.00%   0.950s    0.950s   create_connection (urllib3/util/connection.py:74)
  0.00%   0.00%   0.910s    0.910s   do_commit (sqlalchemy/engine/default.py:546)
  1.00%   1.00%   0.880s    0.880s   write (asyncio/selector_events.py:908)
  0.00%   0.00%   0.700s    0.810s   __eq__ (zeroconf/__init__.py:606)
  2.00%   2.00%   0.670s    0.670s   unpack (zeroconf/__init__.py:737)
```
