### PR TITLE
Mark zeroconf.exceptions as protected by renaming to zeroconf._exceptions

### DIFF
--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -14,7 +14,7 @@ import pytest
 from zeroconf.aio import AsyncServiceInfo, AsyncServiceListener, AsyncZeroconf
 from zeroconf import Zeroconf
 from zeroconf.const import _LISTENER_TIME
-from zeroconf.exceptions import BadTypeInNameException, NonUniqueNameException, ServiceNameAlreadyRegistered
+from zeroconf._exceptions import BadTypeInNameException, NonUniqueNameException, ServiceNameAlreadyRegistered
 from zeroconf.services import ServiceInfo, ServiceListener
 from zeroconf.utils.time import current_time_millis
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 
-""" Unit tests for zeroconf.exceptions """
+""" Unit tests for zeroconf._exceptions """
 
 import logging
 import unittest

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -37,7 +37,7 @@ from ._dns import (  # noqa # import needed for backwards compat
     DNSText,
 )
 from ._logger import QuietLogger, log  # noqa # import needed for backwards compat
-from .exceptions import (  # noqa # import needed for backwards compat
+from ._exceptions import (  # noqa # import needed for backwards compat
     AbstractMethodException,
     BadTypeInNameException,
     Error,

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -29,6 +29,7 @@ from types import TracebackType  # noqa # used in type hints
 from typing import Dict, List, Optional, Type, Union, cast
 
 from ._dns import DNSIncoming, DNSOutgoing, DNSQuestion
+from ._exceptions import NonUniqueNameException
 from ._handlers import QueryHandler, RecordManager
 from ._logger import QuietLogger, log
 from .cache import DNSCache
@@ -48,7 +49,6 @@ from .const import (
     _TYPE_PTR,
     _UNREGISTER_TIME,
 )
-from .exceptions import NonUniqueNameException
 from .services import (
     RecordUpdateListener,
     ServiceBrowser,

--- a/zeroconf/_dns.py
+++ b/zeroconf/_dns.py
@@ -25,6 +25,7 @@ import socket
 import struct
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, Tuple, Union, cast
 
+from ._exceptions import AbstractMethodException, IncomingDecodeError, NamePartTooLongException
 from ._logger import QuietLogger, log
 from .const import (
     _CLASSES,
@@ -48,7 +49,6 @@ from .const import (
     _TYPE_SRV,
     _TYPE_TXT,
 )
-from .exceptions import AbstractMethodException, IncomingDecodeError, NamePartTooLongException
 from .utils.net import _is_v6_address
 from .utils.struct import int2byte
 from .utils.time import current_time_millis, millis_to_seconds

--- a/zeroconf/_exceptions.py
+++ b/zeroconf/_exceptions.py
@@ -20,8 +20,6 @@
     USA
 """
 
-# Exceptions
-
 
 class Error(Exception):
     pass

--- a/zeroconf/aio.py
+++ b/zeroconf/aio.py
@@ -28,8 +28,8 @@ from typing import Awaitable, Callable, Dict, List, Optional, Type, Union
 
 from ._core import NotifyListener, Zeroconf
 from ._dns import DNSOutgoing
+from ._exceptions import NonUniqueNameException
 from .const import _BROWSER_TIME, _CHECK_TIME, _LISTENER_TIME, _MDNS_PORT, _REGISTER_TIME, _UNREGISTER_TIME
-from .exceptions import NonUniqueNameException
 from .services import ServiceInfo, _ServiceBrowserBase, instance_name_from_service_info
 from .utils.aio import wait_condition_or_timeout
 from .utils.net import IPVersion, InterfaceChoice, InterfacesType

--- a/zeroconf/services/__init__.py
+++ b/zeroconf/services/__init__.py
@@ -28,6 +28,7 @@ from collections import OrderedDict
 from typing import Any, Callable, Dict, List, Optional, Set, TYPE_CHECKING, Tuple, Union, cast
 
 from .._dns import DNSAddress, DNSOutgoing, DNSPointer, DNSQuestion, DNSRecord, DNSService, DNSText
+from .._exceptions import BadTypeInNameException
 from ..const import (
     _BROWSER_BACKOFF_LIMIT,
     _BROWSER_TIME,
@@ -47,7 +48,6 @@ from ..const import (
     _TYPE_SRV,
     _TYPE_TXT,
 )
-from ..exceptions import BadTypeInNameException
 from ..utils.name import service_type_name
 from ..utils.net import (
     IPVersion,

--- a/zeroconf/services/registry.py
+++ b/zeroconf/services/registry.py
@@ -24,7 +24,7 @@ import threading
 from typing import Dict, List, Optional
 
 
-from ..exceptions import ServiceNameAlreadyRegistered
+from .._exceptions import ServiceNameAlreadyRegistered
 from ..services import ServiceInfo
 
 

--- a/zeroconf/utils/name.py
+++ b/zeroconf/utils/name.py
@@ -20,6 +20,7 @@
     USA
 """
 
+from .._exceptions import BadTypeInNameException
 from ..const import (
     _HAS_ASCII_CONTROL_CHARS,
     _HAS_A_TO_Z,
@@ -29,7 +30,6 @@ from ..const import (
     _NONTCP_PROTOCOL_LOCAL_TRAILER,
     _TCP_PROTOCOL_LOCAL_TRAILER,
 )
-from ..exceptions import BadTypeInNameException
 
 
 def service_type_name(type_: str, *, strict: bool = True) -> str:  # pylint: disable=too-many-branches


### PR DESCRIPTION
- The public API should only access zeroconf and zeroconf.aio
  as internals may be relocated between releases