### PR TITLE
Synchronize created time for incoming and outgoing queries

### DIFF
--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -465,19 +465,20 @@ class Zeroconf(QuietLogger):
         #
         # _CLASS_UNIQUE is the "QU" bit
         out.add_question(DNSQuestion(info.type, _TYPE_PTR, _CLASS_IN | _CLASS_UNIQUE))
-        out.add_authorative_answer(info.dns_pointer())
+        out.add_authorative_answer(info.dns_pointer(created=current_time_millis()))
         return out
 
     def _add_broadcast_answer(  # pylint: disable=no-self-use
         self, out: DNSOutgoing, info: ServiceInfo, override_ttl: Optional[int]
     ) -> None:
         """Add answers to broadcast a service."""
+        now = current_time_millis()
         other_ttl = info.other_ttl if override_ttl is None else override_ttl
         host_ttl = info.host_ttl if override_ttl is None else override_ttl
-        out.add_answer_at_time(info.dns_pointer(override_ttl=other_ttl), 0)
-        out.add_answer_at_time(info.dns_service(override_ttl=host_ttl), 0)
-        out.add_answer_at_time(info.dns_text(override_ttl=other_ttl), 0)
-        for dns_address in info.dns_addresses(override_ttl=host_ttl):
+        out.add_answer_at_time(info.dns_pointer(override_ttl=other_ttl, created=now), 0)
+        out.add_answer_at_time(info.dns_service(override_ttl=host_ttl, created=now), 0)
+        out.add_answer_at_time(info.dns_text(override_ttl=other_ttl, created=now), 0)
+        for dns_address in info.dns_addresses(override_ttl=host_ttl, created=now):
             out.add_answer_at_time(dns_address, 0)
 
     def unregister_service(self, info: ServiceInfo) -> None:

--- a/zeroconf/_dns.py
+++ b/zeroconf/_dns.py
@@ -139,10 +139,12 @@ class DNSRecord(DNSEntry):
     """A DNS record - like a DNS entry, but has a TTL"""
 
     # TODO: Switch to just int ttl
-    def __init__(self, name: str, type_: int, class_: int, ttl: Union[float, int]) -> None:
+    def __init__(
+        self, name: str, type_: int, class_: int, ttl: Union[float, int], created: Optional[float] = None
+    ) -> None:
         super().__init__(name, type_, class_)
         self.ttl = ttl
-        self.created = current_time_millis()
+        self.created = created or current_time_millis()
         self._expiration_time: Optional[float] = None
         self._stale_time: Optional[float] = None
         self._recent_time: Optional[float] = None
@@ -218,8 +220,10 @@ class DNSAddress(DNSRecord):
 
     """A DNS address record"""
 
-    def __init__(self, name: str, type_: int, class_: int, ttl: int, address: bytes) -> None:
-        super().__init__(name, type_, class_, ttl)
+    def __init__(
+        self, name: str, type_: int, class_: int, ttl: int, address: bytes, created: Optional[float] = None
+    ) -> None:
+        super().__init__(name, type_, class_, ttl, created)
         self.address = address
 
     def write(self, out: 'DNSOutgoing') -> None:
@@ -252,8 +256,10 @@ class DNSHinfo(DNSRecord):
 
     """A DNS host information record"""
 
-    def __init__(self, name: str, type_: int, class_: int, ttl: int, cpu: str, os: str) -> None:
-        super().__init__(name, type_, class_, ttl)
+    def __init__(
+        self, name: str, type_: int, class_: int, ttl: int, cpu: str, os: str, created: Optional[float] = None
+    ) -> None:
+        super().__init__(name, type_, class_, ttl, created)
         self.cpu = cpu
         self.os = os
 
@@ -284,8 +290,10 @@ class DNSPointer(DNSRecord):
 
     """A DNS pointer record"""
 
-    def __init__(self, name: str, type_: int, class_: int, ttl: int, alias: str) -> None:
-        super().__init__(name, type_, class_, ttl)
+    def __init__(
+        self, name: str, type_: int, class_: int, ttl: int, alias: str, created: Optional[float] = None
+    ) -> None:
+        super().__init__(name, type_, class_, ttl, created)
         self.alias = alias
 
     @property
