### PR TITLE
Ensure cache is cleared before starting known answer enumeration query test

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -593,6 +593,7 @@ def test_known_answer_supression_service_type_enumeration_query():
     )
     zc.register_service(info)
     now = current_time_millis()
+    _clear_cache(zc)
 
     # Test PTR supression
     generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)


### PR DESCRIPTION
- We prevent the same record from being multicast within 1s
  because of RFC6762 sec 14.