### PR TITLE
Loosen validation to ensure get_service_info can handle production devices

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1770,7 +1770,6 @@ class ServiceInfo(RecordUpdateListener):
     * other_ttl: ttl used for PTR/TXT records
     * addresses and parsed_addresses: List of IP addresses (either as bytes, network byte order, or in parsed
       form as text; at most one of those parameters can be provided)
-    * strict: Controls validation for service_name and protocol
 
     """
 
@@ -1792,13 +1791,12 @@ class ServiceInfo(RecordUpdateListener):
         other_ttl: int = _DNS_OTHER_TTL,
         *,
         addresses: Optional[List[bytes]] = None,
-        parsed_addresses: Optional[List[str]] = None,
-        strict: bool = True
+        parsed_addresses: Optional[List[str]] = None
     ) -> None:
         # Accept both none, or one, but not both.
         if addresses is not None and parsed_addresses is not None:
             raise TypeError("addresses and parsed_addresses cannot be provided together")
-        if not type_.endswith(service_type_name(name, strict=strict, allow_underscores=True)):
+        if not type_.endswith(service_type_name(name, strict=False, allow_underscores=True)):
             raise BadTypeInNameException
         self.type = type_
         self.name = name

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -277,8 +277,8 @@ def service_type_name(type_: str, *, allow_underscores: bool = False, strict: bo
     """
 
     if type_.endswith(_TCP_PROTOCOL_LOCAL_TRAILER) or type_.endswith(_NONTCP_PROTOCOL_LOCAL_TRAILER):
-        remaining = type_[:-len(_TCP_PROTOCOL_LOCAL_TRAILER)].split('.')
-        trailer = type_[-len(_TCP_PROTOCOL_LOCAL_TRAILER):]
+        remaining = type_[: -len(_TCP_PROTOCOL_LOCAL_TRAILER)].split('.')
+        trailer = type_[-len(_TCP_PROTOCOL_LOCAL_TRAILER) :]
         has_protocol = True
     elif strict:
         raise BadTypeInNameException(
@@ -286,7 +286,7 @@ def service_type_name(type_: str, *, allow_underscores: bool = False, strict: bo
             % (type_, _TCP_PROTOCOL_LOCAL_TRAILER, _NONTCP_PROTOCOL_LOCAL_TRAILER)
         )
     elif type_.endswith(_LOCAL_TRAILER):
-        remaining = type_[:-len(_LOCAL_TRAILER)].split('.')
+        remaining = type_[: -len(_LOCAL_TRAILER)].split('.')
         trailer = type_[-len(_LOCAL_TRAILER) + 1 :]
         has_protocol = False
     else:

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -183,9 +183,6 @@ _LOCAL_TRAILER = '.local.'
 _TCP_PROTOCOL_LOCAL_TRAILER = '._tcp.local.'
 _NONTCP_PROTOCOL_LOCAL_TRAILER = '._udp.local.'
 
-_LOCAL_LEN = len(_LOCAL_TRAILER)
-_PROTOCOL_LOCAL_LEN = len(_TCP_PROTOCOL_LOCAL_TRAILER)
-
 try:
     _IPPROTO_IPV6 = socket.IPPROTO_IPV6
 except AttributeError:
@@ -280,8 +277,8 @@ def service_type_name(type_: str, *, allow_underscores: bool = False, strict: bo
     """
 
     if type_.endswith(_TCP_PROTOCOL_LOCAL_TRAILER) or type_.endswith(_NONTCP_PROTOCOL_LOCAL_TRAILER):
-        remaining = type_[:-_PROTOCOL_LOCAL_LEN].split('.')
-        trailer = type_[-_PROTOCOL_LOCAL_LEN:]
+        remaining = type_[:-len(_TCP_PROTOCOL_LOCAL_TRAILER)].split('.')
+        trailer = type_[-len(_TCP_PROTOCOL_LOCAL_TRAILER):]
         has_protocol = True
     elif strict:
         raise BadTypeInNameException(
@@ -289,8 +286,8 @@ def service_type_name(type_: str, *, allow_underscores: bool = False, strict: bo
             % (type_, _TCP_PROTOCOL_LOCAL_TRAILER, _NONTCP_PROTOCOL_LOCAL_TRAILER)
         )
     elif type_.endswith(_LOCAL_TRAILER):
-        remaining = type_[:-_LOCAL_LEN].split('.')
-        trailer = type_[-_LOCAL_LEN + 1 :]
+        remaining = type_[:-len(_LOCAL_TRAILER)].split('.')
+        trailer = type_[-len(_LOCAL_TRAILER) + 1 :]
         has_protocol = False
     else:
         raise BadTypeInNameException("Type '%s' must end with '%s'" % (type_, _LOCAL_TRAILER))

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -2446,7 +2446,7 @@ class Zeroconf(QuietLogger):
         """Returns network's service information for a particular
         name and type, or None if no service matches by the timeout,
         which defaults to 3 seconds."""
-        info = ServiceInfo(type_, name, strict=False)
+        info = ServiceInfo(type_, name)
         if info.request(self, timeout):
             return info
         return None

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -179,6 +179,13 @@ _EXPIRE_FULL_TIME_PERCENT = 100
 _EXPIRE_STALE_TIME_PERCENT = 50
 _EXPIRE_REFRESH_TIME_PERCENT = 75
 
+_LOCAL_TRAILER = '.local.'
+_TCP_PROTOCOL_LOCAL_TRAILER = '._tcp.local.'
+_NONTCP_PROTOCOL_LOCAL_TRAILER = '._udp.local.'
+
+_LOCAL_LEN = len(_LOCAL_TRAILER)
+_PROTOCOL_LOCAL_LEN = len(_TCP_PROTOCOL_LOCAL_TRAILER)
+
 try:
     _IPPROTO_IPV6 = socket.IPPROTO_IPV6
 except AttributeError:
@@ -229,7 +236,7 @@ def _encode_address(address: str) -> bytes:
     return socket.inet_pton(address_family, address)
 
 
-def service_type_name(type_: str, *, allow_underscores: bool = False) -> str:
+def service_type_name(type_: str, *, allow_underscores: bool = False, strict: bool = True) -> str:
     """
     Validate a fully qualified service name, instance or subtype. [rfc6763]
 
@@ -246,9 +253,11 @@ def service_type_name(type_: str, *, allow_underscores: bool = False) -> str:
       This is true because we are implementing mDNS and since the 'm' means
       multi-cast, the 'local.' domain is mandatory.
 
-    2) local is preceded with either '_udp.' or '_tcp.'
+    2) local is preceded with either '_udp.' or '_tcp.' unless
+       strict is False
 
