### PR TITLE
Add ZeroconfServiceTypes to zeroconf.__all__

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -57,7 +57,7 @@ from ._services import (  # noqa # import needed for backwards compat
     ServiceStateChange,
 )
 from ._services.registry import ServiceRegistry  # noqa # import needed for backwards compat
-from ._services.types import ZeroconfServiceTypes  # noqa # import needed for backwards compat
+from ._services.types import ZeroconfServiceTypes
 from ._utils.name import service_type_name  # noqa # import needed for backwards compat
 from ._utils.net import (  # noqa # import needed for backwards compat
     add_multicast_member,
@@ -89,6 +89,7 @@ __all__ = [
     "InterfaceChoice",
     "ServiceStateChange",
     "IPVersion",
+    "ZeroconfServiceTypes",
 ]
 
 if sys.version_info <= (3, 6):


### PR DESCRIPTION
- This class is in the readme, but is not exported by
  default

fixes #600