### PR TITLE
Narrow exception catch in DNSAddress.__repr__ to only expected exceptions

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -597,7 +597,7 @@ class DNSAddress(DNSRecord):
                     socket.AF_INET6 if _is_v6_address(self.address) else socket.AF_INET, self.address
                 )
             )
-        except Exception:  # pylint: disable=broad-except  # TODO stop catching all Exceptions
+        except (ValueError, OSError):
             return self.to_string(str(self.address))
 
 


### PR DESCRIPTION
- If the bytes object packed_ip is not the correct length for the
  specified address family, ValueError will be raised.
  OSError is raised for errors from the call to inet_ntop()