### PR TITLE
examples/browser.py: fix IPv6 addresses output

### DIFF
--- a/examples/browser.py
+++ b/examples/browser.py
@@ -7,7 +7,6 @@ The default is HTTP and HAP; use --find to search for all available services in 
 
 import argparse
 import logging
-import socket
 from time import sleep
 from typing import cast
 
@@ -23,7 +22,7 @@ def on_service_state_change(
         info = zeroconf.get_service_info(service_type, name)
         print("Info from zeroconf.get_service_info: %r" % (info))
         if info:
-            addresses = ["%s:%d" % (socket.inet_ntoa(addr), cast(int, info.port)) for addr in info.addresses]
+            addresses = ["%s:%d" % (addr, cast(int, info.port)) for addr in info.parsed_addresses()]
             print("  Addresses: %s" % ", ".join(addresses))
             print("  Weight: %d, priority: %d" % (info.weight, info.priority))
             print("  Server: %s" % (info.server,))


### PR DESCRIPTION
Before this change, script `examples/browser.py` printed IPv4 only, even with `--v6` argument.
With this change, `examples/browser.py` prints both IPv4 + IPv6 by default, and IPv6 only with `--v6-only` argument.

I took the idea from the fork
https://github.com/ad3angel1s/python-zeroconf/blob/master/examples/browser.py