### PR TITLE
Make a base class for DNSIncoming and DNSOutgoing

### DIFF
--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -936,6 +936,7 @@ class TestRegistrar(unittest.TestCase):
 
         # query
         query = r.DNSOutgoing(r._FLAGS_QR_QUERY | r._FLAGS_AA)
+        assert query.is_query() is True
         query.add_question(r.DNSQuestion(info.type, r._TYPE_PTR, r._CLASS_IN))
         query.add_question(r.DNSQuestion(info.name, r._TYPE_SRV, r._CLASS_IN))
         query.add_question(r.DNSQuestion(info.name, r._TYPE_TXT, r._CLASS_IN))
@@ -1463,6 +1464,7 @@ class TestServiceBrowser(unittest.TestCase):
         def mock_incoming_msg(service_state_change: r.ServiceStateChange) -> r.DNSIncoming:
 
             generated = r.DNSOutgoing(r._FLAGS_QR_RESPONSE)
+            assert generated.is_response() is True
 
             if service_state_change == r.ServiceStateChange.Removed:
                 ttl = 0


### PR DESCRIPTION
- In order to fix the TC bit not being set, we will need
  to be able to check if a DNSOutgoing is a query or
  a response

Supports https://github.com/jstasiak/python-zeroconf/pull/494