### PR TITLE
Avoid processing duplicate packets

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1381,6 +1381,17 @@ class Listener(QuietLogger):
             self.log_exception_warning('Error reading from socket %d', socket_.fileno())
             return
 
+        if self.data == data:
+            log.debug(
+                'Ignoring duplicate message received from %r:%r (socket %d) (%d bytes) as [%r]',
+                addr,
+                port,
+                socket_.fileno(),
+                len(data),
+                data,
+            )
+            return
+
         self.data = data
         msg = DNSIncoming(data)
         if msg.valid:


### PR DESCRIPTION
When watching packet captures, I noticed that zeroconf was processing
incoming data 3x on a my Home Assistant OS install because there are
three interfaces.

We can skip processing duplicate packets in order to reduce the overhead
of decoding data we have already processed.

`strace -p 231 -f -s 4096 -e trace=recvfrom`


```
[pid   267] recvfrom(7, "\224\7\0\0\0\1\0\0\0\0\0\0\17_home-assistant\4_tcp\5local\0\0\f\0\1", 8966, 0, {sa_family=AF_INET, sin_port=htons(5353), sin_addr=inet_addr("172.30.32.3")}, [16]) = 44
[pid   267] recvfrom(7, "\224\7\0\0\0\1\0\0\0\0\0\0\17_home-assistant\4_tcp\5local\0\0\f\0\1", 8966, 0, {sa_family=AF_INET, sin_port=htons(5353), sin_addr=inet_addr("192.168.213.154")}, [16]) = 44
[pid   267] recvfrom(9, "\224\7\0\0\0\1\0\0\0\0\0\0\17_home-assistant\4_tcp\5local\0\0\f\0\1", 8966, 0, {sa_family=AF_INET, sin_port=htons(5353), sin_addr=inet_addr("172.30.32.3")}, [16]) = 44
```

Top 10 Before
```
  0.00%   0.00%    2.01s     2.01s   handle_read (zeroconf/__init__.py:1379)
  0.00%   0.00%    1.48s     1.48s   read_utf (zeroconf/__init__.py:838)
  0.00%   0.00%    1.27s     2.75s   read_name (zeroconf/__init__.py:854)
  0.00%   0.00%   0.570s    0.570s   unpack (zeroconf/__init__.py:738)
  0.00%   0.00%   0.420s    0.420s   read_name (zeroconf/__init__.py:848)
  0.00%   0.00%   0.410s    0.410s   do_execute (sqlalchemy/engine/default.py:593)
  0.00%   0.00%   0.390s    0.520s   __eq__ (zeroconf/__init__.py:607)
  0.00%   0.00%   0.390s    0.390s   read_name (zeroconf/__init__.py:859)
  0.00%   0.00%   0.360s    0.360s   get_expiration_time (zeroconf/__init__.py:494)
  0.00%   0.00%   0.330s    0.330s   write (asyncio/selector_events.py:908)
```

Top 10 After
```
  3.00%   3.00%    2.01s     2.01s   handle_read (zeroconf/__init__.py:1379)
  0.00%   0.00%    1.30s     1.30s   create_connection (urllib3/util/connection.py:74)
  0.00%   0.00%    1.25s     1.25s   get_subscription (pysonos/events_base.py:765)
  0.00%   0.00%    1.05s     1.05s   __init__ (socket.py:231)
  2.00%   2.00%    1.02s     1.02s   read_utf (zeroconf/__init__.py:838)
  0.00%   0.00%   0.950s    0.950s   do_commit (sqlalchemy/engine/default.py:546)
  0.00%   0.00%   0.940s    0.940s   subscribe (pysonos/events_base.py:476)
  0.00%   0.00%   0.880s    0.880s   readinto (socket.py:669)
  0.00%   0.00%   0.850s    0.850s   getaddrinfo (socket.py:918)
  0.00%   2.00%   0.780s     1.81s   read_name (zeroconf/__init__.py:854)
```