### PR TITLE
Rename handlers and internals to make it clear what is threadsafe

### DIFF
--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1219,7 +1219,7 @@ def test_service_browser_is_aware_of_port_changes():
         zc,
         mock_incoming_msg([info.dns_pointer(), info.dns_service(), info.dns_text(), *info.dns_addresses()]),
     )
-    zc.wait(100)
+    time.sleep(0.1)
 
     assert callbacks == [('_hap._tcp.local.', ServiceStateChange.Added, 'xxxyyy._hap._tcp.local.')]
     assert zc.get_service_info(type_, registration_name).port == 80
@@ -1229,7 +1229,7 @@ def test_service_browser_is_aware_of_port_changes():
         zc,
         mock_incoming_msg([info.dns_service()]),
     )
-    zc.wait(100)
+    time.sleep(0.1)
 
     assert callbacks == [
         ('_hap._tcp.local.', ServiceStateChange.Added, 'xxxyyy._hap._tcp.local.'),

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -146,8 +146,8 @@ class AsyncEngine:
         """Periodic cache cleanup."""
         while not self.zc.done:
             now = current_time_millis()
-            self.zc.record_manager.updates(now, list(self.zc.cache.expire(now)))
-            self.zc.record_manager.updates_complete()
+            self.zc.record_manager.async_updates(now, list(self.zc.cache.expire(now)))
+            self.zc.record_manager.async_updates_complete()
             await asyncio.sleep(millis_to_seconds(_CACHE_CLEANUP_INTERVAL))
 
     async def _async_close(self) -> None:
@@ -565,7 +565,7 @@ class Zeroconf(QuietLogger):
     def handle_response(self, msg: DNSIncoming) -> None:
         """Deal with incoming response packets.  All answers
         are held in the cache, and listeners are notified."""
-        self.record_manager.updates_from_response(msg)
+        self.record_manager.async_updates_from_response(msg)
 
     def handle_query(self, msg: DNSIncoming, addr: str, port: int) -> None:
         """Deal with incoming query packets.  Provides a response if
@@ -594,7 +594,7 @@ class Zeroconf(QuietLogger):
         if msg:
             packets.append(msg)
 
-        unicast_out, multicast_out = self.query_handler.response(packets, addr, port)
+        unicast_out, multicast_out = self.query_handler.async_response(packets, addr, port)
         if unicast_out:
             self.async_send(unicast_out, addr, port)
         if multicast_out:

--- a/zeroconf/_services/__init__.py
+++ b/zeroconf/_services/__init__.py
@@ -134,7 +134,7 @@ class RecordUpdateListener:
         """
         raise RuntimeError("update_record is deprecated and will be removed in a future version.")
 
-    def update_records(self, zc: 'Zeroconf', now: float, records: List[DNSRecord]) -> None:
+    def async_update_records(self, zc: 'Zeroconf', now: float, records: List[DNSRecord]) -> None:
         """Update multiple records in one shot.
 
         All records that are received in a single packet are passed
@@ -146,14 +146,18 @@ class RecordUpdateListener:
         NotImplementedError in a future version.
 
         At this point the cache will not have the new records
+
+        This method will be run in the event loop.
         """
         for record in records:
             self.update_record(zc, now, record)
 
-    def update_records_complete(self) -> None:
+    def async_update_records_complete(self) -> None:
         """Called when a record update has completed for all handlers.
 
         At this point the cache will have the new records.
+
+        This method will be run in the event loop.
         """
 
 
@@ -353,20 +357,24 @@ class _ServiceBrowserBase(RecordUpdateListener):
         if type_:
             self._enqueue_callback(ServiceStateChange.Updated, type_, record.name)
 
-    def update_records(self, zc: 'Zeroconf', now: float, records: List[DNSRecord]) -> None:
+    def async_update_records(self, zc: 'Zeroconf', now: float, records: List[DNSRecord]) -> None:
         """Callback invoked by Zeroconf when new information arrives.
 
         Updates information required by browser in the Zeroconf cache.
 
         Ensures that there is are no unecessary duplicates in the list.
+
+        This method will be run in the event loop.
         """
         for record in records:
             self._process_record_update(now, record)
 
-    def update_records_complete(self) -> None:
+    def async_update_records_complete(self) -> None:
         """Called when a record update has completed for all handlers.
 
         At this point the cache will have the new records.
+
+        This method will be run in the event loop.
         """
         # Cannot use .update here since can fail with
         # RuntimeError: dictionary changed size during iteration
@@ -677,26 +685,35 @@ class ServiceInfo(RecordUpdateListener):
 
         This method is deprecated and will be removed in a future version.
         update_records should be implemented instead.
+
+        This method will be run in the event loop.
         """
         if record is not None:
-            self.update_records(zc, now, [record])
+            self._process_records_threadsafe(zc, now, [record])
 
-    def update_records(self, zc: 'Zeroconf', now: float, records: List[DNSRecord]) -> None:
-        """Updates service information from a DNS record."""
+    def async_update_records(self, zc: 'Zeroconf', now: float, records: List[DNSRecord]) -> None:
+        """Updates service information from a DNS record.
+
+        This method will be run in the event loop.
+        """
+        self._process_records_threadsafe(zc, now, records)
+
+    def _process_records_threadsafe(self, zc: 'Zeroconf', now: float, records: List[DNSRecord]) -> None:
+        """Thread safe record updating."""
         update_addresses = False
         for record in records:
             if isinstance(record, DNSService):
                 update_addresses = True
-            self._process_record(record, now)
+            self._process_record_threadsafe(record, now)
 
         # Only update addresses if the DNSService (.server) has changed
         if not update_addresses:
             return
 
         for record in self._get_address_records_from_cache(zc):
-            self._process_record(record, now)
+            self._process_record_threadsafe(record, now)
 
-    def _process_record(self, record: DNSRecord, now: float) -> None:
+    def _process_record_threadsafe(self, record: DNSRecord, now: float) -> None:
         if record.is_expired(now):
             return
 
@@ -785,7 +802,10 @@ class ServiceInfo(RecordUpdateListener):
         return address_records
 
     def load_from_cache(self, zc: 'Zeroconf') -> bool:
-        """Populate the service info from the cache."""
+        """Populate the service info from the cache.
+
+        This method is designed to be threadsafe.
+        """
         now = current_time_millis()
         record_updates = []
         cached_srv_record = zc.cache.get_by_details(self.name, _TYPE_SRV, _CLASS_IN)
@@ -798,7 +818,7 @@ class ServiceInfo(RecordUpdateListener):
         cached_txt_record = zc.cache.get_by_details(self.name, _TYPE_TXT, _CLASS_IN)
         if cached_txt_record:
             record_updates.append(cached_txt_record)
-        self.update_records(zc, now, record_updates)
+        self._process_records_threadsafe(zc, now, record_updates)
         return self._is_complete
 
     @property


### PR DESCRIPTION
- It was too easy to get confused about what was threadsafe and
  what was not threadsafe which lead to unexpected failures.
  Rename functions to make it clear what will be run in the event
  loop and what is expected to be threadsafe