### PR TITLE
Remove AA flags from handlers test

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -230,7 +230,7 @@ def test_ptr_optimization():
     zc.register_service(info)
 
     # Verify we won't respond for 1s with the same multicast
-    query = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
+    query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     query.add_question(r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN))
     unicast_out, multicast_out = zc.query_handler.response(
         [r.DNSIncoming(packet) for packet in query.packets()], None, const._MDNS_PORT
@@ -242,7 +242,7 @@ def test_ptr_optimization():
     _clear_cache(zc)
 
     # Verify we will now respond
-    query = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
+    query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     query.add_question(r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN))
     unicast_out, multicast_out = zc.query_handler.response(
         [r.DNSIncoming(packet) for packet in query.packets()], None, const._MDNS_PORT
@@ -340,7 +340,7 @@ def test_unicast_response():
     _clear_cache(zc)
 
     # query
-    query = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
+    query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     query.add_question(r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN))
     unicast_out, multicast_out = zc.query_handler.response(
         [r.DNSIncoming(packet) for packet in query.packets()], "1.2.3.4", 1234
@@ -413,7 +413,7 @@ def test_qu_response():
         assert has_srv and has_txt and has_a
 
     # With QU should respond to only unicast when the answer has been recently multicast
-    query = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
+    query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN)
     question.unique = True  # Set the QU bit
     assert question.unicast is True
@@ -427,7 +427,7 @@ def test_qu_response():
 
     _clear_cache(zc)
     # With QU should respond to only multicast since the response hasn't been seen since 75% of the ttl
-    query = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
+    query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN)
     question.unique = True  # Set the QU bit
     assert question.unicast is True
@@ -439,7 +439,7 @@ def test_qu_response():
     _validate_complete_response(query, multicast_out)
 
     # With QU set and an authorative answer (probe) should respond to both unitcast and multicast since the response hasn't been seen since 75% of the ttl
-    query = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
+    query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN)
     question.unique = True  # Set the QU bit
     assert question.unicast is True
@@ -453,7 +453,7 @@ def test_qu_response():
 
     _inject_response(zc, r.DNSIncoming(multicast_out.packets()[0]))
     # With the cache repopulated; should respond to only unicast when the answer has been recently multicast
-    query = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
+    query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN)
     question.unique = True  # Set the QU bit
     assert question.unicast is True


### PR DESCRIPTION
- The flag was added by mistake when copying from other tests