### PR TITLE
Complete ServiceInfo request as soon as all questions are answered

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -2008,6 +2008,8 @@ class ServiceInfo(RecordUpdateListener):
                     if self.server is not None:
                         out.add_question_or_one_cache(zc, now, self.server, _TYPE_A, _CLASS_IN)
                         out.add_question_or_all_cache(zc, now, self.server, _TYPE_AAAA, _CLASS_IN)
+                    if not out.questions:
+                        return True
                     zc.send(out)
                     next_ = now + delay
                     delay *= 2


### PR DESCRIPTION
- Closes a small race condition where there were no questions
  to ask because the cache was populated in between checks

Avoids `2021-05-27 16:58:15 DEBUG (zeroconf-Engine-240) [zeroconf] Received from '192.168.208.5':5353 (socket 18): <DNSIncoming:{id=13823, flags=288, n_q=0, n_ans=0, n_auth=0, n_add=0, questions=[], answers=[]}> (12 bytes) as [b'5\xff\x01 \x00\x00\x00\x00\x00\x00\x00\x00']`