### PR TITLE
Reenable types test on win32

### DIFF
--- a/tests/services/test_types.py
+++ b/tests/services/test_types.py
@@ -53,7 +53,7 @@ class ServiceTypesQuery(unittest.TestCase):
     @unittest.skipIf(os.environ.get('SKIP_IPV6'), 'IPv6 tests disabled')
     def test_integration_with_listener_v6_records(self):
 
-        type_ = "_test-srvc-type._tcp.local."
+        type_ = "_test-srvc-v6rec._tcp.local."
         name = "xxxyyy"
         registration_name = "%s.%s" % (name, type_)
         addr = "2606:2800:220:1:248:1893:25c8:1946"  # example.com
@@ -84,11 +84,11 @@ class ServiceTypesQuery(unittest.TestCase):
         finally:
             zeroconf_registrar.close()
 
-    @unittest.skipIf(not has_working_ipv6() or sys.platform == 'win32', 'Requires IPv6')
+    @unittest.skipIf(not has_working_ipv6(), 'Requires IPv6')
     @unittest.skipIf(os.environ.get('SKIP_IPV6'), 'IPv6 tests disabled')
     def test_integration_with_listener_ipv6(self):
 
-        type_ = "_test-srvc-type._tcp.local."
+        type_ = "_test-srvc-v6._tcp.local."
         name = "xxxyyy"
         registration_name = "%s.%s" % (name, type_)
 

--- a/tests/services/test_types.py
+++ b/tests/services/test_types.py
@@ -4,10 +4,10 @@
 
 """Unit tests for zeroconf._services.types."""
 
+import logging
 import os
 import unittest
 import socket
-import sys
 import time
 
 import zeroconf as r

--- a/tests/services/test_types.py
+++ b/tests/services/test_types.py
@@ -16,6 +16,21 @@ from zeroconf import Zeroconf, ServiceInfo, ZeroconfServiceTypes
 from .. import _clear_cache, has_working_ipv6
 
 
+log = logging.getLogger('zeroconf')
+original_logging_level = logging.NOTSET
+
+
+def setup_module():
+    global original_logging_level
+    original_logging_level = log.level
+    log.setLevel(logging.DEBUG)
+
+
+def teardown_module():
+    if original_logging_level != logging.NOTSET:
+        log.setLevel(original_logging_level)
+
+
 class ServiceTypesQuery(unittest.TestCase):
     def test_integration_with_listener(self):
 


### PR DESCRIPTION
- Now that there is a unique name, there is no risk of delayed
  packets from the previous test affecting the ipv6 test