### PR TITLE
Convert unnecessary use of a comprehension to a list

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -2699,7 +2699,7 @@ class Zeroconf(QuietLogger):
 
     def remove_all_service_listeners(self) -> None:
         """Removes a listener from the set that is currently listening."""
-        for listener in [k for k in self.browsers]:
+        for listener in list(self.browsers):
             self.remove_service_listener(listener)
 
     def register_service(


### PR DESCRIPTION
`zeroconf/__init__.py:2702:0: R1721: Unnecessary use of a comprehension (unnecessary-comprehension)`