-    3) service name <sn> precedes <_tcp|_udp>
+    3) service name <sn> precedes <_tcp|_udp> unless
+       strict is False
 
       The rules for Service Names [RFC6335] state that they may be no more
       than fifteen characters long (not counting the mandatory underscore),
@@ -269,44 +278,64 @@ def service_type_name(type_: str, *, allow_underscores: bool = False) -> str:
     :param type_: Type, SubType or service name to validate
     :return: fully qualified service name (eg: _http._tcp.local.)
     """
-    if not (type_.endswith('._tcp.local.') or type_.endswith('._udp.local.')):
-        raise BadTypeInNameException("Type '%s' must end with '._tcp.local.' or '._udp.local.'" % type_)
 
-    remaining = type_[: -len('._tcp.local.')].split('.')
-    name = remaining.pop()
-    if not name:
-        raise BadTypeInNameException("No Service name found")
-
-    if len(remaining) == 1 and len(remaining[0]) == 0:
-        raise BadTypeInNameException("Type '%s' must not start with '.'" % type_)
-
-    if name[0] != '_':
-        raise BadTypeInNameException("Service name (%s) must start with '_'" % name)
-
-    # remove leading underscore
-    name = name[1:]
-
-    if len(name) > 15:
-        raise BadTypeInNameException("Service name (%s) must be <= 15 bytes" % name)
-
-    if '--' in name:
-        raise BadTypeInNameException("Service name (%s) must not contain '--'" % name)
-
-    if '-' in (name[0], name[-1]):
-        raise BadTypeInNameException("Service name (%s) may not start or end with '-'" % name)
-
-    if not _HAS_A_TO_Z.search(name):
-        raise BadTypeInNameException("Service name (%s) must contain at least one letter (eg: 'A-Z')" % name)
-
-    allowed_characters_re = (
-        _HAS_ONLY_A_TO_Z_NUM_HYPHEN_UNDERSCORE if allow_underscores else _HAS_ONLY_A_TO_Z_NUM_HYPHEN
-    )
-
-    if not allowed_characters_re.search(name):
+    if type_.endswith(_TCP_PROTOCOL_LOCAL_TRAILER) or type_.endswith(_NONTCP_PROTOCOL_LOCAL_TRAILER):
+        remaining = type_[:-_PROTOCOL_LOCAL_LEN].split('.')
+        trailer = type_[-_PROTOCOL_LOCAL_LEN:]
+        has_protocol = True
+    elif strict:
         raise BadTypeInNameException(
-            "Service name (%s) must contain only these characters: "
-            "A-Z, a-z, 0-9, hyphen ('-')%s" % (name, ", underscore ('_')" if allow_underscores else "")
+            "Type '%s' must end with '%s' or '%s'"
+            % (type_, _TCP_PROTOCOL_LOCAL_TRAILER, _NONTCP_PROTOCOL_LOCAL_TRAILER)
         )
+    elif type_.endswith(_LOCAL_TRAILER):
+        remaining = type_[:-_LOCAL_LEN].split('.')
+        trailer = type_[-_LOCAL_LEN + 1 :]
+        has_protocol = False
+    else:
+        raise BadTypeInNameException("Type '%s' must end with '%s'" % (type_, _LOCAL_TRAILER))
+
+    if strict or has_protocol:
+        service_name = remaining.pop()
+        if not service_name:
+            raise BadTypeInNameException("No Service name found")
+
+        if len(remaining) == 1 and len(remaining[0]) == 0:
+            raise BadTypeInNameException("Type '%s' must not start with '.'" % type_)
+
+        if service_name[0] != '_':
+            raise BadTypeInNameException("Service name (%s) must start with '_'" % service_name)
+
+        test_service_name = service_name[1:]
+
+        if len(test_service_name) > 15:
+            raise BadTypeInNameException("Service name (%s) must be <= 15 bytes" % test_service_name)
+
+        if '--' in test_service_name:
+            raise BadTypeInNameException("Service name (%s) must not contain '--'" % test_service_name)
+
+        if '-' in (test_service_name[0], test_service_name[-1]):
+            raise BadTypeInNameException(
+                "Service name (%s) may not start or end with '-'" % test_service_name
+            )
+
+        if not _HAS_A_TO_Z.search(test_service_name):
+            raise BadTypeInNameException(
+                "Service name (%s) must contain at least one letter (eg: 'A-Z')" % test_service_name
+            )
+
+        allowed_characters_re = (
+            _HAS_ONLY_A_TO_Z_NUM_HYPHEN_UNDERSCORE if allow_underscores else _HAS_ONLY_A_TO_Z_NUM_HYPHEN
+        )
+
+        if not allowed_characters_re.search(test_service_name):
+            raise BadTypeInNameException(
+                "Service name (%s) must contain only these characters: "
+                "A-Z, a-z, 0-9, hyphen ('-')%s"
+                % (test_service_name, ", underscore ('_')" if allow_underscores else "")
+            )
+    else:
+        service_name = ''
 
     if remaining and remaining[-1] == '_sub':
         remaining.pop()
@@ -326,7 +355,7 @@ def service_type_name(type_: str, *, allow_underscores: bool = False) -> str:
                 "Ascii control character 0x00-0x1F and 0x7F illegal in '%s'" % remaining[0]
             )
 
-    return '_' + name + type_[-len('._tcp.local.') :]
+    return service_name + trailer
 
 
 # Exceptions
@@ -1744,6 +1773,7 @@ class ServiceInfo(RecordUpdateListener):
     * other_ttl: ttl used for PTR/TXT records
     * addresses and parsed_addresses: List of IP addresses (either as bytes, network byte order, or in parsed
       form as text; at most one of those parameters can be provided)
+    * strict: Controls validation for service_name and protocol
 
     """
 
