### PR TITLE
Remove unreachable code in ServiceInfo.get_name

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -1925,9 +1925,7 @@ class ServiceInfo(RecordUpdateListener):
 
     def get_name(self) -> str:
         """Name accessor"""
-        if self.type is not None and self.name.endswith("." + self.type):
-            return self.name[: len(self.name) - len(self.type) - 1]
-        return self.name
+        return self.name[: len(self.name) - len(self.type) - 1]
 
     def update_record(self, zc: 'Zeroconf', now: float, record: Optional[DNSRecord]) -> None:
         """Updates service information from a DNS record"""

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -1551,6 +1551,18 @@ class TestServiceBrowser(unittest.TestCase):
 
 
 class TestServiceInfo(unittest.TestCase):
+    def test_get_name(self):
+        """Verify the name accessor can strip the type."""
+        desc = {'path': '/~paulsm/'}
+        service_name = 'name._type._tcp.local.'
+        service_type = '_type._tcp.local.'
+        service_server = 'ash-1.local.'
+        service_address = socket.inet_aton("10.0.1.2")
+        info = ServiceInfo(
+            service_type, service_name, 22, 0, 0, desc, service_server, addresses=[service_address]
+        )
+        assert info.get_name() == "name"
+
     def test_service_info_rejects_non_matching_updates(self):
         """Verify records with the wrong name are rejected."""
 


### PR DESCRIPTION
- The name must always end with the type or the
  constructor will throw BadTypeInNameException