### PR TITLE
AddingPowerSupport_CI/Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+ - amd64
+ - ppc64le
 language: python
 python:
     - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,13 @@ python:
     - "3.9-dev"
     - "pypy3.5"
     - "pypy3"
+ jobs:
+  exclude:
+   - arch: ppc64le
+     python: pypy3
+   - arch: ppc64le
+     python: pypy3.5
+     
 matrix:
   allow_failures:
     - python: "3.9-dev"


### PR DESCRIPTION
Adding Power Support.

Adding power support ppc64le with Continues Integration/testing so that code remains architecture independent.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.

The build is successful on both arch: amd64/ppc64le, please find the Travis Link below.
https://travis-ci.com/github/santosh653/python-zeroconf

Please let me know if you need any further details.

Thank You !!