### PR TITLE
Add fast cache lookup functions

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -131,11 +131,13 @@ class TestDNSCacheAPI(unittest.TestCase):
     def test_get(self):
         record1 = r.DNSAddress('a', const._TYPE_A, const._CLASS_IN, 1, b'a')
         record2 = r.DNSAddress('a', const._TYPE_A, const._CLASS_IN, 1, b'b')
+        record3 = r.DNSAddress('a', const._TYPE_AAAA, const._CLASS_IN, 1, b'ipv6')
         cache = r.DNSCache()
-        cache.async_add_records([record1, record2])
+        cache.async_add_records([record1, record2, record3])
         assert cache.get(record1) == record1
         assert cache.get(record2) == record2
         assert cache.get(r.DNSEntry('a', const._TYPE_A, const._CLASS_IN)) == record2
+        assert cache.get(r.DNSEntry('a', const._TYPE_AAAA, const._CLASS_IN)) == record3
         assert cache.get(r.DNSEntry('notthere', const._TYPE_A, const._CLASS_IN)) is None
 
     def test_get_by_details(self):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -85,13 +85,13 @@ class TestDNSCache(unittest.TestCase):
 
 
 class TestDNSAsyncCacheAPI(unittest.TestCase):
-    def test_async_get(self):
+    def test_async_get_unique(self):
         record1 = r.DNSAddress('a', const._TYPE_A, const._CLASS_IN, 1, b'a')
         record2 = r.DNSAddress('a', const._TYPE_A, const._CLASS_IN, 1, b'b')
         cache = r.DNSCache()
         cache.async_add_records([record1, record2])
-        assert cache.async_get(record1) == record1
-        assert cache.async_get(record2) == record2
+        assert cache.async_get_unique(record1) == record1
+        assert cache.async_get_unique(record2) == record2
 
     def test_async_get_all_by_details(self):
         record1 = r.DNSAddress('a', const._TYPE_A, const._CLASS_IN, 1, b'a')

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -138,6 +138,7 @@ class TestDNSCacheAPI(unittest.TestCase):
         assert cache.get(record1) == record1
         assert cache.get(record2) == record2
         assert cache.get(r.DNSEntry('a', const._TYPE_A, const._CLASS_IN)) == record2
+        assert cache.get(r.DNSEntry('notthere', const._TYPE_A, const._CLASS_IN)) is None
 
     def test_get_by_details(self):
         record1 = r.DNSAddress('a', const._TYPE_A, const._CLASS_IN, 1, b'a')

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -93,14 +93,12 @@ class TestDNSAsyncCacheAPI(unittest.TestCase):
         assert cache.async_get_unique(record1) == record1
         assert cache.async_get_unique(record2) == record2
 
-    def test_async_get_all_by_details(self):
+    def test_async_all_by_details(self):
         record1 = r.DNSAddress('a', const._TYPE_A, const._CLASS_IN, 1, b'a')
         record2 = r.DNSAddress('a', const._TYPE_A, const._CLASS_IN, 1, b'b')
         cache = r.DNSCache()
         cache.async_add_records([record1, record2])
