### PR TITLE
Ensure ZeroconfServiceTypes.find always cancels the ServiceBrowser

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -2083,11 +2083,11 @@ class ZeroconfServiceTypes(ServiceListener):
         # wait for responses
         time.sleep(timeout)
 
+        browser.cancel()
+
         # close down anything we opened
         if zc is None:
             local_zc.close()
-        else:
-            browser.cancel()
 
         return tuple(sorted(listener.found_services))
 


### PR DESCRIPTION
- There was a short window where the ServiceBrowser thread
  could be left running after Zeroconf is closed because
  the .join() was never waited for when a new Zeroconf
  object was created