### PR TITLE
Fix random test failures due to monkey patching not being undone between tests

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -81,7 +81,7 @@ class Names(unittest.TestCase):
         # verify that name changing works
         self.verify_name_change(zc, type_, name, server_count)
 
-        # we are going to monkey patch the zeroconf send to check packet sizes
+        # we are going to patch the zeroconf send to check packet sizes
         old_send = zc.send
 
         longest_packet_len = 0
@@ -96,71 +96,74 @@ class Names(unittest.TestCase):
                     longest_packet = out
                 old_send(out, addr=addr, port=port)
 
-        # monkey patch the zeroconf send
-        setattr(zc, "send", send)
+        # patch the zeroconf send
+        with unittest.mock.patch.object(zc, "send", send):
 
-        # dummy service callback
-        def on_service_state_change(zeroconf, service_type, state_change, name):
-            pass
+            # dummy service callback
+            def on_service_state_change(zeroconf, service_type, state_change, name):
+                pass
 
-        # start a browser
-        browser = ServiceBrowser(zc, type_, [on_service_state_change])
+            # start a browser
+            browser = ServiceBrowser(zc, type_, [on_service_state_change])
 
-        # wait until the browse request packet has maxed out in size
-        sleep_count = 0
-        # we will never get to this large of a packet given the application-layer
-        # splitting of packets, but we still want to track the longest_packet_len
-        # for the debug message below
-        while sleep_count < 100 and longest_packet_len < const._MAX_MSG_ABSOLUTE - 100:
-            sleep_count += 1
-            time.sleep(0.1)
+            # wait until the browse request packet has maxed out in size
+            sleep_count = 0
+            # we will never get to this large of a packet given the application-layer
+            # splitting of packets, but we still want to track the longest_packet_len
+            # for the debug message below
+            while sleep_count < 100 and longest_packet_len < const._MAX_MSG_ABSOLUTE - 100:
+                sleep_count += 1
+                time.sleep(0.1)
 
-        browser.cancel()
-        time.sleep(0.5)
+            browser.cancel()
+            time.sleep(0.5)
 
-        import zeroconf
+            import zeroconf
 
-        zeroconf.log.debug('sleep_count %d, sized %d', sleep_count, longest_packet_len)
+            zeroconf.log.debug('sleep_count %d, sized %d', sleep_count, longest_packet_len)
 
-        # now the browser has sent at least one request, verify the size
-        assert longest_packet_len <= const._MAX_MSG_TYPICAL
-        assert longest_packet_len >= const._MAX_MSG_TYPICAL - 100
+            # now the browser has sent at least one request, verify the size
+            assert longest_packet_len <= const._MAX_MSG_TYPICAL
+            assert longest_packet_len >= const._MAX_MSG_TYPICAL - 100
 
-        # mock zeroconf's logger warning() and debug()
-        from unittest.mock import patch
+            # mock zeroconf's logger warning() and debug()
+            from unittest.mock import patch
 
-        patch_warn = patch('zeroconf._logger.log.warning')
-        patch_debug = patch('zeroconf._logger.log.debug')
-        mocked_log_warn = patch_warn.start()
-        mocked_log_debug = patch_debug.start()
+            patch_warn = patch('zeroconf._logger.log.warning')
+            patch_debug = patch('zeroconf._logger.log.debug')
+            mocked_log_warn = patch_warn.start()
+            mocked_log_debug = patch_debug.start()
 
-        # now that we have a long packet in our possession, let's verify the
-        # exception handling.
-        out = longest_packet
-        assert out is not None
-        out.data.append(b'\0' * 1000)
+            # now that we have a long packet in our possession, let's verify the
+            # exception handling.
+            out = longest_packet
+            assert out is not None
+            out.data.append(b'\0' * 1000)
 
-        # mock the zeroconf logger and check for the correct logging backoff
-        call_counts = mocked_log_warn.call_count, mocked_log_debug.call_count
-        # try to send an oversized packet
-        zc.send(out)
-        assert mocked_log_warn.call_count == call_counts[0]
-        zc.send(out)
-        assert mocked_log_warn.call_count == call_counts[0]
+            # mock the zeroconf logger and check for the correct logging backoff
+            call_counts = mocked_log_warn.call_count, mocked_log_debug.call_count
+            # try to send an oversized packet
+            zc.send(out)
+            assert mocked_log_warn.call_count == call_counts[0]
+            zc.send(out)
+            assert mocked_log_warn.call_count == call_counts[0]
 
-        # mock the zeroconf logger and check for the correct logging backoff
-        call_counts = mocked_log_warn.call_count, mocked_log_debug.call_count
-        # force receive on oversized packet
-        zc.send(out, const._MDNS_ADDR, const._MDNS_PORT)
-        zc.send(out, const._MDNS_ADDR, const._MDNS_PORT)
-        time.sleep(2.0)
-        zeroconf.log.debug(
-            'warn %d debug %d was %s', mocked_log_warn.call_count, mocked_log_debug.call_count, call_counts
-        )
-        assert mocked_log_debug.call_count > call_counts[0]
+            # mock the zeroconf logger and check for the correct logging backoff
+            call_counts = mocked_log_warn.call_count, mocked_log_debug.call_count
+            # force receive on oversized packet
+            zc.send(out, const._MDNS_ADDR, const._MDNS_PORT)
+            zc.send(out, const._MDNS_ADDR, const._MDNS_PORT)
+            time.sleep(2.0)
+            zeroconf.log.debug(
+                'warn %d debug %d was %s',
+                mocked_log_warn.call_count,
+                mocked_log_debug.call_count,
+                call_counts,
+            )
+            assert mocked_log_debug.call_count > call_counts[0]
 
-        # close our zeroconf which will close the sockets
-        zc.close()
+            # close our zeroconf which will close the sockets
+            zc.close()
 
     def verify_name_change(self, zc, type_, name, number_hosts):
         desc = {'path': '/~paulsm/'}


### PR DESCRIPTION
- Switch patching to use unitest.mock.patch to ensure the patch
  is reverted when the test is completed

Fixes #505