### PR TITLE
Increase timeouts to fix flakey test on pypy windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,10 @@ mypy:
 	mypy examples/*.py zeroconf/*.py
 
 test:
-	pytest -v zeroconf/test.py zeroconf/test_asyncio.py
+	pytest -s -v zeroconf/test.py zeroconf/test_asyncio.py
 
 test_coverage:
-	pytest -v --cov=zeroconf --cov-branch --cov-report html --cov-report term-missing zeroconf/test.py zeroconf/test_asyncio.py
+	pytest -s -vv --cov=zeroconf --cov-branch --cov-report html --cov-report term-missing zeroconf/test.py zeroconf/test_asyncio.py
 
 autopep8:
 	autopep8 --max-line-length=$(MAX_LINE_LENGTH) -i setup.py examples zeroconf

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -2083,11 +2083,11 @@ class ZeroconfServiceTypes(ServiceListener):
         # wait for responses
         time.sleep(timeout)
 
+        browser.cancel()
+
         # close down anything we opened
         if zc is None:
             local_zc.close()
-        else:
-            browser.cancel()
 
         return tuple(sorted(listener.found_services))
 

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -461,6 +461,7 @@ class Names(unittest.TestCase):
         assert mocked_log_debug.call_count > call_counts[0]
 
         # close our zeroconf which will close the sockets
+        browser.cancel()
         zc.close()
 
         # pop the big chunk off the end of the data and send on a closed socket
@@ -1084,9 +1085,9 @@ class ServiceTypesQuery(unittest.TestCase):
         zeroconf_registrar.register_service(info)
 
         try:
-            service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=0.5)
+            service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=1)
             assert type_ in service_types
-            service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=0.5)
+            service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=1)
             assert type_ in service_types
 
         finally:
@@ -1116,9 +1117,9 @@ class ServiceTypesQuery(unittest.TestCase):
         zeroconf_registrar.register_service(info)
 
         try:
-            service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=0.5)
+            service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=1)
             assert type_ in service_types
-            service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=0.5)
+            service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=1)
             assert type_ in service_types
 
         finally:
@@ -1147,9 +1148,9 @@ class ServiceTypesQuery(unittest.TestCase):
         zeroconf_registrar.register_service(info)
 
         try:
-            service_types = ZeroconfServiceTypes.find(ip_version=r.IPVersion.V6Only, timeout=0.5)
+            service_types = ZeroconfServiceTypes.find(ip_version=r.IPVersion.V6Only, timeout=1)
             assert type_ in service_types
-            service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=0.5)
+            service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=1)
             assert type_ in service_types
 
         finally:
@@ -1178,9 +1179,9 @@ class ServiceTypesQuery(unittest.TestCase):
         zeroconf_registrar.register_service(info)
 
         try:
-            service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=0.5)
+            service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=1)
             assert discovery_type in service_types
-            service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=0.5)
+            service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=1)
             assert discovery_type in service_types
 
         finally:


### PR DESCRIPTION
- Ensure all service browsers are canceled in tests

- Ensure patch remains in effect during test for test_update_record