### PR TITLE
Allow passing in a sync Zeroconf instance to AsyncZeroconf

### DIFF
--- a/zeroconf/asyncio.py
+++ b/zeroconf/asyncio.py
@@ -90,6 +90,7 @@ class AsyncZeroconf:
         unicast: bool = False,
         ip_version: Optional[IPVersion] = None,
         apple_p2p: bool = False,
+        zc: Optional['Zeroconf'] = None,
     ) -> None:
         """Creates an instance of the Zeroconf class, establishing
         multicast communications, listening and reaping threads.
@@ -106,7 +107,7 @@ class AsyncZeroconf:
             from it. Otherwise defaults to V4 only for backward compatibility.
         :param apple_p2p: use AWDL interface (only macOS)
         """
-        self.zeroconf = Zeroconf(
+        self.zeroconf = zc or Zeroconf(
             interfaces=interfaces,
             unicast=unicast,
             ip_version=ip_version,

--- a/zeroconf/test_asyncio.py
+++ b/zeroconf/test_asyncio.py
@@ -28,6 +28,15 @@ async def test_async_basic_usage() -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_with_sync_passed_in() -> None:
+    """Test we can create and close the instance when passing in a sync Zeroconf."""
+    zc = Zeroconf(interfaces=['127.0.0.1'])
+    aiozc = AsyncZeroconf(zc=zc)
+    assert aiozc.zeroconf is zc
+    await aiozc.async_close()
+
+
+@pytest.mark.asyncio
 async def test_async_service_registration() -> None:
     """Test registering services broadcasts the registration by default."""
     aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])


### PR DESCRIPTION
- Uses the same pattern as ZeroconfServiceTypes.find

closes #405