### PR TITLE
Test with Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,12 @@ python:
     - "3.6"
     - "3.7"
     - "3.8"
+    - "3.9-dev"
     - "pypy3.5"
     - "pypy3"
+matrix:
+  allow_failures:
+    - python: "3.9-dev"
 install:
     - pip install --upgrade -r requirements-dev.txt
     # mypy can't be installed on pypy


### PR DESCRIPTION
There've been reports of test failures on Python 3.9, let's verify this.
Allowing failures for now until it goes stable.