### PR TITLE
Suppress additionals when answer is suppressed

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -230,7 +230,7 @@ def test_ptr_optimization():
     zc.register_service(info)
 
     # Verify we won't respond for 1s with the same multicast
-    query = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
+    query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     query.add_question(r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN))
     unicast_out, multicast_out = zc.query_handler.response(
         [r.DNSIncoming(packet) for packet in query.packets()], None, const._MDNS_PORT
@@ -242,7 +242,7 @@ def test_ptr_optimization():
     _clear_cache(zc)
 
     # Verify we will now respond
-    query = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
+    query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     query.add_question(r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN))
     unicast_out, multicast_out = zc.query_handler.response(
         [r.DNSIncoming(packet) for packet in query.packets()], None, const._MDNS_PORT
@@ -340,7 +340,7 @@ def test_unicast_response():
     _clear_cache(zc)
 
     # query
-    query = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
+    query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     query.add_question(r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN))
     unicast_out, multicast_out = zc.query_handler.response(
         [r.DNSIncoming(packet) for packet in query.packets()], "1.2.3.4", 1234
@@ -413,7 +413,7 @@ def test_qu_response():
         assert has_srv and has_txt and has_a
 
     # With QU should respond to only unicast when the answer has been recently multicast
-    query = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
+    query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN)
     question.unique = True  # Set the QU bit
     assert question.unicast is True
@@ -427,7 +427,7 @@ def test_qu_response():
 
     _clear_cache(zc)
     # With QU should respond to only multicast since the response hasn't been seen since 75% of the ttl
-    query = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
+    query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN)
     question.unique = True  # Set the QU bit
     assert question.unicast is True
@@ -439,7 +439,7 @@ def test_qu_response():
     _validate_complete_response(query, multicast_out)
 
     # With QU set and an authorative answer (probe) should respond to both unitcast and multicast since the response hasn't been seen since 75% of the ttl
-    query = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
+    query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN)
     question.unique = True  # Set the QU bit
     assert question.unicast is True
@@ -453,7 +453,7 @@ def test_qu_response():
 
     _inject_response(zc, r.DNSIncoming(multicast_out.packets()[0]))
     # With the cache repopulated; should respond to only unicast when the answer has been recently multicast
-    query = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
+    query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN)
     question.unique = True  # Set the QU bit
     assert question.unicast is True
@@ -700,4 +700,69 @@ def test_known_answer_supression_service_type_enumeration_query():
     # unregister
     zc.registry.remove(info)
     zc.registry.remove(info2)
+    zc.close()
+
+
+def test_qu_response_only_sends_additionals_if_sends_answer():
+    """Test that a QU response does not send additionals unless it sends the answer as well."""
+    # instantiate a zeroconf instance
+    zc = Zeroconf(interfaces=['127.0.0.1'])
+
+    # service definition
+    type_ = "_test-srvc-type._tcp.local."
+    name = "xxxyyy"
+    registration_name = "%s.%s" % (name, type_)
+    desc = {'path': '/~paulsm/'}
+    info = ServiceInfo(
+        type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[socket.inet_aton("10.0.1.2")]
+    )
+    # register
+    zc.registry.add(info)
+
+    ptr_record = info.dns_pointer()
+
+    # Add the PTR record to the cache
+    zc.cache.add(ptr_record)
+
+    # Add the A record to the cache with 50% ttl remaining
+    a_record = info.dns_addresses()[0]
+    a_record._set_created_ttl(current_time_millis() - (a_record.ttl * 1000 / 2), a_record.ttl)
+    zc.cache.add(a_record)
+
+    # With QU should respond to only unicast when the answer has been recently multicast
+    # even if the additional has not been recently multicast
+    query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
+    question = r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN)
+    question.unique = True  # Set the QU bit
+    assert question.unicast is True
+    query.add_question(question)
+
+    unicast_out, multicast_out = zc.query_handler.response(
+        [r.DNSIncoming(packet) for packet in query.packets()], "1.2.3.4", const._MDNS_PORT
+    )
+    assert multicast_out is None
+    assert a_record in unicast_out.additionals
+    assert unicast_out.answers[0][0] == ptr_record
+
+    # Remove the 50% A record and add a 100% A record
+    zc.cache.remove(a_record)
+    a_record = info.dns_addresses()[0]
+    zc.cache.add(a_record)
+    # With QU should respond to only unicast when the answer has been recently multicast
+    # even if the additional has not been recently multicast
+    query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
+    question = r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN)
+    question.unique = True  # Set the QU bit
+    assert question.unicast is True
+    query.add_question(question)
+
+    unicast_out, multicast_out = zc.query_handler.response(
+        [r.DNSIncoming(packet) for packet in query.packets()], "1.2.3.4", const._MDNS_PORT
+    )
+    assert multicast_out is None
+    assert a_record in unicast_out.additionals
+    assert unicast_out.answers[0][0] == ptr_record
+
+    # unregister
+    zc.registry.remove(info)
     zc.close()

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -806,10 +806,12 @@ def test_qu_response_only_sends_additionals_if_sends_answer():
     question.unique = True  # Set the QU bit
     assert question.unicast is True
     query.add_question(question)