-        assert set(cache.async_get_all_by_details('a', const._TYPE_A, const._CLASS_IN)) == set(
-            [record1, record2]
-        )
+        assert set(cache.async_all_by_details('a', const._TYPE_A, const._CLASS_IN)) == set([record1, record2])
 
     def test_async_entries_with_server(self):
         record1 = r.DNSService(

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -137,6 +137,7 @@ class TestDNSCacheAPI(unittest.TestCase):
         cache.async_add_records([record1, record2])
         assert cache.get(record1) == record1
         assert cache.get(record2) == record2
+        assert cache.get(r.DNSEntry('a', const._TYPE_A, const._CLASS_IN)) == record2
 
     def test_get_by_details(self):
         record1 = r.DNSAddress('a', const._TYPE_A, const._CLASS_IN, 1, b'a')

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -84,6 +84,49 @@ class TestDNSCache(unittest.TestCase):
         assert 'a' not in cache.cache
 
 
+class TestDNSAsyncCacheAPI(unittest.TestCase):
+    def test_async_get(self):
+        record1 = r.DNSAddress('a', const._TYPE_A, const._CLASS_IN, 1, b'a')
+        record2 = r.DNSAddress('a', const._TYPE_A, const._CLASS_IN, 1, b'b')
+        cache = r.DNSCache()
+        cache.async_add_records([record1, record2])
+        assert cache.async_get(record1) == record1
+        assert cache.async_get(record2) == record2
+
+    def test_async_get_all_by_details(self):
+        record1 = r.DNSAddress('a', const._TYPE_A, const._CLASS_IN, 1, b'a')
+        record2 = r.DNSAddress('a', const._TYPE_A, const._CLASS_IN, 1, b'b')
+        cache = r.DNSCache()
+        cache.async_add_records([record1, record2])
+        assert set(cache.async_get_all_by_details('a', const._TYPE_A, const._CLASS_IN)) == set(
+            [record1, record2]
+        )
+
+    def test_async_entries_with_server(self):
+        record1 = r.DNSService(
+            'irrelevant', const._TYPE_SRV, const._CLASS_IN, const._DNS_HOST_TTL, 0, 0, 85, 'ab'
+        )
+        record2 = r.DNSService(
+            'irrelevant', const._TYPE_SRV, const._CLASS_IN, const._DNS_HOST_TTL, 0, 0, 80, 'ab'
+        )
+        cache = r.DNSCache()
+        cache.async_add_records([record1, record2])
+        assert set(cache.async_entries_with_server('ab')) == set([record1, record2])
+        assert set(cache.async_entries_with_server('AB')) == set([record1, record2])
+
+    def test_async_entries_with_name(self):
+        record1 = r.DNSService(
+            'irrelevant', const._TYPE_SRV, const._CLASS_IN, const._DNS_HOST_TTL, 0, 0, 85, 'ab'
+        )
+        record2 = r.DNSService(
+            'irrelevant', const._TYPE_SRV, const._CLASS_IN, const._DNS_HOST_TTL, 0, 0, 80, 'ab'
+        )
+        cache = r.DNSCache()
+        cache.async_add_records([record1, record2])
+        assert set(cache.async_entries_with_name('irrelevant')) == set([record1, record2])
+        assert set(cache.async_entries_with_name('Irrelevant')) == set([record1, record2])
+
+
 # These functions have been seen in other projects so
 # we try to maintain a stable API for all the threadsafe getters
 class TestDNSCacheAPI(unittest.TestCase):

--- a/zeroconf/_cache.py
+++ b/zeroconf/_cache.py
@@ -21,7 +21,6 @@
 """
 
 import itertools
-
 from typing import Dict, Iterable, List, Optional, Union, cast
 
 from ._dns import DNSAddress, DNSEntry, DNSHinfo, DNSPointer, DNSRecord, DNSService, DNSText

--- a/zeroconf/_cache.py
+++ b/zeroconf/_cache.py
@@ -101,16 +101,14 @@ class DNSCache:
         self.async_remove_records(expired)
         return expired
 
-    def async_get(self, entry: DNSEntry) -> Optional[DNSRecord]:
-        """Gets an entry by key.  Will return None if there is no
+    def async_get_unique(self, entry: _UniqueRecordsType) -> Optional[DNSRecord]:
+        """Gets a unique entry by key.  Will return None if there is no
         matching entry.
 
         This function is not threadsafe and must be called from
         the event loop.
         """
-        if isinstance(entry, _UNIQUE_RECORD_TYPES):
-            return self._lookup_unique_entry_threadsafe(entry)
-        return self._async_get(entry)
+        return self._lookup_unique_entry_threadsafe(entry)
 
     def async_get_all_by_details(self, name: str, type_: int, class_: int) -> List[DNSRecord]:
         """Gets all matching entries by details.

--- a/zeroconf/_cache.py
+++ b/zeroconf/_cache.py
@@ -27,8 +27,7 @@ from ._utils.time import current_time_millis
 from .const import _TYPE_PTR
 
 _UNIQUE_RECORD_TYPES = (DNSAddress, DNSHinfo, DNSPointer, DNSText, DNSService)
-
-
+_UniqueRecordsType = Union[DNSAddress, DNSHinfo, DNSPointer, DNSText, DNSService]
 _DNSRecordCacheType = Dict[str, Dict[DNSRecord, DNSRecord]]
 
 
@@ -139,7 +138,7 @@ class DNSCache:
         """
         return self.service_cache.get(name.lower(), {})
 
-    def _async_get(self, entry: DNSEntry):
+    def _async_get(self, entry: DNSEntry) -> Optional[DNSRecord]:
         """Search a dict of entries by making a copy of it first.
 
         This function is not threadsafe and must be called from
@@ -154,13 +153,11 @@ class DNSCache:
     # event loop, however they all make copies so they significantly
     # inefficent
 
-    def _lookup_unique_entry_threadsafe(
-        self, entry: Union[DNSAddress, DNSHinfo, DNSPointer, DNSText, DNSService]
-    ) -> Optional[Union[DNSAddress, DNSHinfo, DNSPointer, DNSText, DNSService]]:
+    def _lookup_unique_entry_threadsafe(self, entry: _UniqueRecordsType) -> Optional[DNSRecord]:
         """Lookup a unique entry threadsafe."""
         return self.cache.get(entry.key, {}).get(entry)
 
-    def _get_threadsafe(self, entry: DNSEntry):
+    def _get_threadsafe(self, entry: DNSEntry) -> Optional[DNSRecord]:
         """Search a dict of entries by making a copy of it first."""
         for cached_entry in reversed(list(self.cache.get(entry.key, []))):
             if entry.__eq__(cached_entry):

--- a/zeroconf/_cache.py
+++ b/zeroconf/_cache.py
@@ -182,7 +182,7 @@ class DNSCache:
 
         Use get_all_by_details instead.
         """
-        return self.get(DNSEntry(name, type_, class_))
+        return self._get_threadsafe(DNSEntry(name, type_, class_))
 
     def get_all_by_details(self, name: str, type_: int, class_: int) -> List[DNSRecord]:
         """Gets all matching entries by details."""

--- a/zeroconf/_cache.py
+++ b/zeroconf/_cache.py
@@ -178,6 +178,7 @@ class DNSCache:
         for cached_entry in reversed(list(self.cache.get(key, []))):
             if dns_entry_matches(cached_entry, key, type_, class_):
                 return cached_entry
+        return None
 
     def get_all_by_details(self, name: str, type_: int, class_: int) -> List[DNSRecord]:
         """Gets all matching entries by details."""

--- a/zeroconf/_cache.py
+++ b/zeroconf/_cache.py
@@ -23,7 +23,16 @@
 import itertools
 from typing import Dict, Iterable, List, Optional, Union, cast
 
-from ._dns import DNSAddress, DNSEntry, DNSHinfo, DNSPointer, DNSRecord, DNSService, DNSText
+from ._dns import (
+    DNSAddress,
+    DNSEntry,
+    DNSHinfo,
+    DNSPointer,
+    DNSRecord,
+    DNSService,
+    DNSText,
+    dns_entry_matches,
+)
 from ._utils.time import current_time_millis
 from .const import _TYPE_PTR
 
@@ -116,8 +125,8 @@ class DNSCache:
         This function is not threadsafe and must be called from
         the event loop.
         """
-        match_entry = DNSEntry(name, type_, class_)
-        return [entry for entry in self.cache.get(match_entry.key, []) if match_entry.__eq__(entry)]
+        key = name.lower()
+        return [entry for entry in self.cache.get(key, []) if dns_entry_matches(entry, key, type_, class_)]
 
     def async_entries_with_name(self, name: str) -> Dict[DNSRecord, DNSRecord]:
         """Returns a dict of entries whose key matches the name.
@@ -143,19 +152,15 @@ class DNSCache:
         """Lookup a unique entry threadsafe."""
         return self.cache.get(entry.key, {}).get(entry)
 
-    def _get_threadsafe(self, entry: DNSEntry) -> Optional[DNSRecord]:
-        """Search a dict of entries by making a copy of it first."""
-        for cached_entry in reversed(list(self.cache.get(entry.key, []))):
-            if entry.__eq__(cached_entry):
-                return cached_entry
-        return None
-
     def get(self, entry: DNSEntry) -> Optional[DNSRecord]:
         """Gets an entry by key.  Will return None if there is no
         matching entry."""
         if isinstance(entry, _UNIQUE_RECORD_TYPES):
             return self._lookup_unique_entry_threadsafe(entry)
-        return self._get_threadsafe(entry)
+        for cached_entry in reversed(list(self.cache.get(entry.key, []))):
+            if entry.__eq__(cached_entry):
+                return cached_entry
+        return None
 
     def get_by_details(self, name: str, type_: int, class_: int) -> Optional[DNSRecord]:
         """Gets the first matching entry by details. Returns None if no entries match.
@@ -169,12 +174,17 @@ class DNSCache:
 
         Use get_all_by_details instead.
         """
-        return self._get_threadsafe(DNSEntry(name, type_, class_))
+        key = name.lower()
+        for cached_entry in reversed(list(self.cache.get(key, []))):
+            if dns_entry_matches(cached_entry, key, type_, class_):
+                return cached_entry
 
     def get_all_by_details(self, name: str, type_: int, class_: int) -> List[DNSRecord]:
         """Gets all matching entries by details."""
-        match_entry = DNSEntry(name, type_, class_)
-        return [entry for entry in list(self.cache.get(match_entry.key, [])) if match_entry.__eq__(entry)]
+        key = name.lower()
+        return [
+            entry for entry in list(self.cache.get(key, [])) if dns_entry_matches(entry, key, type_, class_)
+        ]
 
     def entries_with_server(self, server: str) -> List[DNSRecord]:
         """Returns a list of entries whose server matches the name."""

--- a/zeroconf/_cache.py
+++ b/zeroconf/_cache.py
@@ -135,17 +135,6 @@ class DNSCache:
         """
         return self.service_cache.get(name.lower(), {})
 
-    def _async_get(self, entry: DNSEntry) -> Optional[DNSRecord]:
-        """Search a dict of entries by making a copy of it first.
-
-        This function is not threadsafe and must be called from
-        the event loop.
-        """
-        for cached_entry in self.cache.get(entry.key, []):
-            if entry.__eq__(cached_entry):
-                return cached_entry
-        return None
-
     # The below functions are threadsafe and do not need to be run in the
     # event loop, however they all make copies so they significantly
     # inefficent

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -146,7 +146,7 @@ class AsyncEngine:
         """Periodic cache cleanup."""
         while not self.zc.done:
             now = current_time_millis()
-            self.zc.record_manager.async_updates(now, list(self.zc.cache.async_expire(now)))
+            self.zc.record_manager.async_updates(now, self.zc.cache.async_expire(now))
             self.zc.record_manager.async_updates_complete()
             await asyncio.sleep(millis_to_seconds(_CACHE_CLEANUP_INTERVAL))
 

--- a/zeroconf/_dns.py
+++ b/zeroconf/_dns.py
@@ -49,6 +49,10 @@ if TYPE_CHECKING:
     from ._protocol import DNSIncoming, DNSOutgoing  # pylint: disable=cyclic-import
 
 
+def dns_entry_matches(record: 'DNSEntry', key: str, type_: int, class_: int) -> bool:
+    return key == record.key and type_ == record.type and class_ == record.class_
+
+
 class DNSEntry:
 
     """A DNS entry"""
@@ -66,12 +70,7 @@ class DNSEntry:
 
     def __eq__(self, other: Any) -> bool:
         """Equality test on key (lowercase name), type, and class"""
-        return (
-            self.key == other.key
-            and self.type == other.type
-            and self.class_ == other.class_
-            and isinstance(other, DNSEntry)
-        )
+        return dns_entry_matches(other, self.key, self.type, self.class_) and isinstance(other, DNSEntry)
 
     @staticmethod
     def get_class_(class_: int) -> str:

--- a/zeroconf/_dns.py
+++ b/zeroconf/_dns.py
@@ -422,3 +422,10 @@ class DNSRRSet:
             self._lookup = {record: record for record in self._records}
         other = self._lookup.get(record)
         return bool(other and other.ttl > (record.ttl / 2))
+
+    def __contains__(self, record: DNSRecord) -> bool:
+        """Returns true if the rrset contains the record."""
+        if self._lookup is None:
+            # Build the hash table so we can lookup the record independent of the ttl
+            self._lookup = {record: record for record in self._records}
+        return record in self._lookup

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -365,7 +365,7 @@ class RecordManager:
         # and rrclass that were received more than one second ago are declared
         # invalid, and marked to expire from the cache in one second.
         for entry in self.cache.async_all_by_details(record.name, record.type, record.class_):
-            if record.created - entry.created > 1000 and entry not in answers_rrset:
+            if record.created - entry.created > 1000 and entry != record and entry not in answers_rrset:
                 # Expire in 1s
                 entry.set_created_ttl(now, 1)
 

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -21,9 +21,9 @@
 """
 
 import itertools
-from typing import Dict, List, Optional, Set, TYPE_CHECKING, Tuple, Union
+from typing import Dict, List, Optional, Set, TYPE_CHECKING, Tuple, Union, cast
 
-from ._cache import DNSCache
+from ._cache import _UniqueRecordsType, DNSCache
 from ._dns import DNSAddress, DNSPointer, DNSQuestion, DNSRRSet, DNSRecord
 from ._logger import log
 from ._protocol import DNSIncoming, DNSOutgoing
@@ -141,7 +141,7 @@ class _QueryResponse:
         SHOULD instead multicast the response so as to keep all the peer
         caches up to date
         """
-        maybe_entry = self._cache.async_get_unique(record)
+        maybe_entry = self._cache.async_get_unique(cast(_UniqueRecordsType, record))
         return bool(maybe_entry and maybe_entry.is_recent(self._now))
 
     def _has_mcast_record_in_last_second(self, record: DNSRecord) -> bool:
@@ -149,7 +149,7 @@ class _QueryResponse:
         Protect the network against excessive packet flooding
         https://datatracker.ietf.org/doc/html/rfc6762#section-14
         """
-        maybe_entry = self._cache.async_get_unique(record)
+        maybe_entry = self._cache.async_get_unique(cast(_UniqueRecordsType, record))
         return bool(maybe_entry and self._now - maybe_entry.created < 1000)
 
 
@@ -328,7 +328,7 @@ class RecordManager:
                         entry.set_created_ttl(now, 1)
 
             expired = record.is_expired(now)
-            maybe_entry = self.cache.async_get_unique(record)
+            maybe_entry = self.cache.async_get_unique(cast(_UniqueRecordsType, record))
             if not expired:
                 if maybe_entry is not None:
                     maybe_entry.reset_ttl(record)

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -373,7 +373,7 @@ class RecordManager:
         answers_rrset = DNSRRSet(answers)
         for name, type_, class_ in unique_types:
             for entry in self.cache.async_all_by_details(name, type_, class_):
-                if now - entry.created > 1000 and entry not in answers_rrset:
+                if (now - entry.created > 1000) and entry not in answers_rrset:
                     # Expire in 1s
                     entry.set_created_ttl(now, 1)
 

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -333,10 +333,6 @@ class RecordManager:
                 updates.append(record)
                 removes.append(record)
 
-        import pprint
-
-        pprint.pprint(unique_types)
-
         if unique_types:
             self._async_mark_unique_cached_records_older_than_1s_to_expire(unique_types, msg.answers, now)
 

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -364,7 +364,7 @@ class RecordManager:
         # Since unique is set, all old records with that name, rrtype,
         # and rrclass that were received more than one second ago are declared
         # invalid, and marked to expire from the cache in one second.
-        for entry in self.cache.async_get_all_by_details(record.name, record.type, record.class_):
+        for entry in self.cache.async_all_by_details(record.name, record.type, record.class_):
             if record.created - entry.created > 1000 and entry not in answers_rrset:
                 # Expire in 1s
                 entry.set_created_ttl(now, 1)

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -141,7 +141,7 @@ class _QueryResponse:
         SHOULD instead multicast the response so as to keep all the peer
         caches up to date
         """
-        maybe_entry = self._cache.get(record)
+        maybe_entry = self._cache.async_get(record)
         return bool(maybe_entry and maybe_entry.is_recent(self._now))
 
     def _has_mcast_record_in_last_second(self, record: DNSRecord) -> bool:
@@ -149,7 +149,7 @@ class _QueryResponse:
         Protect the network against excessive packet flooding
         https://datatracker.ietf.org/doc/html/rfc6762#section-14
         """
-        maybe_entry = self._cache.get(record)
+        maybe_entry = self._cache.async_get(record)
         return bool(maybe_entry and self._now - maybe_entry.created < 1000)
 
 
@@ -320,7 +320,7 @@ class RecordManager:
                 # Since unique is set, all old records with that name, rrtype,
                 # and rrclass that were received more than one second ago are declared
                 # invalid, and marked to expire from the cache in one second.
-                for entry in self.cache.get_all_by_details(record.name, record.type, record.class_):
+                for entry in self.cache.async_get_all_by_details(record.name, record.type, record.class_):
                     if entry == record:
                         updated = False
                     if record.created - entry.created > 1000 and entry not in msg.answers:
@@ -328,7 +328,7 @@ class RecordManager:
                         entry.set_created_ttl(now, 1)
 
             expired = record.is_expired(now)
-            maybe_entry = self.cache.get(record)
+            maybe_entry = self.cache.async_get(record)
             if not expired:
                 if maybe_entry is not None:
                     maybe_entry.reset_ttl(record)

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -23,7 +23,7 @@
 import itertools
 from typing import Dict, List, Optional, Set, TYPE_CHECKING, Tuple, Union, cast
 
-from ._cache import _UniqueRecordsType, DNSCache
+from ._cache import DNSCache, _UniqueRecordsType
 from ._dns import DNSAddress, DNSPointer, DNSQuestion, DNSRRSet, DNSRecord
 from ._logger import log
 from ._protocol import DNSIncoming, DNSOutgoing

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -333,6 +333,10 @@ class RecordManager:
                 updates.append(record)
                 removes.append(record)
 
+        import pprint
+
+        pprint.pprint(unique_types)
+
         if unique_types:
             self._async_mark_unique_cached_records_older_than_1s_to_expire(unique_types, msg.answers, now)
 

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -324,8 +324,7 @@ class RecordManager:
                         address_adds.append(record)
                     else:
                         other_adds.append(record)
-                if not maybe_entry:
-                    updates.append(record)
+                updates.append(record)
             # This is likely a goodbye since the record is
             # expired and exists in the cache
             elif maybe_entry is not None:

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -141,7 +141,7 @@ class _QueryResponse:
         SHOULD instead multicast the response so as to keep all the peer
         caches up to date
         """
-        maybe_entry = self._cache.async_get(record)
+        maybe_entry = self._cache.async_get_unique(record)
         return bool(maybe_entry and maybe_entry.is_recent(self._now))
 
     def _has_mcast_record_in_last_second(self, record: DNSRecord) -> bool:
@@ -149,7 +149,7 @@ class _QueryResponse:
         Protect the network against excessive packet flooding
         https://datatracker.ietf.org/doc/html/rfc6762#section-14
         """
-        maybe_entry = self._cache.async_get(record)
+        maybe_entry = self._cache.async_get_unique(record)
         return bool(maybe_entry and self._now - maybe_entry.created < 1000)
 
 
@@ -328,7 +328,7 @@ class RecordManager:
                         entry.set_created_ttl(now, 1)
 
             expired = record.is_expired(now)
-            maybe_entry = self.cache.async_get(record)
+            maybe_entry = self.cache.async_get_unique(record)
             if not expired:
                 if maybe_entry is not None:
                     maybe_entry.reset_ttl(record)

--- a/zeroconf/_services/__init__.py
+++ b/zeroconf/_services/__init__.py
@@ -316,7 +316,7 @@ class _ServiceBrowserBase(RecordUpdateListener):
         ):
             self._pending_handlers[key] = state_change
 
