### PR TITLE
Remove DNSOutgoing.packet backwards compatibility

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -116,7 +116,7 @@ class Framework(unittest.TestCase):
                     ),
                     0,
                 )
-                return r.DNSIncoming(generated.packet())
+                return r.DNSIncoming(generated.packets()[0])
 
             if service_state_change == r.ServiceStateChange.Removed:
                 ttl = 0
@@ -154,7 +154,7 @@ class Framework(unittest.TestCase):
                 0,
             )
 
-            return r.DNSIncoming(generated.packet())
+            return r.DNSIncoming(generated.packets()[0])
 
         def mock_split_incoming_msg(service_state_change: r.ServiceStateChange) -> r.DNSIncoming:
             """Mock an incoming message for the case where the packet is split."""
@@ -183,7 +183,7 @@ class Framework(unittest.TestCase):
                 ),
                 0,
             )
-            return r.DNSIncoming(generated.packet())
+            return r.DNSIncoming(generated.packets()[0])
 
         service_name = 'name._type._tcp.local.'
         service_type = '_type._tcp.local.'

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -43,28 +43,28 @@ class Names(unittest.TestCase):
             "this.is.a.very.long.name.with.lots.of.parts.in.it.local.", const._TYPE_SRV, const._CLASS_IN
         )
         generated.add_question(question)
-        r.DNSIncoming(generated.packet())
+        r.DNSIncoming(generated.packets()[0])
 
     def test_exceedingly_long_name(self):
         generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
         name = "%slocal." % ("part." * 1000)
         question = r.DNSQuestion(name, const._TYPE_SRV, const._CLASS_IN)
         generated.add_question(question)
-        r.DNSIncoming(generated.packet())
+        r.DNSIncoming(generated.packets()[0])
 
     def test_extra_exceedingly_long_name(self):
         generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
         name = "%slocal." % ("part." * 4000)
         question = r.DNSQuestion(name, const._TYPE_SRV, const._CLASS_IN)
         generated.add_question(question)
-        r.DNSIncoming(generated.packet())
+        r.DNSIncoming(generated.packets()[0])
 
     def test_exceedingly_long_name_part(self):
         name = "%s.local." % ("a" * 1000)
         generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
         question = r.DNSQuestion(name, const._TYPE_SRV, const._CLASS_IN)
         generated.add_question(question)
-        self.assertRaises(r.NamePartTooLongException, generated.packet)
+        self.assertRaises(r.NamePartTooLongException, generated.packets)
 
     def test_same_name(self):
         name = "paired.local."
@@ -72,7 +72,7 @@ class Names(unittest.TestCase):
         question = r.DNSQuestion(name, const._TYPE_SRV, const._CLASS_IN)
         generated.add_question(question)
         generated.add_question(question)
-        r.DNSIncoming(generated.packet())
+        r.DNSIncoming(generated.packets()[0])
 
     def test_lots_of_names(self):
 
@@ -156,7 +156,7 @@ class Names(unittest.TestCase):
         assert mocked_log_warn.call_count == call_counts[0]
 
         # force a receive of a packet
-        packet = out.packet()
+        packet = out.packets()[0]
         s = zc._respond_sockets[0]
 
         # mock the zeroconf logger and check for the correct logging backoff
@@ -317,7 +317,7 @@ class TestRegistrar(unittest.TestCase):
         query.add_question(r.DNSQuestion(info.name, const._TYPE_SRV, const._CLASS_IN))
         query.add_question(r.DNSQuestion(info.name, const._TYPE_TXT, const._CLASS_IN))
         query.add_question(r.DNSQuestion(info.server, const._TYPE_A, const._CLASS_IN))
-        _process_outgoing_packet(zc.query_handler.response(r.DNSIncoming(query.packet()), False))
+        _process_outgoing_packet(zc.query_handler.response(r.DNSIncoming(query.packets()[0]), False))
         assert nbr_answers == 4 and nbr_additionals == 4 and nbr_authorities == 0
         nbr_answers = nbr_additionals = nbr_authorities = 0
 
@@ -348,7 +348,7 @@ class TestRegistrar(unittest.TestCase):
         query.add_question(r.DNSQuestion(info.name, const._TYPE_SRV, const._CLASS_IN))
         query.add_question(r.DNSQuestion(info.name, const._TYPE_TXT, const._CLASS_IN))
         query.add_question(r.DNSQuestion(info.server, const._TYPE_A, const._CLASS_IN))
