### PR TITLE
Qualify IPv6 link-local addresses with scope_id

### DIFF
--- a/examples/browser.py
+++ b/examples/browser.py
@@ -21,8 +21,9 @@ def on_service_state_change(
     if state_change is ServiceStateChange.Added:
         info = zeroconf.get_service_info(service_type, name)
         print("Info from zeroconf.get_service_info: %r" % (info))
+
         if info:
-            addresses = ["%s:%d" % (addr, cast(int, info.port)) for addr in info.parsed_addresses()]
+            addresses = ["%s:%d" % (addr, cast(int, info.port)) for addr in info.parsed_scoped_addresses()]
             print("  Addresses: %s" % ", ".join(addresses))
             print("  Weight: %d, priority: %d" % (info.weight, info.priority))
             print("  Server: %s" % (info.server,))


### PR DESCRIPTION
When a service is advertised on an IPv6 address where
the scope is link local, i.e. fe80::/64 (see RFC 4007)
the resolved IPv6 address must be extended with the
scope_id that identifies through the "%" symbol the
local interface to be used when routing to that address.
A new API is provided to return qualified addresses
to avoid breaking compatibility on the existing
parsed_addresses().

This patch:
 * Extracts the scope_id from an IPv6 link-local address
   and return it in the retrieved information in ServiceInfo.
 * Adjusts the browser test to be able to show IPv6 link-local
   addresses by using the new method parsed_scoped_addresses().
 * Uses scope_id in unicast replies to IPv6 link-local addresses,
   and adds some unit tests to verify the new interface provided.

Co-authored-by: Lokesh Prajapati <lokesh.prajapati@ncipher.com>

Closes #314 