### PR TITLE
Lint before testing in the CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ env:
 	cp requirements-dev.txt ./env/requirements.built
 
 .PHONY: ci
-ci: test_coverage lint
+ci: lint test_coverage
 
 .PHONY: lint
 lint: $(LINT_TARGETS)


### PR DESCRIPTION
- If there is a lint problem, we fail before we start running the
  tests to ensure the submitter gets feedback right away instead
  of waiting for the tests to run.