### PR TITLE
Update python compatibility as PyPy3 7.2 is required

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Python compatibility
 --------------------
 
 * CPython 3.6+
-* PyPy3 5.8+
+* PyPy3 7.2+
 
 Versioning
 ----------


### PR DESCRIPTION
- When the version requirement changed to cpython 3.6, PyPy
  was not bumped as well

closes #508