### PR TITLE
Add missing update_service method to ZeroconfServiceTypes

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -2157,13 +2157,18 @@ class ZeroconfServiceTypes(ServiceListener):
     """
 
     def __init__(self) -> None:
+        """Keep track of found services in a set."""
         self.found_services = set()  # type: Set[str]
 
     def add_service(self, zc: 'Zeroconf', type_: str, name: str) -> None:
+        """Service added."""
         self.found_services.add(name)
 
+    def update_service(self, zc: 'Zeroconf', type_: str, name: str) -> None:
+        """Service updated."""
+
     def remove_service(self, zc: 'Zeroconf', type_: str, name: str) -> None:
-        pass
+        """Service removed."""
 
     @classmethod
     def find(


### PR DESCRIPTION
Fixes `zeroconf/__init__.py:2154:0: W0223: Method 'update_service' is abstract in class 'ServiceListener' but is not overridden (abstract-method)`