@@ -1765,12 +1795,13 @@ class ServiceInfo(RecordUpdateListener):
         other_ttl: int = _DNS_OTHER_TTL,
         *,
         addresses: Optional[List[bytes]] = None,
-        parsed_addresses: Optional[List[str]] = None
+        parsed_addresses: Optional[List[str]] = None,
+        strict: bool = True
     ) -> None:
         # Accept both none, or one, but not both.
         if addresses is not None and parsed_addresses is not None:
             raise TypeError("addresses and parsed_addresses cannot be provided together")
-        if not type_.endswith(service_type_name(name, allow_underscores=True)):
+        if not type_.endswith(service_type_name(name, strict=strict, allow_underscores=True)):
             raise BadTypeInNameException
         self.type = type_
         self.name = name
@@ -2420,7 +2451,7 @@ class Zeroconf(QuietLogger):
         """Returns network's service information for a particular
         name and type, or None if no service matches by the timeout,
         which defaults to 3 seconds."""
-        info = ServiceInfo(type_, name)
+        info = ServiceInfo(type_, name, strict=False)
         if info.request(self, timeout):
             return info
         return None

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -657,14 +657,59 @@ class Exceptions(unittest.TestCase):
         for name in bad_names_to_try:
             self.assertRaises(r.BadTypeInNameException, self.browser.get_service_info, name, 'x.' + name)
 
