### PR TITLE
Allow unregistering a service multiple times

### DIFF
--- a/tests/services/test_registry.py
+++ b/tests/services/test_registry.py
@@ -28,6 +28,29 @@ class TestServiceRegistry(unittest.TestCase):
         registry.remove(info)
         registry.add(info)
 
+    def test_unregister_multiple_times(self):
+        """Verify we can unregister a service multiple times.
+
+        In production unregister_service and unregister_all_services
+        may happen at the same time during shutdown. We want to treat
+        this as non-fatal since its expected to happen and it is unlikely
+        that the callers know about each other.
+        """
+        type_ = "_test-srvc-type._tcp.local."
+        name = "xxxyyy"
+        registration_name = "%s.%s" % (name, type_)
+
+        desc = {'path': '/~paulsm/'}
+        info = ServiceInfo(
+            type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[socket.inet_aton("10.0.1.2")]
+        )
+
+        registry = r.ServiceRegistry()
+        registry.add(info)
+        self.assertRaises(r.ServiceNameAlreadyRegistered, registry.add, info)
+        registry.remove(info)
+        registry.remove(info)
+
     def test_lookups(self):
         type_ = "_test-srvc-type._tcp.local."
         name = "xxxyyy"

--- a/zeroconf/_services/registry.py
+++ b/zeroconf/_services/registry.py
@@ -106,6 +106,8 @@ class ServiceRegistry:
     def _remove(self, infos: List[ServiceInfo]) -> None:
         """Remove a services under the lock."""
         for info in infos:
+            if info.key not in self._services:
+                continue
             old_service_info = self._services[info.key]
             self.types[old_service_info.type.lower()].remove(info.key)
             self.servers[old_service_info.server_key].remove(info.key)


### PR DESCRIPTION
- In production unregister_service and unregister_all_services
  may happen at the same time during shutdown. We want to treat
  this as non-fatal since its expected to happen and it is unlikely
  that the callers know about each other.

Fixes #675