### PR TITLE
Clear cache in ZeroconfServiceTypes tests to ensure responses can be mcast before the timeout

### DIFF
--- a/tests/services/test_types.py
+++ b/tests/services/test_types.py
@@ -35,7 +35,7 @@ class ServiceTypesQuery(unittest.TestCase):
             addresses=[socket.inet_aton("10.0.1.2")],
         )
         zeroconf_registrar.register_service(info)
-
+        _clear_cache(zeroconf_registrar)
         try:
             service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=0.5)
             assert type_ in service_types
@@ -68,7 +68,7 @@ class ServiceTypesQuery(unittest.TestCase):
             addresses=[socket.inet_pton(socket.AF_INET6, addr)],
         )
         zeroconf_registrar.register_service(info)
-
+        _clear_cache(zeroconf_registrar)
         try:
             service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=0.5)
             assert type_ in service_types
@@ -100,7 +100,7 @@ class ServiceTypesQuery(unittest.TestCase):
             addresses=[socket.inet_aton("10.0.1.2")],
         )
         zeroconf_registrar.register_service(info)
-
+        _clear_cache(zeroconf_registrar)
         try:
             service_types = ZeroconfServiceTypes.find(ip_version=r.IPVersion.V6Only, timeout=0.5)
             assert type_ in service_types
@@ -132,7 +132,7 @@ class ServiceTypesQuery(unittest.TestCase):
             addresses=[socket.inet_aton("10.0.1.2")],
         )
         zeroconf_registrar.register_service(info)
-
+        _clear_cache(zeroconf_registrar)
         try:
             service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=0.5)
             assert discovery_type in service_types


### PR DESCRIPTION
- We prevent the same record from being multicast within 1s
  because of RFC6762 sec 14. Since these test timeout after
  0.5s, the answers they are looking for many be suppressed.
  Since a legitimate querier will retry again later, we need
  to clear the cache to simulate that the record has not
  been multicast recently