-    def test_good_instance_names(self):
+    def test_good_names_for_get_service_info(self):
         good_names_to_try = (
-            '.._x._tcp.local.',
-            'x.sub._http._tcp.local.',
-            '6d86f882b90facee9170ad3439d72a4d6ee9f511._zget._http._tcp.local.',
+            "Rachio-C73233.local.",
+            'YeelightColorBulb-3AFD.local.',
+            'YeelightTunableBulb-7220.local.',
+            "AlexanderHomeAssistant 74651D.local.",
+            'iSmartGate-152.local.',
+            'MyQ-FGA.local.',
+            'lutron-02c4392a.local.',
+            'WICED-hap-3E2734.local.',
+            'MyHost.local.',
+            'MyHost.sub.local.',
         )
         for name in good_names_to_try:
-            r.service_type_name(name)
+            self.browser.get_service_info('_http._tcp.local.', name)
+
+    def test_bad_local_names_for_get_service_info(self):
+        bad_names_to_try = (
+            'homekitdev._nothttp._tcp.local.',
+            'homekitdev._http._udp.local.',
+        )
+        for name in bad_names_to_try:
+            self.assertRaises(
+                r.BadTypeInNameException, self.browser.get_service_info, '_http._tcp.local.', name
+            )
+
+    def test_good_instance_names(self):
+        assert r.service_type_name('.._x._tcp.local.') == '_x._tcp.local.'
+        assert r.service_type_name('x.sub._http._tcp.local.') == '_http._tcp.local.'
+        assert (
+            r.service_type_name('6d86f882b90facee9170ad3439d72a4d6ee9f511._zget._http._tcp.local.')
+            == '_http._tcp.local.'
+        )
+
+    def test_good_instance_names_without_protocol(self):
+        good_names_to_try = (
+            "Rachio-C73233.local.",
+            'YeelightColorBulb-3AFD.local.',
+            'YeelightTunableBulb-7220.local.',
+            "AlexanderHomeAssistant 74651D.local.",
+            'iSmartGate-152.local.',
+            'MyQ-FGA.local.',
+            'lutron-02c4392a.local.',
+            'WICED-hap-3E2734.local.',
+            'MyHost.local.',
+            'MyHost.sub.local.',
+        )
+        for name in good_names_to_try:
+            assert r.service_type_name(name, strict=False) == 'local.'
+
+        for name in good_names_to_try:
+            # Raises without strict=False
+            self.assertRaises(r.BadTypeInNameException, r.service_type_name, name)
 
     def test_bad_types(self):
         bad_names_to_try = (
@@ -686,18 +731,13 @@ class Exceptions(unittest.TestCase):
             self.assertRaises(r.BadTypeInNameException, r.service_type_name, name)
 
     def test_good_service_names(self):
-        good_names_to_try = (
-            '_x._tcp.local.',
-            '_x._udp.local.',
-            '_12345-67890-abc._udp.local.',
-            'x._sub._http._tcp.local.',
-            'a' * 63 + '._sub._http._tcp.local.',
-            'a' * 61 + u'â._sub._http._tcp.local.',
-        )
-        for name in good_names_to_try:
-            r.service_type_name(name)
-
-        r.service_type_name('_one_two._tcp.local.', allow_underscores=True)
+        assert r.service_type_name('_x._tcp.local.') == '_x._tcp.local.'
+        assert r.service_type_name('_x._udp.local.') == '_x._udp.local.'
+        assert r.service_type_name('_12345-67890-abc._udp.local.') == '_12345-67890-abc._udp.local.'
+        assert r.service_type_name('x._sub._http._tcp.local.') == '_http._tcp.local.'
+        assert r.service_type_name('a' * 63 + '._sub._http._tcp.local.') == '_http._tcp.local.'
+        assert r.service_type_name('a' * 61 + u'â._sub._http._tcp.local.') == '_http._tcp.local.'
+        assert r.service_type_name('_one_two._tcp.local.', allow_underscores=True) == '_one_two._tcp.local.'
 
     def test_invalid_addresses(self):
         type_ = "_test-srvc-type._tcp.local."
@@ -714,6 +754,29 @@ class Exceptions(unittest.TestCase):
                 registration_name,
                 port=80,
                 addresses=[addr],
+            )
+
+    def test_service_info_for_local_name(self):
+        type_ = "_hap._tcp.local."
+        registration_names = (
+            "Rachio-C73233.local.",
+            'YeelightColorBulb-3AFD.local.',
+            'YeelightTunableBulb-7220.local.',
+            "AlexanderHomeAssistant 74651D.local.",
+            'iSmartGate-152.local.',
+            'MyQ-FGA.local.',
+            'lutron-02c4392a.local.',
+            'WICED-hap-3E2734.local.',
+            'MyHost.local.',
+        )
+
+        for registration_name in registration_names:
+            ServiceInfo(
+                type_,
+                registration_name,
+                port=80,
+                addresses=[socket.inet_aton("10.0.1.2")],
+                strict=False,
             )
 
 

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -715,12 +715,18 @@ class Exceptions(unittest.TestCase):
             self.assertRaises(r.BadTypeInNameException, r.service_type_name, name)
 
     def test_good_service_names(self):
