### PR TITLE
Fix flakey ZeroconfServiceTypes types test

### DIFF
--- a/tests/services/test_types.py
+++ b/tests/services/test_types.py
@@ -8,6 +8,7 @@ import os
 import unittest
 import socket
 import sys
+import time
 
 import zeroconf as r
 from zeroconf import Zeroconf, ServiceInfo, ZeroconfServiceTypes
@@ -35,6 +36,8 @@ class ServiceTypesQuery(unittest.TestCase):
             addresses=[socket.inet_aton("10.0.1.2")],
         )
         zeroconf_registrar.register_service(info)
+        # Ensure we do not clear the cache until after the last broadcast is processed
+        time.sleep(0.2)
         _clear_cache(zeroconf_registrar)
         try:
             service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=0.5)
@@ -68,6 +71,8 @@ class ServiceTypesQuery(unittest.TestCase):
             addresses=[socket.inet_pton(socket.AF_INET6, addr)],
         )
         zeroconf_registrar.register_service(info)
+        # Ensure we do not clear the cache until after the last broadcast is processed
+        time.sleep(0.2)
         _clear_cache(zeroconf_registrar)
         try:
             service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=0.5)
@@ -100,6 +105,8 @@ class ServiceTypesQuery(unittest.TestCase):
             addresses=[socket.inet_aton("10.0.1.2")],
         )
         zeroconf_registrar.register_service(info)
+        # Ensure we do not clear the cache until after the last broadcast is processed
+        time.sleep(0.2)
         _clear_cache(zeroconf_registrar)
         try:
             service_types = ZeroconfServiceTypes.find(ip_version=r.IPVersion.V6Only, timeout=0.5)
@@ -132,6 +139,8 @@ class ServiceTypesQuery(unittest.TestCase):
             addresses=[socket.inet_aton("10.0.1.2")],
         )
         zeroconf_registrar.register_service(info)
+        # Ensure we do not clear the cache until after the last broadcast is processed
+        time.sleep(0.2)
         _clear_cache(zeroconf_registrar)
         try:
             service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=0.5)


### PR DESCRIPTION
- We need to wait to clear the cache until after the last
  service broadcast is processed as it may recreate the cache