### PR TITLE
Remove broad exception catch from RecordManager.remove_listener

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -2912,8 +2912,8 @@ class RecordManager:
         try:
             self.listeners.remove(listener)
             self.zc.notify_all()
-        except Exception as e:  # pylint: disable=broad-except  # TODO stop catching all Exceptions
-            log.exception('Unknown error, possibly benign: %r', e)
+        except ValueError as e:
+            log.exception('Failed to remove listener: %r', e)
 
 
 class Zeroconf(QuietLogger):

--- a/zeroconf/test.py
+++ b/zeroconf/test.py
@@ -2747,7 +2747,9 @@ def test_legacy_record_update_listener():
             nonlocal updates
             updates.append(record)
 
-    zc.add_listener(LegacyRecordUpdateListener(), None)
+    listener = LegacyRecordUpdateListener()
+
+    zc.add_listener(listener, None)
 
     # dummy service callback
     def on_service_state_change(zeroconf, service_type, state_change, name):
@@ -2777,5 +2779,9 @@ def test_legacy_record_update_listener():
 
     assert len(updates)
     assert len([isinstance(update, r.DNSPointer) and update.name == type_ for update in updates]) >= 1
+
+    zc.remove_listener(listener)
+    # Removing a second time should not throw
+    zc.remove_listener(listener)
 
     zc.close()


### PR DESCRIPTION
- The only expected exception is ValueError from calling
  the function with a listener that has already been removed
  or never added.

Closes #515