### PR TITLE
Add the ability for ServiceInfo.dns_addresses to filter by address type

### DIFF
--- a/zeroconf/_services/__init__.py
+++ b/zeroconf/_services/__init__.py
@@ -655,7 +655,9 @@ class ServiceInfo(RecordUpdateListener):
             if record.key == self.key:
                 self._set_text(record.text)
 
-    def dns_addresses(self, override_ttl: Optional[int] = None) -> List[DNSAddress]:
+    def dns_addresses(
+        self, override_ttl: Optional[int] = None, version: IPVersion = IPVersion.All
+    ) -> List[DNSAddress]:
         """Return matching DNSAddress from ServiceInfo."""
         return [
             DNSAddress(
@@ -665,7 +667,7 @@ class ServiceInfo(RecordUpdateListener):
                 override_ttl if override_ttl is not None else self.host_ttl,
                 address,
             )
-            for address in self._addresses
+            for address in self.addresses_by_version(version)
         ]
 
     def dns_pointer(self, override_ttl: Optional[int] = None) -> DNSPointer:


### PR DESCRIPTION
Needed to fix (partial) https://github.com/jstasiak/python-zeroconf/issues/595