### PR TITLE
Ensure the ServiceInfo.key gets updated when the name is changed externally

### DIFF
--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1239,3 +1239,22 @@ def test_service_browser_is_aware_of_port_changes():
     browser.cancel()
 
     zc.close()
+
+
+def test_changing_name_updates_serviceinfo_key():
+    """Verify a name change will adjust the underlying key value."""
+    type_ = "_homeassistant._tcp.local."
+    name = "MyTestHome"
+    info_service = ServiceInfo(
+        type_,
+        '%s.%s' % (name, type_),
+        80,
+        0,
+        0,
+        {'path': '/~paulsm/'},
+        "ash-2.local.",
+        addresses=[socket.inet_aton("10.0.1.2")],
+    )
+    assert info_service.key == "mytesthome._homeassistant._tcp.local."
+    info_service.name = "YourTestHome._homeassistant._tcp.local."
+    assert info_service.key == "yourtesthome._homeassistant._tcp.local."

--- a/zeroconf/_services/__init__.py
+++ b/zeroconf/_services/__init__.py
@@ -466,7 +466,7 @@ class ServiceInfo(RecordUpdateListener):
         if not type_.endswith(service_type_name(name, strict=False)):
             raise BadTypeInNameException
         self.type = type_
-        self.name = name
+        self._name = name
         self.key = name.lower()
         if addresses is not None:
             self._addresses = addresses
@@ -493,6 +493,17 @@ class ServiceInfo(RecordUpdateListener):
         self._set_properties(properties)
         self.host_ttl = host_ttl
         self.other_ttl = other_ttl
+
+    @property
+    def name(self) -> str:
+        """The name of the service."""
+        return self._name
+
+    @name.setter
+    def name(self, name: str) -> None:
+        """Replace the the name and reset the key."""
+        self._name = name
+        self.key = name.lower()
 
     @property
     def addresses(self) -> List[bytes]:


### PR DESCRIPTION
When registering a service, allow_name change can mutate the ServiceInfo.name