### PR TITLE
Efficiently bucket queries with known answers

### DIFF
--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1379,7 +1379,7 @@ def test_serviceinfo_accepts_bytes_or_string_dict():
     assert info_service.dns_text().text == b'\x0epath=/~paulsm/'
 
 
-def test_group_queries_with_known_answers():
+def test_group_ptr_queries_with_known_answers():
     questions_with_known_answers: s._QuestionWithKnownAnswers = {}
     now = current_time_millis()
     for i in range(120):
@@ -1394,7 +1394,7 @@ def test_group_queries_with_known_answers():
             )
             for counter in range(i)
         )
-    outs = s.group_queries_with_known_answers(now, True, questions_with_known_answers)
+    outs = s._group_ptr_queries_with_known_answers(now, True, questions_with_known_answers)
     for out in outs:
         packets = out.packets()
         # If we generate multiple packets there must

--- a/zeroconf/_dns.py
+++ b/zeroconf/_dns.py
@@ -83,7 +83,7 @@ class DNSEntry:
         """Maximum size of the base record in the packet."""
         return _BASE_MAX_SIZE + self._name_max_size()
 
-    def _name_max_size(self):
+    def _name_max_size(self) -> int:
         """Maximum size of the name in the packet."""
         return len(self.name.encode('utf-8')) + _LEN_SHORT
 
@@ -249,11 +249,6 @@ class DNSAddress(DNSRecord):
         super().__init__(name, type_, class_, ttl)
         self.address = address
 
-    @property
-    def max_size(self) -> int:
-        """Maximum size of the record in the packet."""
-        return super().max_size + len(self.address)
-
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet"""
         out.write_string(self.address)
@@ -288,17 +283,6 @@ class DNSHinfo(DNSRecord):
         super().__init__(name, type_, class_, ttl)
         self.cpu = cpu
         self.os = os
-
-    @property
-    def max_size(self) -> int:
-        """Maximum size of the record in the packet."""
-        return (
-            super().max_size
-            + len(self.cpu.encode('utf-8'))
-            + _LEN_BYTE
-            + len(self.os.encode('utf-8'))
-            + _LEN_BYTE
-        )
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet"""
@@ -372,11 +356,6 @@ class DNSText(DNSRecord):
         super().__init__(name, type_, class_, ttl)
         self.text = text
 
-    @property
-    def max_size(self) -> int:
-        """Maximum size of the record in the packet."""
-        return super().max_size + len(self.text)
-
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet"""
         out.write_string(self.text)
@@ -416,18 +395,6 @@ class DNSService(DNSRecord):
         self.weight = weight
         self.port = port
         self.server = server
-
-    @property
-    def max_size(self) -> int:
-        """Maximum size of the record in the packet."""
-        return (
-            super().max_size
-            + _LEN_SHORT  # priority
-            + _LEN_SHORT  # weight
-            + _LEN_SHORT  # port
-            + len(self.server.encode('utf-8'))
-            + 1  # server
-        )
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet"""

--- a/zeroconf/_dns.py
+++ b/zeroconf/_dns.py
@@ -78,15 +78,6 @@ class DNSEntry:
         self.class_ = class_ & _CLASS_MASK
         self.unique = (class_ & _CLASS_UNIQUE) != 0
 
-    @property
-    def max_size(self) -> int:
-        """Maximum size of the base record in the packet."""
-        return _BASE_MAX_SIZE + self._name_max_size()
-
-    def _name_max_size(self) -> int:
-        """Maximum size of the name in the packet."""
-        return len(self.name.encode('utf-8')) + _LEN_SHORT
-
     def _entry_tuple(self) -> Tuple[str, int, int]:
         """Entry Tuple for DNSEntry."""
         return (self.key, self.type, self.class_)
@@ -314,11 +305,6 @@ class DNSPointer(DNSRecord):
     def __init__(self, name: str, type_: int, class_: int, ttl: int, alias: str) -> None:
         super().__init__(name, type_, class_, ttl)
         self.alias = alias
-
-    @property
-    def max_size(self) -> int:
-        """Maximum size of the record in the packet."""
-        return super().max_size + len(self.alias.encode('utf-8')) + _LEN_BYTE
 
     @property
     def max_size_compressed(self) -> int:

--- a/zeroconf/aio.py
+++ b/zeroconf/aio.py
@@ -159,8 +159,8 @@ class AsyncServiceBrowser(_ServiceBrowserBase):
                     if not self._handlers_to_call:
                         await wait_condition_or_timeout(self.aiozc.condition, timeout)
 
-            out = self.generate_ready_queries()
-            if out:
+            outs = self.generate_ready_queries()
+            for out in outs:
                 self.aiozc.zeroconf.async_send(out, addr=self.addr, port=self.port)
 
             if not self._handlers_to_call:

--- a/zeroconf/const.py
+++ b/zeroconf/const.py
@@ -47,6 +47,8 @@ _DNS_PORT = 53
 _DNS_HOST_TTL = 120  # two minute for host records (A, SRV etc) as-per RFC6762
 _DNS_OTHER_TTL = 4500  # 75 minutes for non-host records (PTR, TXT etc) as-per RFC6762
 
+_DNS_PACKET_HEADER_LEN = 12
+
 _MAX_MSG_TYPICAL = 1460  # unused
 _MAX_MSG_ABSOLUTE = 8966
 


### PR DESCRIPTION
- Aggregate queries so that as many known answers as possible fit in the same packet
  without having known answers spill over into the next packet unless the
  question and known answers are always going to exceed the packet size.

- Some responders do not implement multi-packet known answer suppression
  so we try to keep all the known answers in the same packet as the
  questions.

- Basic design is extensible to other record types besides PTR, however
  we currently don't need to support any other record types.

Fixes #691