### PR TITLE
Remove unneeded-not in new_socket

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -2333,7 +2333,7 @@ def new_socket(
         try:
             s.setsockopt(socket.SOL_SOCKET, reuseport, 1)
         except OSError as err:
-            if not err.errno == errno.ENOPROTOOPT:
+            if err.errno != errno.ENOPROTOOPT:
                 raise
 
     if port == _MDNS_PORT:


### PR DESCRIPTION
`zeroconf/__init__.py:2336:15: C0113: Consider changing "not err.errno == errno.ENOPROTOOPT" to "err.errno != errno.ENOPROTOOPT" (unneeded-not)`