### PR TITLE
Switch to using DNSRRSet in RecordManager

### DIFF
--- a/zeroconf/_dns.py
+++ b/zeroconf/_dns.py
@@ -423,3 +423,10 @@ class DNSRRSet:
             self._lookup = {record: record for record in self._records}
         other = self._lookup.get(record)
         return bool(other and other.ttl > (record.ttl / 2))
+
+    def __contains__(self, record: DNSRecord) -> bool:
+        """Returns true if the rrset contains the record."""
+        if self._lookup is None:
+            # Build the hash table so we can lookup the record independent of the ttl
+            self._lookup = {record: record for record in self._records}
+        return record in self._lookup


### PR DESCRIPTION
- RRSet is able to do O(1) lookups of records assuming
  there are no collisions.

Builds on the test coverage added in https://github.com/jstasiak/python-zeroconf/pull/734