### PR TITLE
Add test for launching with apple_p2p=True

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,6 +9,7 @@ import logging
 import os
 import pytest
 import socket
+import sys
 import time
 import unittest
 import unittest.mock
@@ -98,6 +99,16 @@ class Framework(unittest.TestCase):
         rv.close()
         rv = r.Zeroconf(interfaces=r.InterfaceChoice.Default, ip_version=r.IPVersion.V6Only)
         rv.close()
+
+    @unittest.skipIf(sys.platform != 'darwin', reason="apple_p2p only available on mac")
+    def test_launch_and_close_apple_p2p(self):
+        rv = r.Zeroconf(apple_p2p=True)
+        rv.close()
+
+    @unittest.skipIf(sys.platform == 'darwin', reason="apple_p2p available on mac")
+    def test_launch_and_close_apple_p2p(self):
+        with pytest.raises(RuntimeError):
+            r.Zeroconf(apple_p2p=True)
 
     def test_handle_response(self):
         def mock_incoming_msg(service_state_change: r.ServiceStateChange) -> r.DNSIncoming:

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -283,7 +283,7 @@ class Zeroconf(QuietLogger):
         # hook for threads
         self._GLOBAL_DONE = False
 
-        if apple_p2p and not sys.platform == 'darwin':
+        if apple_p2p and sys.platform != 'darwin':
             raise RuntimeError('Option `apple_p2p` is not supported on non-Apple platforms.')
 
         listen_socket, respond_sockets = create_sockets(interfaces, unicast, ip_version, apple_p2p=apple_p2p)

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -24,8 +24,8 @@ import asyncio
 import contextlib
 import errno
 import itertools
-import platform
 import socket
+import sys
 import threading
 from types import TracebackType  # noqa # used in type hints
 from typing import Dict, List, Optional, Tuple, Type, Union, cast
@@ -283,7 +283,7 @@ class Zeroconf(QuietLogger):
         # hook for threads
         self._GLOBAL_DONE = False
 
-        if apple_p2p and not platform.system() == 'Darwin':
+        if apple_p2p and not sys.platform == 'darwin':
             raise RuntimeError('Option `apple_p2p` is not supported on non-Apple platforms.')
 
         listen_socket, respond_sockets = create_sockets(interfaces, unicast, ip_version, apple_p2p=apple_p2p)


### PR DESCRIPTION
- Switch to using `sys.platform` to detect Mac instead of
  `platform.system()` since `platform.system()` is not intended
  to be machine parsable and is only for humans.

Closes #650
