### PR TITLE
Fix AttributeError: module 'unittest' has no attribute 'mock'

### DIFF
--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -12,6 +12,7 @@ import struct
 import threading
 import time
 import unittest
+import unittest.mock
 from threading import Event
 from typing import Dict, Optional  # noqa # used in type hints
 from typing import cast


### PR DESCRIPTION
We only had module-level unittest import before now, but code accessing
mock through unittest.mock was working because we have a test-level
import from unittest.mock which causes unittest to gain the mock
attribute and if the test was run before other tests (those using
unittest.mock.patch) all was good. If the test was not run before them,
though, they'd fail.

Closes GH-295.