### PR TITLE
Set mypy follow_imports to skip as ignore is not a valid option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ ignore=E203,W503
 
 [mypy]
 ignore_missing_imports = true
-follow_imports = ignore
+follow_imports = skip
 check_untyped_defs = true
 no_implicit_optional = true
 warn_incomplete_stub = true


### PR DESCRIPTION
Fixes #589