-    def _process_record_update(self, now: float, record: DNSRecord) -> None:
+    def _async_process_record_update(self, now: float, record: DNSRecord) -> None:
         """Process a single record update from a batch of updates."""
         expired = record.is_expired(now)
 
@@ -340,12 +340,12 @@ class _ServiceBrowserBase(RecordUpdateListener):
             return
 
         # If its expired or already exists in the cache it cannot be updated.
-        if expired or self.zc.cache.get(record):
+        if expired or self.zc.cache.async_get(record):
             return
 
         if isinstance(record, DNSAddress):
             # Iterate through the DNSCache and callback any services that use this address
-            for service in self.zc.cache.entries_with_server(record.name):
+            for service in self.zc.cache.async_entries_with_server(record.name):
                 type_ = self._record_matching_type(service)
                 if type_:
                     self._enqueue_callback(ServiceStateChange.Updated, type_, service.name)
@@ -367,7 +367,7 @@ class _ServiceBrowserBase(RecordUpdateListener):
         This method will be run in the event loop.
         """
         for record in records:
-            self._process_record_update(now, record)
+            self._async_process_record_update(now, record)
 
     def async_update_records_complete(self) -> None:
         """Called when a record update has completed for all handlers.

--- a/zeroconf/_services/__init__.py
+++ b/zeroconf/_services/__init__.py
@@ -27,6 +27,7 @@ import warnings
 from collections import OrderedDict
 from typing import Any, Callable, Dict, List, Optional, Set, TYPE_CHECKING, Tuple, Union, cast
 
