### PR TITLE
Ensure services are removed from the registry when calling unregister_all_services

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -184,8 +184,21 @@ class Names(unittest.TestCase):
         # verify no name conflict https://tools.ietf.org/html/rfc6762#section-6.6
         zc.register_service(info_service, cooperating_responders=True)
 
-        zc.register_service(info_service, allow_name_change=True)
-        assert info_service.name.split('.')[0] == '%s-%d' % (name, number_hosts + 1)
+        # Create a new object since allow_name_change will mutate the
+        # original object and then we will have the wrong service
+        # in the registry
+        info_service2 = ServiceInfo(
+            type_,
+            '%s.%s' % (name, type_),
+            80,
+            0,
+            0,
+            desc,
+            "ash-2.local.",
+            addresses=[socket.inet_aton("10.0.1.2")],
+        )
+        zc.register_service(info_service2, allow_name_change=True)
+        assert info_service2.name.split('.')[0] == '%s-%d' % (name, number_hosts + 1)
 
     def generate_many_hosts(self, zc, type_, name, number_hosts):
         records_per_server = 2

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -476,10 +476,22 @@ class Zeroconf(QuietLogger):
         self.registry.remove(info)
         self._broadcast_service(info, _UNREGISTER_TIME, 0)
 
-    def unregister_all_services(self) -> None:
-        """Unregister all registered services."""
+    def generate_unregister_all_services(self) -> Optional[DNSOutgoing]:
+        """Generate a DNSOutgoing goodbye for all services and remove them from the registry."""
         service_infos = self.registry.get_service_infos()
         if not service_infos:
+            return None
+        out = DNSOutgoing(_FLAGS_QR_RESPONSE | _FLAGS_AA)
+        for info in service_infos:
+            self._add_broadcast_answer(out, info, 0)
+        self.registry.remove(service_infos)
+        return out
+
+    def unregister_all_services(self) -> None:
+        """Unregister all registered services."""
+        # Send Goodbye packets https://datatracker.ietf.org/doc/html/rfc6762#section-10.1
+        out = self.generate_unregister_all_services()
+        if not out:
             return
         now = current_time_millis()
         next_time = now
@@ -489,9 +501,6 @@ class Zeroconf(QuietLogger):
                 self.wait(next_time - now)
                 now = current_time_millis()
                 continue
-            out = DNSOutgoing(_FLAGS_QR_RESPONSE | _FLAGS_AA)
-            for info in service_infos:
-                self._add_broadcast_answer(out, info, 0)
             self.send(out)
             i += 1
             next_time += _UNREGISTER_TIME
@@ -604,8 +613,8 @@ class Zeroconf(QuietLogger):
         if self._GLOBAL_DONE:
             return
         # remove service listeners
-        self.remove_all_service_listeners()
         self.unregister_all_services()
+        self.remove_all_service_listeners()
         self._GLOBAL_DONE = True
         self.engine.close()
         # shutdown the rest

--- a/zeroconf/_services/__init__.py
+++ b/zeroconf/_services/__init__.py
@@ -466,7 +466,7 @@ class ServiceInfo(RecordUpdateListener):
         if not type_.endswith(service_type_name(name, strict=False)):
             raise BadTypeInNameException
         self.type = type_
-        self.name = name
+        self._name = name
         self.key = name.lower()
         if addresses is not None:
             self._addresses = addresses
@@ -493,6 +493,17 @@ class ServiceInfo(RecordUpdateListener):
         self._set_properties(properties)
         self.host_ttl = host_ttl
         self.other_ttl = other_ttl
+
+    @property
+    def name(self) -> str:
+        """The name of the service."""
+        return self._name
+
+    @name.setter
+    def name(self, name: str) -> None:
+        """Replace the the name and reset the key."""
+        self._name = name
+        self.key = name.lower()
 
     @property
     def addresses(self) -> List[bytes]:

--- a/zeroconf/_services/registry.py
+++ b/zeroconf/_services/registry.py
@@ -21,7 +21,7 @@
 """
 
 import threading
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 
 from .._exceptions import ServiceNameAlreadyRegistered
@@ -47,21 +47,21 @@ class ServiceRegistry:
 
     def add(self, info: ServiceInfo) -> None:
         """Add a new service to the registry."""
-
         with self._lock:
             self._add(info)
 
-    def remove(self, info: ServiceInfo) -> None:
+    def remove(self, info: Union[List[ServiceInfo], ServiceInfo]) -> None:
         """Remove a new service from the registry."""
+        infos = info if isinstance(info, list) else [info]
 
         with self._lock:
-            self._remove(info)
+            self._remove(infos)
 
     def update(self, info: ServiceInfo) -> None:
         """Update new service in the registry."""
 
         with self._lock:
-            self._remove(info)
+            self._remove([info])
             self._add(info)
 
     def get_service_infos(self) -> List[ServiceInfo]:
@@ -101,18 +101,17 @@ class ServiceRegistry:
 
     def _add(self, info: ServiceInfo) -> None:
         """Add a new service under the lock."""
-        lower_name = info.name.lower()
-        if lower_name in self._services:
+        if info.key in self._services:
             raise ServiceNameAlreadyRegistered
 
-        self._services[lower_name] = info
-        self.types.setdefault(info.type.lower(), []).append(lower_name)
-        self.servers.setdefault(info.server.lower(), []).append(lower_name)
+        self._services[info.key] = info
+        self.types.setdefault(info.type.lower(), []).append(info.key)
+        self.servers.setdefault(info.server_key, []).append(info.key)
 
-    def _remove(self, info: ServiceInfo) -> None:
-        """Remove a service under the lock."""
-        lower_name = info.name.lower()
-        old_service_info = self._services[lower_name]
-        self.types[old_service_info.type.lower()].remove(lower_name)
-        self.servers[old_service_info.server.lower()].remove(lower_name)
-        del self._services[lower_name]
+    def _remove(self, infos: List[ServiceInfo]) -> None:
+        """Remove a services under the lock."""
+        for info in infos:
+            old_service_info = self._services[info.key]
+            self.types[old_service_info.type.lower()].remove(info.key)
+            self.servers[old_service_info.server_key].remove(info.key)
+            del self._services[info.key]


### PR DESCRIPTION
- There was a race condition where a query could be answered for a service
  in the registry while goodbye packets which could result a fresh record
  being broadcast after the goodbye if a query came in at just the right
  time. To avoid this, we now remove the services from the registry right
  after we generate the goodbye packet