### PR TITLE
Qualify IPv6 link-local addresses with scope_id

### DIFF
--- a/examples/async_browser.py
+++ b/examples/async_browser.py
@@ -28,7 +28,7 @@ async def async_display_service_info(zeroconf: Zeroconf, service_type: str, name
     await info.async_request(zeroconf, 3000)
     print("Info from zeroconf.get_service_info: %r" % (info))
     if info:
-        addresses = ["%s:%d" % (addr, cast(int, info.port)) for addr in info.parsed_addresses()]
+        addresses = ["%s:%d" % (addr, cast(int, info.port)) for addr in info.parsed_scoped_addresses()]
         print("  Name: %s" % name)
         print("  Addresses: %s" % ", ".join(addresses))
         print("  Weight: %d, priority: %d" % (info.weight, info.priority))

--- a/examples/browser.py
+++ b/examples/browser.py
@@ -21,8 +21,9 @@ def on_service_state_change(
     if state_change is ServiceStateChange.Added:
         info = zeroconf.get_service_info(service_type, name)
         print("Info from zeroconf.get_service_info: %r" % (info))
+
         if info:
-            addresses = ["%s:%d" % (addr, cast(int, info.port)) for addr in info.parsed_addresses()]
+            addresses = ["%s:%d" % (addr, cast(int, info.port)) for addr in info.parsed_scoped_addresses()]
             print("  Addresses: %s" % ", ".join(addresses))
             print("  Weight: %d, priority: %d" % (info.weight, info.priority))
             print("  Server: %s" % (info.server,))

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -447,10 +447,10 @@ def test_backoff(suppresses_mock):
         """Current system time in milliseconds"""
         return start_time + time_offset * 1000
 
-    def send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT):
+    def send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT, v6_flow_scope=None):
         """Sends an outgoing packet."""
         got_query.set()
-        old_send(out, addr=addr, port=port)
+        old_send(out, addr=addr, port=port, v6_flow_scope=v6_flow_scope)
 
     # patch the zeroconf send
     # patch the zeroconf current_time_millis
@@ -674,7 +674,7 @@ def test_integration():
     expected_ttl = const._DNS_HOST_TTL
     nbr_answers = 0
 
-    def send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT):
+    def send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT, v6_flow_scope=None):
         """Sends an outgoing packet."""
         pout = r.DNSIncoming(out.packets()[0])
         nonlocal nbr_answers
@@ -686,7 +686,7 @@ def test_integration():
         got_query.set()
         got_query.clear()
 
-        old_send(out, addr=addr, port=port)
+        old_send(out, addr=addr, port=port, v6_flow_scope=v6_flow_scope)
 
     # patch the zeroconf send
     # patch the zeroconf current_time_millis

--- a/zeroconf/_dns.py
+++ b/zeroconf/_dns.py
@@ -242,13 +242,22 @@ class DNSAddress(DNSRecord):
 
     """A DNS address record"""
 
-    __slots__ = ('address',)
+    __slots__ = ('address', 'scope_id')
 
     def __init__(
-        self, name: str, type_: int, class_: int, ttl: int, address: bytes, created: Optional[float] = None
+        self,
+        name: str,
+        type_: int,
+        class_: int,
+        ttl: int,
+        address: bytes,
+        *,
+        scope_id: Optional[int] = None,
+        created: Optional[float] = None,
     ) -> None:
         super().__init__(name, type_, class_, ttl, created)
         self.address = address
+        self.scope_id = scope_id
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet"""
@@ -257,12 +266,15 @@ class DNSAddress(DNSRecord):
     def __eq__(self, other: Any) -> bool:
         """Tests equality on address"""
         return (
-            isinstance(other, DNSAddress) and DNSEntry.__eq__(self, other) and self.address == other.address
+            isinstance(other, DNSAddress)
+            and DNSEntry.__eq__(self, other)
+            and self.address == other.address
+            and self.scope_id == other.scope_id
         )
 
     def __hash__(self) -> int:
         """Hash to compare like DNSAddresses."""
-        return hash((*self._entry_tuple(), self.address))
+        return hash((*self._entry_tuple(), self.address, self.scope_id))
 
     def __repr__(self) -> str:
         """String representation"""


### PR DESCRIPTION
This replaces https://github.com/jstasiak/python-zeroconf/pull/315 which has been abandoned by the original author.
There are some outstanding problems with the original PR that I'll try to address:
* Is there a better way to provide this functionality than with a new separate API?
* Missing scope_id when IPv6 advertisement received over IPv4. https://github.com/jstasiak/python-zeroconf/pull/315#issuecomment-809827529
* Test coverage decrease.
* Travis CI failed on pypy3.

Closes #314