-        assert r.service_type_name('_x._tcp.local.') == '_x._tcp.local.'
-        assert r.service_type_name('_x._udp.local.') == '_x._udp.local.'
-        assert r.service_type_name('_12345-67890-abc._udp.local.') == '_12345-67890-abc._udp.local.'
-        assert r.service_type_name('x._sub._http._tcp.local.') == '_http._tcp.local.'
-        assert r.service_type_name('a' * 63 + '._sub._http._tcp.local.') == '_http._tcp.local.'
-        assert r.service_type_name('a' * 61 + u'â._sub._http._tcp.local.') == '_http._tcp.local.'
+        good_names_to_try = (
+            ('_x._tcp.local.', '_x._tcp.local.'),
+            ('_x._udp.local.', '_x._udp.local.'),
+            ('_12345-67890-abc._udp.local.', '_12345-67890-abc._udp.local.'),
+            ('x._sub._http._tcp.local.', '_http._tcp.local.'),
+            ('a' * 63 + '._sub._http._tcp.local.', '_http._tcp.local.'),
+            ('a' * 61 + u'â._sub._http._tcp.local.', '_http._tcp.local.'),
+        )
+
+        for name, result in good_names_to_try:
+            assert r.service_type_name(name) == result
+
         assert r.service_type_name('_one_two._tcp.local.', allow_underscores=True) == '_one_two._tcp.local.'
 
     def test_invalid_addresses(self):
@@ -760,7 +766,6 @@ class Exceptions(unittest.TestCase):
                 registration_name,
                 port=80,
                 addresses=[socket.inet_aton("10.0.1.2")],
-                strict=False,
             )
 
 

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -657,22 +657,6 @@ class Exceptions(unittest.TestCase):
         for name in bad_names_to_try:
             self.assertRaises(r.BadTypeInNameException, self.browser.get_service_info, name, 'x.' + name)
 
-    def test_good_names_for_get_service_info(self):
-        good_names_to_try = (
-            "Rachio-C73233.local.",
-            'YeelightColorBulb-3AFD.local.',
-            'YeelightTunableBulb-7220.local.',
-            "AlexanderHomeAssistant 74651D.local.",
-            'iSmartGate-152.local.',
-            'MyQ-FGA.local.',
-            'lutron-02c4392a.local.',
-            'WICED-hap-3E2734.local.',
-            'MyHost.local.',
-            'MyHost.sub.local.',
-        )
-        for name in good_names_to_try:
-            self.browser.get_service_info('_http._tcp.local.', name)
-
     def test_bad_local_names_for_get_service_info(self):
         bad_names_to_try = (
             'homekitdev._nothttp._tcp.local.',

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -746,28 +746,6 @@ class Exceptions(unittest.TestCase):
                 addresses=[addr],
             )
 
-    def test_service_info_for_local_name(self):
-        type_ = "_hap._tcp.local."
-        registration_names = (
-            "Rachio-C73233.local.",
-            'YeelightColorBulb-3AFD.local.',
-            'YeelightTunableBulb-7220.local.',
-            "AlexanderHomeAssistant 74651D.local.",
-            'iSmartGate-152.local.',
-            'MyQ-FGA.local.',
-            'lutron-02c4392a.local.',
-            'WICED-hap-3E2734.local.',
-            'MyHost.local.',
-        )
-
-        for registration_name in registration_names:
-            ServiceInfo(
-                type_,
-                registration_name,
-                port=80,
-                addresses=[socket.inet_aton("10.0.1.2")],
-            )
-
 
 class TestDnsIncoming(unittest.TestCase):
     def test_incoming_exception_handling(self):


### PR DESCRIPTION
Validation of names was too strict and rejected devices that are otherwise
functional.  A partial list of devices that unexpectedly triggered
a BadTypeInNameException:

  Bose Soundtouch
  Yeelights
  Rachio Sprinklers
  iDevices

Fixes: https://github.com/home-assistant/core/issues/39116, https://github.com/home-assistant/core/issues/38914, https://github.com/home-assistant/core/issues/33085, https://github.com/home-assistant/core/issues/31262, https://github.com/home-assistant/core/issues/41355