+from .._cache import _UniqueRecordsType
 from .._dns import DNSAddress, DNSPointer, DNSQuestion, DNSRecord, DNSService, DNSText
 from .._exceptions import BadTypeInNameException
 from .._protocol import DNSOutgoing
@@ -340,7 +341,7 @@ class _ServiceBrowserBase(RecordUpdateListener):
             return
 
         # If its expired or already exists in the cache it cannot be updated.
-        if expired or self.zc.cache.async_get_unique(record):
+        if expired or self.zc.cache.async_get_unique(cast(_UniqueRecordsType, record)):
             return
 
         if isinstance(record, DNSAddress):

--- a/zeroconf/_services/__init__.py
+++ b/zeroconf/_services/__init__.py
@@ -340,7 +340,7 @@ class _ServiceBrowserBase(RecordUpdateListener):
             return
 
         # If its expired or already exists in the cache it cannot be updated.
-        if expired or self.zc.cache.async_get(record):
+        if expired or self.zc.cache.async_get_unique(record):
             return
 
         if isinstance(record, DNSAddress):


### PR DESCRIPTION
The majority of our lookups happen in the event loop so there is no need
for them to be threadsafe. Now that the codebase is more clear about what
needs to be threadsafe and what does not need to be threadsafe we can use
the much faster non-threadsafe versions in the places where we are calling
from the event loop.

Supports https://github.com/jstasiak/python-zeroconf/issues/720