### PR TITLE
Remove Callable quoting

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1521,17 +1521,15 @@ class Signal:
         return SignalRegistrationInterface(self._handlers)
 
 
-# NOTE: Callable quoting needed on Python 3.5.2, see
-# https://github.com/jstasiak/python-zeroconf/issues/208 for details.
 class SignalRegistrationInterface:
-    def __init__(self, handlers: List['Callable[..., None]']) -> None:
+    def __init__(self, handlers: List[Callable[..., None]]) -> None:
         self._handlers = handlers
 
-    def register_handler(self, handler: 'Callable[..., None]') -> 'SignalRegistrationInterface':
+    def register_handler(self, handler: Callable[..., None]) -> 'SignalRegistrationInterface':
         self._handlers.append(handler)
         return self
 
-    def unregister_handler(self, handler: 'Callable[..., None]') -> 'SignalRegistrationInterface':
+    def unregister_handler(self, handler: Callable[..., None]) -> 'SignalRegistrationInterface':
         self._handlers.remove(handler)
         return self
 
@@ -1564,9 +1562,7 @@ class ServiceBrowser(RecordUpdateListener, threading.Thread):
         self,
         zc: 'Zeroconf',
         type_: Union[str, list],
-        # NOTE: Callable quoting needed on Python 3.5.2, see
-        # https://github.com/jstasiak/python-zeroconf/issues/208 for details.
-        handlers: Optional[Union[ServiceListener, List['Callable[..., None]']]] = None,
+        handlers: Optional[Union[ServiceListener, List[Callable[..., None]]]] = None,
         listener: Optional[ServiceListener] = None,
         addr: Optional[str] = None,
         port: int = _MDNS_PORT,
@@ -1600,9 +1596,7 @@ class ServiceBrowser(RecordUpdateListener, threading.Thread):
             listener = cast(ServiceListener, handlers)
             handlers = None
 
-        # NOTE: Callable quoting needed on Python 3.5.2, see
-        # https://github.com/jstasiak/python-zeroconf/issues/208 for details.
-        handlers = cast(List['Callable[..., None]'], handlers or [])
+        handlers = cast(List[Callable[..., None]], handlers or [])
 
         if listener:
 


### PR DESCRIPTION
- The current minimum supported cpython is 3.6+ which does not need
  the quoting