### PR TITLE
Add ServiceListener to __all__ for Zeroconf module

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -51,6 +51,7 @@ __all__ = [
     "Zeroconf",
     "ServiceInfo",
     "ServiceBrowser",
+    "ServiceListener",
     "Error",
     "InterfaceChoice",
     "ServiceStateChange",


### PR DESCRIPTION
This screenshot explains what I'm seeing as a client. The `ServiceBrowser` type hints the listener as an `Optional[ServiceListener]` but trying to import `ServiceListener` gives a warning since it's not explicitly included in the `__all__` of Zeroconf's module.

![Screen Shot 2020-09-05 at 4 33 54 PM](https://user-images.githubusercontent.com/1546215/92314518-c4414980-ef95-11ea-944b-1e598968795b.png)
