### PR TITLE
Refactor to move service registration into a registry

### DIFF
--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -878,6 +878,43 @@ class TestRegistrar(unittest.TestCase):
         nbr_answers = nbr_additionals = nbr_authorities = 0
 
 
+class TestServiceRegistry(unittest.TestCase):
+    def test_only_register_once(self):
+        type_ = "_test-srvc-type._tcp.local."
+        name = "xxxyyy"
+        registration_name = "%s.%s" % (name, type_)
+
+        desc = {'path': '/~paulsm/'}
+        info = ServiceInfo(
+            type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[socket.inet_aton("10.0.1.2")]
+        )
+
+        registry = r.ServiceRegistry()
+        registry.add(info)
+        self.assertRaises(r.ServiceNameAlreadyRegistered, registry.add, info)
+        registry.remove(info)
+        registry.add(info)
+
+    def test_lookups(self):
+        type_ = "_test-srvc-type._tcp.local."
+        name = "xxxyyy"
+        registration_name = "%s.%s" % (name, type_)
+
+        desc = {'path': '/~paulsm/'}
+        info = ServiceInfo(
+            type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[socket.inet_aton("10.0.1.2")]
+        )
+
+        registry = r.ServiceRegistry()
+        registry.add(info)
+
+        assert registry.get_service_infos() == [info]
+        assert registry.get_info_name(registration_name) == info
+        assert registry.get_infos_type(type_) == [info]
+        assert registry.get_infos_server("ash-2.local.") == [info]
+        assert registry.get_types() == [type_]
+
+
 class TestDNSCache(unittest.TestCase):
     def test_order(self):
         record1 = r.DNSAddress('a', r._TYPE_SOA, r._CLASS_IN, 1, b'a')


### PR DESCRIPTION
This permits removing the broad exception catch that
was expanded to avoid a crash in when adding or
removing a service