### PR TITLE
Remove second level caching from ServiceBrowsers

### DIFF
--- a/zeroconf/_services/__init__.py
+++ b/zeroconf/_services/__init__.py
@@ -237,7 +237,7 @@ def generate_service_query(
         )
     return _group_ptr_queries_with_known_answers(now, multicast, questions_with_known_answers)
 
-  
+
 def _service_state_changed_from_listener(listener: ServiceListener) -> Callable[..., None]:
     """Generate a service_state_changed handlers from a listener."""
 


### PR DESCRIPTION
- The ServiceBrowser had its own cache of the last time it
  saw a service which was reimplementing the DNSCache and
  presenting a source of truth problem that lead to unexpected
  queries when the two disagreed.

Fixes #720