### PR TITLE
Permit the ServiceBrowser to browse overlong types

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -60,7 +60,6 @@ class Exceptions(unittest.TestCase):
             '_x-._tcp.local.',
             '_22._udp.local.',
             '_2-2._tcp.local.',
-            '_1234567890-abcde._udp.local.',
             '\x00._x._udp.local.',
         )
         for name in bad_names_to_try:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1258,3 +1258,20 @@ def test_changing_name_updates_serviceinfo_key():
     assert info_service.key == "mytesthome._homeassistant._tcp.local."
     info_service.name = "YourTestHome._homeassistant._tcp.local."
     assert info_service.key == "yourtesthome._homeassistant._tcp.local."
+
+
+def test_servicebrowser_uses_non_strict_names():
+    """Verify we can look for technically invalid names as we cannot change what others do."""
+
+    # dummy service callback
+    def on_service_state_change(zeroconf, service_type, state_change, name):
+        pass
+
+    zc = r.Zeroconf(interfaces=['127.0.0.1'])
+    browser = ServiceBrowser(zc, ["_tivo-videostream._tcp.local."], [on_service_state_change])
+    browser.cancel()
+
+    # Still fail on completely invalid
+    with pytest.raises(r.BadTypeInNameException):
+        browser = ServiceBrowser(zc, ["tivo-videostream._tcp.local."], [on_service_state_change])
+    zc.close()

--- a/tests/utils/test_name.py
+++ b/tests/utils/test_name.py
@@ -10,8 +10,27 @@ from zeroconf._utils import name as nameutils
 from zeroconf import BadTypeInNameException
 
 
-def test_service_type_name():
-    """Test overlong service_type_name."""
+def test_service_type_name_overlong_type():
+    """Test overlong service_type_name type."""
     with pytest.raises(BadTypeInNameException):
         nameutils.service_type_name("Tivo1._tivo-videostream._tcp.local.")
     nameutils.service_type_name("Tivo1._tivo-videostream._tcp.local.", strict=False)
+
+
+def test_service_type_name_overlong_full_name():
+    """Test overlong service_type_name full name."""
+    with pytest.raises(BadTypeInNameException):
+        nameutils.service_type_name(
+            "Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1"
+            "Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1"
+            "Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1"
+            "._tivo-videostream._tcp.local."
+        )
+    with pytest.raises(BadTypeInNameException):
+        nameutils.service_type_name(
+            "Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1"
+            "Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1"
+            "Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1"
+            "._tivo-videostream._tcp.local.",
+            strict=False,
+        )

--- a/tests/utils/test_name.py
+++ b/tests/utils/test_name.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+"""Unit tests for zeroconf._utils.name."""
+
+import pytest
+
+from zeroconf._utils import name as nameutils
+from zeroconf import BadTypeInNameException
+
+
+def test_service_type_name():
+    """Test overlong service_type_name."""
+    with pytest.raises(BadTypeInNameException):
+        nameutils.service_type_name("Tivo1._tivo-videostream._tcp.local.")
+    nameutils.service_type_name("Tivo1._tivo-videostream._tcp.local.", strict=False)

--- a/tests/utils/test_name.py
+++ b/tests/utils/test_name.py
@@ -19,18 +19,8 @@ def test_service_type_name_overlong_type():
 
 def test_service_type_name_overlong_full_name():
     """Test overlong service_type_name full name."""
+    long_name = "Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1" * 100
     with pytest.raises(BadTypeInNameException):
-        nameutils.service_type_name(
-            "Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1"
-            "Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1"
-            "Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1"
-            "._tivo-videostream._tcp.local."
-        )
+        nameutils.service_type_name(f"{long_name}._tivo-videostream._tcp.local.")
     with pytest.raises(BadTypeInNameException):
-        nameutils.service_type_name(
-            "Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1"
-            "Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1"
-            "Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1Tivo1"
-            "._tivo-videostream._tcp.local.",
-            strict=False,
-        )
+        nameutils.service_type_name(f"{long_name}._tivo-videostream._tcp.local.", strict=False)

--- a/zeroconf/_utils/name.py
+++ b/zeroconf/_utils/name.py
@@ -104,7 +104,8 @@ def service_type_name(type_: str, *, strict: bool = True) -> str:  # pylint: dis
 
         test_service_name = service_name[1:]
 
-        if len(test_service_name) > 15:
+        if strict and len(test_service_name) > 15:
+            # https://datatracker.ietf.org/doc/html/rfc6763#section-7.2
             raise BadTypeInNameException("Service name (%s) must be <= 15 bytes" % test_service_name)
 
         if '--' in test_service_name:

--- a/zeroconf/_utils/name.py
+++ b/zeroconf/_utils/name.py
@@ -74,6 +74,9 @@ def service_type_name(type_: str, *, strict: bool = True) -> str:  # pylint: dis
     :param type_: Type, SubType or service name to validate
     :return: fully qualified service name (eg: _http._tcp.local.)
     """
+    if len(type_) > 256:
+        # https://datatracker.ietf.org/doc/html/rfc6763#section-7.2
+        raise BadTypeInNameException("Full name (%s) must be > 256 bytes" % type_)
 
     if type_.endswith((_TCP_PROTOCOL_LOCAL_TRAILER, _NONTCP_PROTOCOL_LOCAL_TRAILER)):
         remaining = type_[: -len(_TCP_PROTOCOL_LOCAL_TRAILER)].split('.')


### PR DESCRIPTION
- At least one type "tivo-videostream" exists in the wild
  so we are permissive about what we will look for, and
  strict about what we will announce.

Fixes #661