### PR TITLE
Fix server cache to be case-insensitive

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -119,6 +119,7 @@ class TestDNSCacheAPI(unittest.TestCase):
         cache = r.DNSCache()
         cache.add_records([record1, record2])
         assert set(cache.entries_with_server('ab')) == set([record1, record2])
+        assert set(cache.entries_with_server('AB')) == set([record1, record2])
 
     def test_entries_with_name(self):
         record1 = r.DNSService(
@@ -130,6 +131,7 @@ class TestDNSCacheAPI(unittest.TestCase):
         cache = r.DNSCache()
         cache.add_records([record1, record2])
         assert set(cache.entries_with_name('irrelevant')) == set([record1, record2])
+        assert set(cache.entries_with_name('Irrelevant')) == set([record1, record2])
 
     def test_current_entry_with_name_and_alias(self):
         record1 = r.DNSPointer(
@@ -142,7 +144,7 @@ class TestDNSCacheAPI(unittest.TestCase):
         cache.add_records([record1, record2])
         assert cache.current_entry_with_name_and_alias('irrelevant', 'x.irrelevant') == record1
 
-    def test_entries_with_name(self):
+    def test_name(self):
         record1 = r.DNSService(
             'irrelevant', const._TYPE_SRV, const._CLASS_IN, const._DNS_HOST_TTL, 0, 0, 85, 'ab'
         )

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -857,6 +857,8 @@ class TestServiceBrowser(unittest.TestCase):
             # service A updated
             service_updated_event.clear()
             service_address = '10.0.1.3'
+            # Verify we match on uppercase
+            service_server = service_server.upper()
             _inject_response(zeroconf, mock_incoming_msg(r.ServiceStateChange.Updated))
             service_updated_event.wait(wait_time)
             assert service_added_count == 1

--- a/zeroconf/_cache.py
+++ b/zeroconf/_cache.py
@@ -134,11 +134,11 @@ class DNSCache:
 
     def entries_with_server(self, server: str) -> List[DNSRecord]:
         """Returns a list of entries whose server matches the name."""
-        return list(self.service_cache.get(server, {}))
+        return list(self.service_cache.get(server.lower(), []))
 
     def entries_with_name(self, name: str) -> List[DNSRecord]:
         """Returns a list of entries whose key matches the name."""
-        return list(self.cache.get(name.lower(), {}))
+        return list(self.cache.get(name.lower(), []))
 
     def current_entry_with_name_and_alias(self, name: str, alias: str) -> Optional[DNSRecord]:
         now = current_time_millis()


### PR DESCRIPTION
- If the server name had uppercase chars and any of the
  matching records were lowercase, the server would not be
  found