-        _process_outgoing_packet(zc.query_handler.response(r.DNSIncoming(query.packet()), False))
+        _process_outgoing_packet(zc.query_handler.response(r.DNSIncoming(query.packets()[0]), False))
         assert nbr_answers == 4 and nbr_additionals == 4 and nbr_authorities == 0
         nbr_answers = nbr_additionals = nbr_authorities = 0
 
@@ -860,7 +860,7 @@ class TestServiceBrowser(unittest.TestCase):
                 r.DNSPointer(service_type, const._TYPE_PTR, const._CLASS_IN, ttl, service_name), 0
             )
 
-            return r.DNSIncoming(generated.packet())
+            return r.DNSIncoming(generated.packets()[0])
 
         zeroconf = r.Zeroconf(interfaces=['127.0.0.1'])
         service_browser = r.ServiceBrowser(zeroconf, service_type, listener=MyServiceListener())
@@ -1021,7 +1021,7 @@ def test_ptr_optimization():
     # query
     query = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
     query.add_question(r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN))
-    out = zc.query_handler.response(r.DNSIncoming(query.packet()), False)
+    out = zc.query_handler.response(r.DNSIncoming(query.packets()[0]), False)
     assert out is not None
     nbr_answers += len(out.answers)
     nbr_authorities += len(out.authorities)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -229,7 +229,7 @@ class TestServiceInfo(unittest.TestCase):
             for record in records:
                 generated.add_answer_at_time(record, 0)
 
-            return r.DNSIncoming(generated.packet())
+            return r.DNSIncoming(generated.packets()[0])
 
         def get_service_info_helper(zc, type, name):
             nonlocal service_info
@@ -366,7 +366,7 @@ class TestServiceInfo(unittest.TestCase):
             for record in records:
                 generated.add_answer_at_time(record, 0)
 
-            return r.DNSIncoming(generated.packet())
+            return r.DNSIncoming(generated.packets()[0])
 
         def get_service_info_helper(zc, type, name):
             nonlocal service_info
@@ -466,7 +466,7 @@ class TestServiceBrowserMultipleTypes(unittest.TestCase):
             generated.add_answer_at_time(
                 r.DNSPointer(service_type, const._TYPE_PTR, const._CLASS_IN, ttl, service_name), 0
             )
-            return r.DNSIncoming(generated.packet())
+            return r.DNSIncoming(generated.packets()[0])
 
         zeroconf = r.Zeroconf(interfaces=['127.0.0.1'])
         service_browser = r.ServiceBrowser(zeroconf, service_types, listener=MyServiceListener())
@@ -638,7 +638,7 @@ def test_integration():
 
     def send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT):
         """Sends an outgoing packet."""
-        pout = r.DNSIncoming(out.packet())
+        pout = r.DNSIncoming(out.packets()[0])
         nonlocal nbr_answers
         for answer in pout.answers:
             nbr_answers += 1

--- a/zeroconf/dns.py
+++ b/zeroconf/dns.py
@@ -799,21 +799,6 @@ class DNSOutgoing(DNSMessage):
             del self.names[name]
         return False
 
-    def packet(self) -> bytes:
-        """Returns a bytestring containing the first packet's bytes.
-
-        Generally, you want to use packets() in case the response
-        does not fit in a single packet, but this exists for
-        backward compatibility."""
-        packets = self.packets()
-        if len(packets) == 0:
-            return b''
-        if len(packets[0]) > _MAX_MSG_ABSOLUTE:
-            QuietLogger.log_warning_once(
-                "Created over-sized packet (%d bytes) %r", len(packets[0]), packets[0]
-            )
-        return packets[0]
-
     def _write_questions_from_offset(self, questions_offset: int) -> int:
         questions_written = 0
         for question in self.questions[questions_offset:]:


### PR DESCRIPTION
- DNSOutgoing.packet only returned a partial message when the
  DNSOutgoing contents exceeded _MAX_MSG_ABSOLUTE or _MAX_MSG_TYPICAL
  This was a legacy function that was replaced with .packets()
  which always returns a complete payload in #248  As packet()
  should not be used since it will end up missing data, it has
  been removed

closes #542