@@ -319,9 +327,11 @@ class DNSText(DNSRecord):
 
     """A DNS text record"""
 
-    def __init__(self, name: str, type_: int, class_: int, ttl: int, text: bytes) -> None:
+    def __init__(
+        self, name: str, type_: int, class_: int, ttl: int, text: bytes, created: Optional[float] = None
+    ) -> None:
         assert isinstance(text, (bytes, type(None)))
-        super().__init__(name, type_, class_, ttl)
+        super().__init__(name, type_, class_, ttl, created)
         self.text = text
 
     def write(self, out: 'DNSOutgoing') -> None:
@@ -357,8 +367,9 @@ class DNSService(DNSRecord):
         weight: int,
         port: int,
         server: str,
+        created: Optional[float] = None,
     ) -> None:
-        super().__init__(name, type_, class_, ttl)
+        super().__init__(name, type_, class_, ttl, created)
         self.priority = priority
         self.weight = weight
         self.port = port

--- a/zeroconf/_services/__init__.py
+++ b/zeroconf/_services/__init__.py
@@ -369,7 +369,7 @@ class _ServiceBrowserBase(RecordUpdateListener):
 
         At this point the cache will have the new records.
         """
-        # Cannot use .update here since PyPy can fail with
+        # Cannot use .update here since can fail with
         # RuntimeError: dictionary changed size during iteration
         # for threaded ServiceBrowsers
         while self._pending_handlers:
@@ -722,7 +722,10 @@ class ServiceInfo(RecordUpdateListener):
                 self._set_text(record.text)
 
     def dns_addresses(
-        self, override_ttl: Optional[int] = None, version: IPVersion = IPVersion.All
+        self,
+        override_ttl: Optional[int] = None,
+        version: IPVersion = IPVersion.All,
+        created: Optional[float] = None,
     ) -> List[DNSAddress]:
         """Return matching DNSAddress from ServiceInfo."""
         return [
@@ -732,11 +735,12 @@ class ServiceInfo(RecordUpdateListener):
                 _CLASS_IN | _CLASS_UNIQUE,
                 override_ttl if override_ttl is not None else self.host_ttl,
                 address,
+                created,
             )
             for address in self.addresses_by_version(version)
         ]
 
-    def dns_pointer(self, override_ttl: Optional[int] = None) -> DNSPointer:
+    def dns_pointer(self, override_ttl: Optional[int] = None, created: Optional[float] = None) -> DNSPointer:
         """Return DNSPointer from ServiceInfo."""
         return DNSPointer(
             self.type,
@@ -744,9 +748,10 @@ class ServiceInfo(RecordUpdateListener):
             _CLASS_IN,
             override_ttl if override_ttl is not None else self.other_ttl,
             self.name,
+            created,
         )
 
-    def dns_service(self, override_ttl: Optional[int] = None) -> DNSService:
+    def dns_service(self, override_ttl: Optional[int] = None, created: Optional[float] = None) -> DNSService:
         """Return DNSService from ServiceInfo."""
         return DNSService(
             self.name,
@@ -757,9 +762,10 @@ class ServiceInfo(RecordUpdateListener):
             self.weight,
             cast(int, self.port),
             self.server,
+            created,
         )
 
-    def dns_text(self, override_ttl: Optional[int] = None) -> DNSText:
+    def dns_text(self, override_ttl: Optional[int] = None, created: Optional[float] = None) -> DNSText:
         """Return DNSText from ServiceInfo."""
         return DNSText(
             self.name,
@@ -767,6 +773,7 @@ class ServiceInfo(RecordUpdateListener):
             _CLASS_IN | _CLASS_UNIQUE,
             override_ttl if override_ttl is not None else self.other_ttl,
             self.text,
+            created,
         )
 
     def _get_address_records_from_cache(self, zc: 'Zeroconf') -> List[DNSRecord]:


### PR DESCRIPTION
- The created time would differ by a few ms for records, these
  should all be the same in each packet to reduce unexpected
  inconsistency

- Records received in the same response MUST be subject to fate
  sharing.  Its possible we could end up expiring part of the unique
  record set because one of the addresses is a few ms older.

Fixes #700