### PR TITLE
Ensure listeners do not miss initial packets if Engine starts too quickly

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1373,7 +1373,6 @@ class Engine(threading.Thread):
         self.condition = threading.Condition()
         self.socketpair = socket.socketpair()
         self._last_cache_cleanup = 0.0
-        self.start()
         self.name = "zeroconf-Engine-%s" % (getattr(self, 'native_id', self.ident),)
 
     def run(self) -> None:
@@ -2539,6 +2538,10 @@ class Zeroconf(QuietLogger):
         if self.multi_socket:
             for s in self._respond_sockets:
                 self.engine.add_reader(self.listener, s)
+        # Start the engine only after all
+        # the readers have been added to avoid
+        # missing any packets that are on the wire
+        self.engine.start()
 
     @property
     def done(self) -> bool:


### PR DESCRIPTION
BREAKING CHANGE

* When manually creating a zeroconf.Engine object, it is no longer started automatically. It must manually be started by calling .start() on the created object.

* The Engine thread is now started after all the listeners have been added to avoid a race condition where packets could be missed at startup.


