### PR TITLE
Simplify read_name

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -880,7 +880,7 @@ class DNSIncoming(QuietLogger):
                 break
             t = length & 0xC0
             if t == 0x00:
-                result = ''.join((result, self.read_utf(off, length) + '.'))
+                result += self.read_utf(off, length) + '.'
                 off += length
             elif t == 0xC0:
                 if next_ < 0:


### PR DESCRIPTION
I'm not sure why this code made a new string every time instead of appending to it.

```
(venv) root@ha-dev:~/python-zeroconf# python3 -m timeit -s 'result=""' -u usec 'result = "".join((result, "thisisaname" + "."))'
20000 loops, best of 5: 16.4 usec per loop
(venv) root@ha-dev:~/python-zeroconf# python3 -m timeit -s 'result=""' -u usec 'result += "thisisaname" + "."'
2000000 loops, best of 5: 0.105 usec per loop
```

<img width="1408" alt="Screen Shot 2021-02-04 at 9 58 26 AM" src="https://user-images.githubusercontent.com/663432/106948286-97719980-66cf-11eb-9574-e90910338656.png">