+
     question = r.DNSQuestion(info2.type, const._TYPE_PTR, const._CLASS_IN)
     question.unique = True  # Set the QU bit
     assert question.unicast is True
     query.add_question(question)
+    zc.cache.add(info2.dns_pointer())  # Add 100% TTL for info2 to the cache
 
     unicast_out, multicast_out = zc.query_handler.response(
         [r.DNSIncoming(packet) for packet in query.packets()], "1.2.3.4", const._MDNS_PORT

--- a/zeroconf/_dns.py
+++ b/zeroconf/_dns.py
@@ -200,6 +200,7 @@ class DNSRecord(DNSEntry):
         self._set_created_ttl(other.created, other.ttl)
 
     def _set_created_ttl(self, created: float, ttl: Union[float, int]) -> None:
+        """Set the created and ttl of a record."""
         self.created = created
         self.ttl = ttl
         self._expiration_time = None

--- a/zeroconf/_dns.py
+++ b/zeroconf/_dns.py
@@ -23,7 +23,7 @@
 import enum
 import socket
 import struct
-from typing import Any, Dict, Iterable, List, Optional, TYPE_CHECKING, Tuple, Union, cast
+from typing import Any, Dict, Iterable, List, Optional, Set, TYPE_CHECKING, Tuple, Union, cast
 
 from ._exceptions import AbstractMethodException, IncomingDecodeError, NamePartTooLongException
 from ._logger import QuietLogger, log
@@ -197,8 +197,11 @@ class DNSRecord(DNSEntry):
     def reset_ttl(self, other: 'DNSRecord') -> None:
         """Sets this record's TTL and created time to that of
         another record."""
-        self.created = other.created
-        self.ttl = other.ttl
+        self._set_created_ttl(other.created, other.ttl)
+
+    def _set_created_ttl(self, created: float, ttl: Union[float, int]) -> None:
+        self.created = created
+        self.ttl = ttl
         self._expiration_time = None
         self._stale_time = None
         self._recent_time = None

--- a/zeroconf/_dns.py
+++ b/zeroconf/_dns.py
@@ -23,7 +23,7 @@
 import enum
 import socket
 import struct
-from typing import Any, Dict, Iterable, List, Optional, Set, TYPE_CHECKING, Tuple, Union, cast
+from typing import Any, Dict, Iterable, List, Optional, TYPE_CHECKING, Tuple, Union, cast
 
 from ._exceptions import AbstractMethodException, IncomingDecodeError, NamePartTooLongException
 from ._logger import QuietLogger, log

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -21,7 +21,7 @@
 """
 
 import itertools
-from typing import Dict, Iterable, List, Optional, Set, TYPE_CHECKING, Tuple, Union, cast
+from typing import Dict, List, Optional, Set, TYPE_CHECKING, Tuple, Union
 
 from ._cache import DNSCache
 from ._dns import DNSAddress, DNSIncoming, DNSOutgoing, DNSPointer, DNSQuestion, DNSRRSet, DNSRecord

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -68,15 +68,14 @@ class _QueryResponse:
         self._ucast_source = ucast_source
         self._now = current_time_millis()
         self._cache = cache
-        self._additionals = {}
-        self._all_answers: _AnswerWithAdditionalsType = {}
+        self._additionals: _AnswerWithAdditionalsType = {}
         self._ucast: Set[DNSRecord] = set()
         self._mcast: Set[DNSRecord] = set()
 
     def add_qu_question_response(self, answers: _AnswerWithAdditionalsType) -> None:
         """Generate a response to a multicast QU query."""
         for record, additionals in answers.items():
-            self._all_answers[record] = additionals
+            self._additionals[record] = additionals
             if self._is_probe:
                 self._ucast.add(record)
             if not self._has_mcast_within_one_quarter_ttl(record):
@@ -86,12 +85,12 @@ class _QueryResponse:
 
     def add_ucast_question_response(self, answers: _AnswerWithAdditionalsType) -> None:
         """Generate a response to a unicast query."""
-        self._all_answers.update(answers)
+        self._additionals.update(answers)
         self._ucast.update(answers.keys())
 
     def add_mcast_question_response(self, answers: _AnswerWithAdditionalsType) -> None:
         """Generate a response to a multicast query."""
-        self._all_answers.update(answers)
+        self._additionals.update(answers)
         self._mcast.update(answers.keys())
 
     def outgoing_unicast(self) -> Optional[DNSOutgoing]:
@@ -127,7 +126,7 @@ class _QueryResponse:
         return out
 
     def _additionals_from_answers_rrset(self, rrset: Set[DNSRecord]) -> Set[DNSRecord]:
-        return set().union(*[self._all_answers[record] for record in rrset])
+        return set().union(*[self._additionals[record] for record in rrset])
 
     def _suppress_known_answers(self, rrset: Set[DNSRecord]) -> None:
         """Remove any records suppressed by known answers."""

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -24,7 +24,7 @@ import itertools
 from typing import Dict, List, Optional, Set, TYPE_CHECKING, Tuple, Union
 
 from ._cache import DNSCache
-from ._dns import DNSAddress, DNSIncoming, DNSOutgoing, DNSPointer, DNSQuestion, DNSRecord, DNSRRSet
+from ._dns import DNSAddress, DNSIncoming, DNSOutgoing, DNSPointer, DNSQuestion, DNSRRSet, DNSRecord
 from ._logger import log
 from ._services import RecordUpdateListener
 from ._services.registry import ServiceRegistry

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -177,24 +177,24 @@ class QueryHandler:
         https://datatracker.ietf.org/doc/html/rfc6763#section-9
         """
         for stype in self.registry.get_types():
-            answer_set.setdefault(
-                DNSPointer(_SERVICE_TYPE_ENUMERATION_NAME, _TYPE_PTR, _CLASS_IN, _DNS_OTHER_TTL, stype), set()
-            )
+            answer_set[
+                DNSPointer(_SERVICE_TYPE_ENUMERATION_NAME, _TYPE_PTR, _CLASS_IN, _DNS_OTHER_TTL, stype)
+            ] = set()
 
     def _add_pointer_answers(self, name: str, answer_set: _AnswerWithAdditionalsType) -> None:
         """Answer PTR/ANY question."""
         for service in self.registry.get_infos_type(name):
             # Add recommended additional answers according to
             # https://tools.ietf.org/html/rfc6763#section-12.1.
-            answer_set.add_answer_with_additonals(
-                service.dns_pointer(), [service.dns_service(), service.dns_text(), *service.dns_addresses()]
+            answer_set[service.dns_pointer()] = set(
+                service.dns_service(), service.dns_text(), *service.dns_addresses()
             )
 
     def _add_address_answers(self, name: str, answer_set: _AnswerWithAdditionalsType, type_: int) -> None:
         """Answer A/AAAA/ANY question."""
         for service in self.registry.get_infos_server(name):
             for dns_address in service.dns_addresses(version=_TYPE_TO_IP_VERSION[type_]):
-                answer_set.setdefault(dns_address, set())
+                answer_set[dns_address] = set()
 
     def _answer_question(self, question: DNSQuestion, answer_set: _AnswerWithAdditionalsType) -> None:
         type_ = question.type
@@ -211,9 +211,9 @@ class QueryHandler:
                 if type_ in (_TYPE_SRV, _TYPE_ANY):
                     # Add recommended additional answers according to
                     # https://tools.ietf.org/html/rfc6763#section-12.2.
-                    answer_set.setdefault(service.dns_service(), set()).update(service.dns_addresses())
+                    answer_set[service.dns_service()] = set(service.dns_addresses())
                 if type_ in (_TYPE_TXT, _TYPE_ANY):
-                    answer_set.setdefault(service.dns_text(), set())
+                    answer_set[service.dns_text()] = set()
 
     def _answer_any_question(
         self,

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -20,12 +20,11 @@
     USA
 """
 
-import enum
 import itertools
 from typing import Dict, List, Optional, Set, TYPE_CHECKING, Tuple, Union
 
 from ._cache import DNSCache
-from ._dns import DNSAddress, DNSIncoming, DNSOutgoing, DNSPointer, DNSQuestion, DNSRRSet, DNSRecord
+from ._dns import DNSAddress, DNSIncoming, DNSOutgoing, DNSPointer, DNSQuestion, DNSRecord, DNSRRSet
 from ._logger import log
 from ._services import RecordUpdateListener
 from ._services.registry import ServiceRegistry
@@ -53,64 +52,52 @@ if TYPE_CHECKING:
     from ._core import Zeroconf  # pylint: disable=cyclic-import
 
 
-@enum.unique
-class RecordSetKeys(enum.Enum):
-    Answers = 1
-    Additionals = 2
-
-
-# Switch to a TypedDict once Python 3.8 is the minimum supported version
-_RecordSetType = Dict[RecordSetKeys, Set[DNSRecord]]
+_AnswerWithAdditionalsType = Dict[DNSRecord, Set[DNSRecord]]
 
 
 class _QueryResponse:
     """A pair for unicast and multicast DNSOutgoing responses."""
 
-    def __init__(self, cache: DNSCache, msg: DNSIncoming, ucast_source: bool) -> None:
+    def __init__(
+        self, cache: DNSCache, msg: DNSIncoming, ucast_source: bool, known_answers: DNSRRSet
+    ) -> None:
         """Build a query response."""
         self._msg = msg
-        self._ucast_source = ucast_source
         self._is_probe = msg.num_authorities > 0
+        self._known_answers = known_answers
+        self._ucast_source = ucast_source
         self._now = current_time_millis()
         self._cache = cache
-        self._ucast: _RecordSetType = {RecordSetKeys.Answers: set(), RecordSetKeys.Additionals: set()}
-        self._mcast: _RecordSetType = {RecordSetKeys.Answers: set(), RecordSetKeys.Additionals: set()}
+        self._additionals = {}
+        self._all_answers: _AnswerWithAdditionalsType = {}
+        self._ucast: Set[DNSRecord] = set()
+        self._mcast: Set[DNSRecord] = set()
 
-    def add_qu_question_response(
-        self,
-        answers: Set[DNSRecord],
-        additionals: Set[DNSRecord],
-    ) -> None:
+    def add_qu_question_response(self, answers: _AnswerWithAdditionalsType) -> None:
         """Generate a response to a multicast QU query."""
-        self._add_qu_question_response_to_target(answers, RecordSetKeys.Answers)
-        self._add_qu_question_response_to_target(additionals, RecordSetKeys.Additionals)
-
-    def _add_qu_question_response_to_target(self, target: Set[DNSRecord], answer_type: RecordSetKeys) -> None:
-        """Add part of the QU response."""
-        for record in target:
+        for record, additionals in answers.items():
+            self._all_answers[record] = additionals
             if self._is_probe:
-                self._ucast[answer_type].add(record)
+                self._ucast.add(record)
             if not self._has_mcast_within_one_quarter_ttl(record):
-                self._mcast[answer_type].add(record)
+                self._mcast.add(record)
             elif not self._is_probe:
-                self._ucast[answer_type].add(record)
+                self._ucast.add(record)
 
-    def add_ucast_question_response(self, answers: Set[DNSRecord], additionals: Set[DNSRecord]) -> None:
+    def add_ucast_question_response(self, answers: _AnswerWithAdditionalsType) -> None:
         """Generate a response to a unicast query."""
-        self._ucast[RecordSetKeys.Answers].update(answers)
-        self._ucast[RecordSetKeys.Additionals].update(additionals)
+        self._all_answers.update(answers)
+        self._ucast.update(answers.keys())
 
-    def add_mcast_question_response(self, answers: Set[DNSRecord], additionals: Set[DNSRecord]) -> None:
+    def add_mcast_question_response(self, answers: _AnswerWithAdditionalsType) -> None:
         """Generate a response to a multicast query."""
-        self._mcast[RecordSetKeys.Answers].update(answers)
-        self._mcast[RecordSetKeys.Additionals].update(additionals)
+        self._all_answers.update(answers)
+        self._mcast.update(answers.keys())
 
     def outgoing_unicast(self) -> Optional[DNSOutgoing]:
         """Build the outgoing unicast response."""
         ucastout = self._construct_outgoing_from_record_set(self._ucast, False)
-        # Adding the questions back when the source is
-        # unicast (not MDNS port) is legacy behavior
-        # Is this correct?
+        # Adding the questions back when the source is legacy unicast behavior
         if ucastout and self._ucast_source:
             for question in self._msg.questions:
                 ucastout.add_question(question)
@@ -119,27 +106,36 @@ class _QueryResponse:
     def outgoing_multicast(self) -> Optional[DNSOutgoing]:
         """Build the outgoing multicast response."""
         if not self._is_probe:
-            self._suppress_mcasts_from_last_second(self._mcast[RecordSetKeys.Answers])
-            self._suppress_mcasts_from_last_second(self._mcast[RecordSetKeys.Additionals])
+            self._suppress_mcasts_from_last_second(self._mcast)
         return self._construct_outgoing_from_record_set(self._mcast, True)
 
     def _construct_outgoing_from_record_set(
-        self, rrset: _RecordSetType, multicast: bool
+        self, answers_rrset: Set[DNSRecord], multicast: bool
     ) -> Optional[DNSOutgoing]:
         """Add answers and additionals to a DNSOutgoing."""
-        if not rrset[RecordSetKeys.Answers] and not rrset[RecordSetKeys.Additionals]:
+        if not answers_rrset:
             return None
-
-        # Suppress any additionals that are already in answers
-        rrset[RecordSetKeys.Additionals] -= rrset[RecordSetKeys.Answers]
+        self._suppress_known_answers(answers_rrset)
+        # Find additionals and suppress any additionals that are already in answers
+        additionals_rrset = self._additionals_from_answers_rrset(answers_rrset) - answers_rrset
 
         out = DNSOutgoing(_FLAGS_QR_RESPONSE | _FLAGS_AA, multicast=multicast, id_=self._msg.id)
-        for answer in rrset[RecordSetKeys.Answers]:
+        for answer in answers_rrset:
             out.add_answer_at_time(answer, 0)
-        for additional in rrset[RecordSetKeys.Additionals]:
+        for additional in additionals_rrset:
             out.add_additional_answer(additional)
-
         return out
+
+    def _additionals_from_answers_rrset(self, rrset: Set[DNSRecord]) -> Set[DNSRecord]:
+        return set(itertools.chain(self._all_answers[record] for record in rrset))
+
+    def _suppress_known_answers(self, rrset: Set[DNSRecord]) -> None:
+        """Remove any records suppressed by known answers."""
+        rrset -= set(record for record in rrset if self._known_answers.suppresses(record))
+
+    def _suppress_mcasts_from_last_second(self, rrset: Set[DNSRecord]) -> None:
+        """Remove any records that were already sent in the last second."""
+        rrset -= set(record for record in rrset if self._has_mcast_record_in_last_second(record))
 
     def _has_mcast_within_one_quarter_ttl(self, record: DNSRecord) -> bool:
         """Check to see if a record has been mcasted recently.
@@ -154,10 +150,6 @@ class _QueryResponse:
         """
         maybe_entry = self._cache.get(record)
         return bool(maybe_entry and maybe_entry.is_recent(self._now))
-
-    def _suppress_mcasts_from_last_second(self, records: Set[DNSRecord]) -> None:
-        """Remove any records that were already sent in the last second."""
-        records -= set(record for record in records if self._has_mcast_record_in_last_second(record))
 
     def _has_mcast_record_in_last_second(self, record: DNSRecord) -> bool:
         """Remove answers that were just broadcast
@@ -178,99 +170,80 @@ class QueryHandler:
 
     def _answer_service_type_enumeration_query(
         self,
-        answers_rrset: DNSRRSet,
+        answer_set: _AnswerWithAdditionalsType,
     ) -> Set[DNSRecord]:
         """Provide an answer to a service type enumeration query.
 
         https://datatracker.ietf.org/doc/html/rfc6763#section-9
         """
-        records: Set[DNSRecord] = set(
-            DNSPointer(_SERVICE_TYPE_ENUMERATION_NAME, _TYPE_PTR, _CLASS_IN, _DNS_OTHER_TTL, stype)
-            for stype in self.registry.get_types()
-        )
-        records -= set(dns_pointer for dns_pointer in records if answers_rrset.suppresses(dns_pointer))
-        return records
+        for stype in self.registry.get_types():
+            answer_set.setdefault(
+                DNSPointer(_SERVICE_TYPE_ENUMERATION_NAME, _TYPE_PTR, _CLASS_IN, _DNS_OTHER_TTL, stype), set()
+            )
 
-    def _add_pointer_answers(
-        self, name: str, answers_rrset: DNSRRSet, answers: Set[DNSRecord], additionals: Set[DNSRecord]
-    ) -> None:
+    def _add_pointer_answers(self, name: str, answer_set: _AnswerWithAdditionalsType) -> None:
         """Answer PTR/ANY question."""
         for service in self.registry.get_infos_type(name):
             # Add recommended additional answers according to
             # https://tools.ietf.org/html/rfc6763#section-12.1.
-            dns_pointer = service.dns_pointer()
-            if not answers_rrset.suppresses(dns_pointer):
-                answers.add(dns_pointer)
-                additionals.add(service.dns_service())
-                additionals.add(service.dns_text())
-                additionals.update(service.dns_addresses())
+            answer_set.add_answer_with_additonals(
+                service.dns_pointer(), [service.dns_service(), service.dns_text(), *service.dns_addresses()]
+            )
 
-    def _add_address_answers(
-        self, name: str, answers_rrset: DNSRRSet, answers: Set[DNSRecord], type_: int
-    ) -> None:
+    def _add_address_answers(self, name: str, answer_set: _AnswerWithAdditionalsType, type_: int) -> None:
         """Answer A/AAAA/ANY question."""
         for service in self.registry.get_infos_server(name):
             for dns_address in service.dns_addresses(version=_TYPE_TO_IP_VERSION[type_]):
-                if not answers_rrset.suppresses(dns_address):
-                    answers.add(dns_address)
+                answer_set.setdefault(dns_address, set())
 
-    def _answer_question(
-        self, answers_rrset: DNSRRSet, question: DNSQuestion
-    ) -> Tuple[Set[DNSRecord], Set[DNSRecord]]:
-        answers: Set[DNSRecord] = set()
-        additionals: Set[DNSRecord] = set()
+    def _answer_question(self, question: DNSQuestion, answer_set: _AnswerWithAdditionalsType) -> None:
         type_ = question.type
 
         if type_ in (_TYPE_PTR, _TYPE_ANY):
-            self._add_pointer_answers(question.name, answers_rrset, answers, additionals)
+            self._add_pointer_answers(question.name, answer_set)
 
         if type_ in (_TYPE_A, _TYPE_AAAA, _TYPE_ANY):
-            self._add_address_answers(question.name, answers_rrset, answers, type_)
+            self._add_address_answers(question.name, answer_set, type_)
 
         if type_ in (_TYPE_SRV, _TYPE_TXT, _TYPE_ANY):
             service = self.registry.get_info_name(question.name)  # type: ignore
             if service is not None:
                 if type_ in (_TYPE_SRV, _TYPE_ANY):
-                    dns_service = service.dns_service()
-                    if not answers_rrset.suppresses(dns_service):
-                        # Add recommended additional answers according to
-                        # https://tools.ietf.org/html/rfc6763#section-12.2.
-                        answers.add(service.dns_service())
-                        additionals.update(service.dns_addresses())
+                    # Add recommended additional answers according to
+                    # https://tools.ietf.org/html/rfc6763#section-12.2.
+                    answer_set.setdefault(service.dns_service(), set()).update(service.dns_addresses())
                 if type_ in (_TYPE_TXT, _TYPE_ANY):
-                    dns_text = service.dns_text()
-                    if not answers_rrset.suppresses(dns_text):
-                        answers.add(service.dns_text())
-
-        return answers, additionals
+                    answer_set.setdefault(service.dns_text(), set())
 
     def _answer_any_question(
-        self, answers_rrset: DNSRRSet, question: DNSQuestion
-    ) -> Tuple[Set[DNSRecord], Set[DNSRecord]]:
+        self,
+        question: DNSQuestion,
+        answer_set: DNSRRSet,
+    ) -> None:
         if question.type == _TYPE_PTR and question.name.lower() == _SERVICE_TYPE_ENUMERATION_NAME:
-            empty_additionals: Set[DNSRecord] = set()
-            return self._answer_service_type_enumeration_query(answers_rrset), empty_additionals
+            self._answer_service_type_enumeration_query(answer_set)
 
-        return self._answer_question(answers_rrset, question)
+        return self._answer_question(question, answer_set)
 
     def response(  # pylint: disable=unused-argument
         self, msgs: List[DNSIncoming], addr: Optional[str], port: int
     ) -> Tuple[Optional[DNSOutgoing], Optional[DNSOutgoing]]:
         """Deal with incoming query packets. Provides a response if possible."""
         ucast_source = port != _MDNS_PORT
-        query_res = _QueryResponse(self.cache, msgs[0], ucast_source)
-        answers_rrset = DNSRRSet(itertools.chain(*[msg.answers for msg in msgs]))
+        known_answers = DNSRRSet(itertools.chain(*[msg.answers for msg in msgs]))
+        query_res = _QueryResponse(self.cache, msgs[0], ucast_source, known_answers)
 
         for question in itertools.chain(*[msg.questions for msg in msgs]):
-            all_answers = self._answer_any_question(answers_rrset, question)
+            answer_set: _AnswerWithAdditionalsType = {}
+            self._answer_any_question(question, answer_set)
             if not ucast_source and question.unicast:
-                query_res.add_qu_question_response(*all_answers)
+                query_res.add_qu_question_response(answer_set)
             else:
                 if ucast_source:
-                    query_res.add_ucast_question_response(*all_answers)
+                    query_res.add_ucast_question_response(answer_set)
                 # We always multicast as well even if its a unicast
                 # source as long as we haven't done it recently (75% of ttl)
-                query_res.add_mcast_question_response(*all_answers)
+                query_res.add_mcast_question_response(answer_set)
 
         return query_res.outgoing_unicast(), query_res.outgoing_multicast()
 

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -113,11 +113,11 @@ class _QueryResponse:
         self, answers_rrset: Set[DNSRecord], multicast: bool
     ) -> Optional[DNSOutgoing]:
         """Add answers and additionals to a DNSOutgoing."""
-        if not answers_rrset:
-            return None
         self._suppress_known_answers(answers_rrset)
         # Find additionals and suppress any additionals that are already in answers
         additionals_rrset = self._additionals_from_answers_rrset(answers_rrset) - answers_rrset
+        if not answers_rrset:
+            return None
 
         out = DNSOutgoing(_FLAGS_QR_RESPONSE | _FLAGS_AA, multicast=multicast, id_=self._msg.id)
         for answer in answers_rrset:
@@ -127,7 +127,7 @@ class _QueryResponse:
         return out
 
     def _additionals_from_answers_rrset(self, rrset: Set[DNSRecord]) -> Set[DNSRecord]:
-        return set(itertools.chain(self._all_answers[record] for record in rrset))
+        return set().union(*[self._all_answers[record] for record in rrset])
 
     def _suppress_known_answers(self, rrset: Set[DNSRecord]) -> None:
         """Remove any records suppressed by known answers."""
@@ -187,7 +187,7 @@ class QueryHandler:
             # Add recommended additional answers according to
             # https://tools.ietf.org/html/rfc6763#section-12.1.
             answer_set[service.dns_pointer()] = set(
-                service.dns_service(), service.dns_text(), *service.dns_addresses()
+                [service.dns_service(), service.dns_text(), *service.dns_addresses()]
             )
 
     def _add_address_answers(self, name: str, answer_set: _AnswerWithAdditionalsType, type_: int) -> None:


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc6762#section-5.4
>  When receiving a question with the unicast-response bit set, a
>  responder SHOULD usually respond with a unicast packet directed back
>  to the querier. However, if the responder has not multicast that
>  record recently (within one quarter of its TTL), then the responder
>  SHOULD instead multicast the response so as to keep all the peer
>  caches up to date, and to permit passive conflict detection. In the
>  case of answering a probe question (Section 8.1) with the unicast-
>  response bit set, the responder should always generate the requested
>  unicast response, but it may also send a multicast announcement if
>  the time since the last multicast announcement of that record is more
>  than a quarter of its TTL.
> 
>  Unicast replies are subject to all the same packet generation rules
>  as multicast replies, including the cache-flush bit (Section 10.2)
>  and (except when defending a unique name against a probe from another
>  host) randomized delays to reduce network collisions (Section 6).

This means additionals are properties of the answers and we only multicast them if we are multicasting the answer as well.

Apple's mDNSResponder behaves this way in testing so lets do that
fixes #689