### PR TITLE
Set stale unique records to expire 1s in the future instead of instant removal

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -17,7 +17,7 @@ import unittest.mock
 from typing import cast
 
 import zeroconf as r
-from zeroconf import _core, const, ServiceBrowser, Zeroconf
+from zeroconf import _core, const, ServiceBrowser, Zeroconf, current_time_millis
 
 from . import has_working_ipv6, _clear_cache, _inject_response
 
@@ -241,7 +241,7 @@ class Framework(unittest.TestCase):
             # service removed
             _inject_response(zeroconf, mock_incoming_msg(r.ServiceStateChange.Removed))
             dns_text = zeroconf.cache.get_by_details(service_name, const._TYPE_TXT, const._CLASS_IN)
-            assert dns_text is None
+            assert dns_text.is_expired(current_time_millis() + 1000)
 
         finally:
             zeroconf.close()

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -735,7 +735,7 @@ def test_qu_response_only_sends_additionals_if_sends_answer():
 
     # Add the A record to the cache with 50% ttl remaining
     a_record = info.dns_addresses()[0]
-    a_record._set_created_ttl(current_time_millis() - (a_record.ttl * 1000 / 2), a_record.ttl)
+    a_record.set_created_ttl(current_time_millis() - (a_record.ttl * 1000 / 2), a_record.ttl)
     assert not a_record.is_recent(current_time_millis())
     zc.cache.add(a_record)
 
@@ -776,7 +776,7 @@ def test_qu_response_only_sends_additionals_if_sends_answer():
 
     # Remove the 100% PTR record and add a 50% PTR record
     zc.cache.remove(ptr_record)
-    ptr_record._set_created_ttl(current_time_millis() - (ptr_record.ttl * 1000 / 2), ptr_record.ttl)
+    ptr_record.set_created_ttl(current_time_millis() - (ptr_record.ttl * 1000 / 2), ptr_record.ttl)
     assert not ptr_record.is_recent(current_time_millis())
     zc.cache.add(ptr_record)
     # With QU should respond to only multicast since the has less

--- a/zeroconf/_dns.py
+++ b/zeroconf/_dns.py
@@ -194,9 +194,9 @@ class DNSRecord(DNSEntry):
     def reset_ttl(self, other: 'DNSRecord') -> None:
         """Sets this record's TTL and created time to that of
         another record."""
-        self._set_created_ttl(other.created, other.ttl)
+        self.set_created_ttl(other.created, other.ttl)
 
-    def _set_created_ttl(self, created: float, ttl: Union[float, int]) -> None:
+    def set_created_ttl(self, created: float, ttl: Union[float, int]) -> None:
         """Set the created and ttl of a record."""
         self.created = created
         self.ttl = ttl

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -298,7 +298,8 @@ class RecordManager:
                     if entry == record:
                         updated = False
                     if record.created - entry.created > 1000 and entry not in msg.answers:
-                        removes.append(entry)
+                        # Expire in 1s
+                        entry.set_created_ttl(now, 1)
 
             expired = record.is_expired(now)
             maybe_entry = self.cache.get(record)


### PR DESCRIPTION
- Fixes #475

- https://tools.ietf.org/html/rfc6762#section-10.2
  Queriers receiving a Multicast DNS response with a TTL of zero SHOULD
  NOT immediately delete the record from the cache, but instead record
  a TTL of 1 and then delete the record one second later.  In the case
  of multiple Multicast DNS responders on the network described in
  Section 6.6 above, if one of the responders shuts down and
  incorrectly sends goodbye packets for its records, it gives the other
  cooperating responders one second to send out their own response to
  "rescue" the records before they expire and are deleted.