### PR TITLE
Run ServiceBrowser queries in the event loop

### DIFF
--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -366,7 +366,7 @@ def test_backoff():
     # patch the zeroconf send
     # patch the zeroconf current_time_millis
     # patch the backoff limit to prevent test running forever
-    with unittest.mock.patch.object(zeroconf_browser, "send", send), unittest.mock.patch.object(
+    with unittest.mock.patch.object(zeroconf_browser, "async_send", send), unittest.mock.patch.object(
         _services_browser, "current_time_millis", current_time_millis
     ), unittest.mock.patch.object(_services_browser, "_BROWSER_BACKOFF_LIMIT", 10):
         # dummy service callback
@@ -459,7 +459,7 @@ def test_integration():
     # patch the zeroconf send
     # patch the zeroconf current_time_millis
     # patch the backoff limit to ensure we always get one query every 1/4 of the DNS TTL
-    with unittest.mock.patch.object(zeroconf_browser, "send", send), unittest.mock.patch.object(
+    with unittest.mock.patch.object(zeroconf_browser, "async_send", send), unittest.mock.patch.object(
         _services_browser, "current_time_millis", current_time_millis
     ), unittest.mock.patch.object(_services_browser, "_BROWSER_BACKOFF_LIMIT", int(expected_ttl / 4)):
         service_added = Event()

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -348,7 +348,7 @@ def test_backoff():
     zeroconf_browser = Zeroconf(interfaces=['127.0.0.1'])
 
     # we are going to patch the zeroconf send to check query transmission
-    old_send = zeroconf_browser.send
+    old_send = zeroconf_browser.async_send
 
     time_offset = 0.0
     start_time = time.time() * 1000
@@ -432,7 +432,7 @@ def test_integration():
     zeroconf_browser = Zeroconf(interfaces=['127.0.0.1'])
 
     # we are going to patch the zeroconf send to check packet sizes
-    old_send = zeroconf_browser.send
+    old_send = zeroconf_browser.async_send
 
     time_offset = 0.0
 

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -631,16 +631,25 @@ def test_service_browser_listeners_update_service():
     class MyServiceListener(r.ServiceListener):
         def add_service(self, zc, type_, name) -> None:
             nonlocal callbacks
+            import pprint
+
+            pprint.pprint(["mylisten", "add", type_, name])
             if name == registration_name:
                 callbacks.append(("add", type_, name))
 
         def remove_service(self, zc, type_, name) -> None:
             nonlocal callbacks
+            import pprint
+
+            pprint.pprint(["mylisten", "remove", type_, name])
             if name == registration_name:
                 callbacks.append(("remove", type_, name))
 
         def update_service(self, zc, type_, name) -> None:
             nonlocal callbacks
+            import pprint
+
+            pprint.pprint(["mylisten", "update", type_, name])
             if name == registration_name:
                 callbacks.append(("update", type_, name))
 

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -631,25 +631,16 @@ def test_service_browser_listeners_update_service():
     class MyServiceListener(r.ServiceListener):
         def add_service(self, zc, type_, name) -> None:
             nonlocal callbacks
-            import pprint
-
-            pprint.pprint(["mylisten", "add", type_, name])
             if name == registration_name:
                 callbacks.append(("add", type_, name))
 
         def remove_service(self, zc, type_, name) -> None:
             nonlocal callbacks
-            import pprint
-
-            pprint.pprint(["mylisten", "remove", type_, name])
             if name == registration_name:
                 callbacks.append(("remove", type_, name))
 
         def update_service(self, zc, type_, name) -> None:
             nonlocal callbacks
-            import pprint
-
-            pprint.pprint(["mylisten", "update", type_, name])
             if name == registration_name:
                 callbacks.append(("update", type_, name))
 

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -109,7 +109,11 @@ async def test_async_service_registration() -> None:
             calls.append(("update", type, name))
 
     listener = MyListener()
+    import pprint
+
+    pprint.pprint("here")
     aiozc.zeroconf.add_service_listener(type_, listener)
+    pprint.pprint("done add_service_listener")
 
     desc = {'path': '/~paulsm/'}
     info = ServiceInfo(

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -109,11 +109,8 @@ async def test_async_service_registration() -> None:
             calls.append(("update", type, name))
 
     listener = MyListener()
-    import pprint
 
-    pprint.pprint("here")
     aiozc.zeroconf.add_service_listener(type_, listener)
-    pprint.pprint("done add_service_listener")
 
     desc = {'path': '/~paulsm/'}
     info = ServiceInfo(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -82,7 +82,7 @@ class Names(unittest.TestCase):
         self.verify_name_change(zc, type_, name, server_count)
 
         # we are going to patch the zeroconf send to check packet sizes
-        old_send = zc.send
+        old_send = zc.async_send
 
         longest_packet_len = 0
         longest_packet = None  # type: Optional[r.DNSOutgoing]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -97,7 +97,7 @@ class Names(unittest.TestCase):
                 old_send(out, addr=addr, port=port)
 
         # patch the zeroconf send
-        with unittest.mock.patch.object(zc, "send", send):
+        with unittest.mock.patch.object(zc, "async_send", send):
 
             # dummy service callback
             def on_service_state_change(zeroconf, service_type, state_change, name):

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -291,7 +291,6 @@ class Zeroconf(QuietLogger):
         self.query_handler = QueryHandler(self.registry, self.cache)
         self.record_manager = RecordManager(self)
 
-        self.condition = threading.Condition()
         self.async_condition: Optional[asyncio.Condition] = None
         self.loop: Optional[asyncio.AbstractEventLoop] = None
         self._loop_thread: Optional[threading.Thread] = None
@@ -338,10 +337,9 @@ class Zeroconf(QuietLogger):
         return self.record_manager.listeners
 
     def wait(self, timeout: float) -> None:
-        """Calling thread waits for a given number of milliseconds or
-        until notified."""
-        with self.condition:
-            self.condition.wait(millis_to_seconds(timeout))
+        """Calling task waits for a given number of milliseconds or until notified."""
+        assert self.loop is not None
+        asyncio.run_coroutine_threadsafe(self.async_wait(timeout), self.loop).result()
 
     async def async_wait(self, timeout: float) -> None:
         """Calling task waits for a given number of milliseconds or until notified."""
@@ -360,11 +358,13 @@ class Zeroconf(QuietLogger):
 
     async def _async_notify_all(self) -> None:
         """Notify all async listeners."""
+        import pprint
+
+        pprint.pprint("_async_notify_all running")
         assert self.async_condition is not None
-        with self.condition:
-            self.condition.notify_all()
-            async with self.async_condition:
-                self.async_condition.notify_all()
+        async with self.async_condition:
+            self.async_condition.notify_all()
+        pprint.pprint("_async_notify_all finished")
 
     def get_service_info(self, type_: str, name: str, timeout: int = 3000) -> Optional[ServiceInfo]:
         """Returns network's service information for a particular

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -358,13 +358,9 @@ class Zeroconf(QuietLogger):
 
     async def _async_notify_all(self) -> None:
         """Notify all async listeners."""
-        import pprint
-
-        pprint.pprint("_async_notify_all running")
         assert self.async_condition is not None
         async with self.async_condition:
             self.async_condition.notify_all()
-        pprint.pprint("_async_notify_all finished")
 
     def get_service_info(self, type_: str, name: str, timeout: int = 3000) -> Optional[ServiceInfo]:
         """Returns network's service information for a particular

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -410,7 +410,7 @@ class RecordManager:
             return
         listener.async_update_records(self.zc, now, records)
         listener.async_update_records_complete()
-        self.zc.notify_all()
+        self.zc.async_notify_all()
 
     def remove_listener(self, listener: RecordUpdateListener) -> None:
         """Removes a listener."""

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -23,8 +23,8 @@
 import asyncio
 import contextlib
 import threading
-import warnings
 import queue
+import warnings
 from collections import OrderedDict
 from typing import Callable, Dict, List, Optional, Set, TYPE_CHECKING, Tuple, Union, cast
 

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -38,7 +38,7 @@ from .._services import (
     Signal,
     SignalRegistrationInterface,
 )
-from .._utils.aio import get_running_loop, wait_condition_or_timeout
+from .._utils.aio import get_best_available_queue, get_running_loop, wait_condition_or_timeout
 from .._utils.name import service_type_name
 from .._utils.time import current_time_millis, millis_to_seconds
 from ..const import (
@@ -420,7 +420,7 @@ class ServiceBrowser(_ServiceBrowserBase, threading.Thread):
     ) -> None:
         threading.Thread.__init__(self)
         super().__init__(zc, type_, handlers=handlers, listener=listener, addr=addr, port=port, delay=delay)
-        self.queue = queue.SimpleQueue()
+        self.queue = get_best_available_queue()
         self.daemon = True
         self.start()
         self.name = "zeroconf-ServiceBrowser-%s-%s" % (

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -228,6 +228,9 @@ class _ServiceBrowserBase(RecordUpdateListener):
     ) -> None:
         # Code to ensure we only do a single update message
         # Precedence is; Added, Remove, Update
+        import pprint
+
+        pprint.pprint(["_enqueue_callback", state_change, type_, name])
         key = (name, type_)
         if (
             state_change is ServiceStateChange.Added
@@ -305,6 +308,9 @@ class _ServiceBrowserBase(RecordUpdateListener):
             except KeyError:
                 return
             self._handlers_to_call[name_type] = state_change
+        import pprint
+
+        pprint.pprint(["handlers to call is now", self._handlers_to_call])
 
     def cancel(self) -> None:
         """Cancel the browser."""
@@ -346,7 +352,7 @@ class _ServiceBrowserBase(RecordUpdateListener):
 
         return millis_to_seconds(next_time - now)
 
-    async def async_create_browser_task(self) -> None:
+    async def async_browser_task(self) -> None:
         """Run the browser task."""
         await self.zc.async_wait_for_start()
         assert self.zc.async_condition is not None
@@ -359,7 +365,11 @@ class _ServiceBrowserBase(RecordUpdateListener):
                     # between when we checked above when we were not
                     # holding the condition
                     if not self._handlers_to_call:
+                        import pprint
+
+                        pprint.pprint(["Waiting until timeout", timeout])
                         await wait_condition_or_timeout(self.zc.async_condition, timeout)
+                        pprint.pprint(["Done Waiting until timeout", timeout])
 
             outs = self.generate_ready_queries()
             for out in outs:
@@ -369,9 +379,12 @@ class _ServiceBrowserBase(RecordUpdateListener):
                 continue
 
             (name_type, state_change) = self._handlers_to_call.popitem(False)
+            import pprint
+
+            pprint.pprint(["incoming event", (name_type, state_change)])
             if self.queue:
                 self.queue.put((name_type, state_change))
-                return
+                continue
 
             self._service_state_changed.fire(
                 zeroconf=self.zc,
@@ -417,11 +430,11 @@ class ServiceBrowser(_ServiceBrowserBase, threading.Thread):
         assert self.zc.loop is not None
         self._browser_task = cast(
             asyncio.Task,
-            asyncio.run_coroutine_threadsafe(self._async_create_browser_task(), self.zc.loop).result(),
+            asyncio.run_coroutine_threadsafe(self._async_browser_task(), self.zc.loop).result(),
         )
 
-    async def _async_create_browser_task(self) -> None:
-        asyncio.ensure_future(self.async_create_browser_task())
+    async def _async_browser_task(self) -> asyncio.Task:
+        return cast(asyncio.Task, asyncio.ensure_future(self.async_browser_task()))
 
     def cancel(self) -> None:
         """Cancel the browser."""
@@ -436,7 +449,13 @@ class ServiceBrowser(_ServiceBrowserBase, threading.Thread):
         """Run the browser thread."""
         assert self.queue is not None
         while True:
+            import pprint
+
+            pprint.pprint(["wait for event"])
             event = self.queue.get()
+            import pprint
+
+            pprint.pprint(["got event", event])
             if event is None:
                 return
             name_type, state_change = event

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -22,8 +22,8 @@
 
 import asyncio
 import contextlib
-import threading
 import queue
+import threading
 import warnings
 from collections import OrderedDict
 from typing import Callable, Dict, List, Optional, Set, TYPE_CHECKING, Tuple, Union, cast

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -228,9 +228,6 @@ class _ServiceBrowserBase(RecordUpdateListener):
     ) -> None:
         # Code to ensure we only do a single update message
         # Precedence is; Added, Remove, Update
-        import pprint
-
-        pprint.pprint(["_enqueue_callback", state_change, type_, name])
         key = (name, type_)
         if (
             state_change is ServiceStateChange.Added
@@ -308,9 +305,6 @@ class _ServiceBrowserBase(RecordUpdateListener):
             except KeyError:
                 return
             self._handlers_to_call[name_type] = state_change
-        import pprint
-
-        pprint.pprint(["handlers to call is now", self._handlers_to_call])
 
     def cancel(self) -> None:
         """Cancel the browser."""
@@ -365,11 +359,7 @@ class _ServiceBrowserBase(RecordUpdateListener):
                     # between when we checked above when we were not
                     # holding the condition
                     if not self._handlers_to_call:
-                        import pprint
-
-                        pprint.pprint(["Waiting until timeout", timeout])
                         await wait_condition_or_timeout(self.zc.async_condition, timeout)
-                        pprint.pprint(["Done Waiting until timeout", timeout])
 
             outs = self.generate_ready_queries()
             for out in outs:
@@ -379,9 +369,6 @@ class _ServiceBrowserBase(RecordUpdateListener):
                 continue
 
             (name_type, state_change) = self._handlers_to_call.popitem(False)
-            import pprint
-
-            pprint.pprint(["incoming event", (name_type, state_change)])
             if self.queue:
                 self.queue.put((name_type, state_change))
                 continue
@@ -435,9 +422,6 @@ class ServiceBrowser(_ServiceBrowserBase, threading.Thread):
             asyncio.Task,
             asyncio.run_coroutine_threadsafe(self._async_browser_task(), self.zc.loop).result(),
         )
-        import pprint
-
-        pprint.pprint("Finished startup")
 
     async def _async_browser_task(self) -> asyncio.Task:
         return cast(asyncio.Task, asyncio.ensure_future(self.async_browser_task()))
@@ -458,13 +442,7 @@ class ServiceBrowser(_ServiceBrowserBase, threading.Thread):
         """Run the browser thread."""
         assert self.queue is not None
         while True:
-            import pprint
-
-            pprint.pprint(["browser thread wait for event on the queue"])
             event = self.queue.get()
-            import pprint
-
-            pprint.pprint(["got event", event])
             if event is None:
                 return
             name_type, state_change = event

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -20,8 +20,11 @@
     USA
 """
 
+import asyncio
+import contextlib
 import threading
 import warnings
+import queue
 from collections import OrderedDict
 from typing import Callable, Dict, List, Optional, Set, TYPE_CHECKING, Tuple, Union, cast
 
@@ -35,6 +38,7 @@ from .._services import (
     Signal,
     SignalRegistrationInterface,
 )
+from .._utils.aio import wait_condition_or_timeout
 from .._utils.name import service_type_name
 from .._utils.time import current_time_millis, millis_to_seconds
 from ..const import (
@@ -180,6 +184,7 @@ class _ServiceBrowserBase(RecordUpdateListener):
         for check_type_ in self.types:
             # Will generate BadTypeInNameException on a bad name
             service_type_name(check_type_, strict=False)
+        self._browser_task: Optional[asyncio.Task] = None
         self.zc = zc
         self.addr = addr
         self.port = port
@@ -190,7 +195,7 @@ class _ServiceBrowserBase(RecordUpdateListener):
         self._pending_handlers: OrderedDict[Tuple[str, str], ServiceStateChange] = OrderedDict()
         self._handlers_to_call: OrderedDict[Tuple[str, str], ServiceStateChange] = OrderedDict()
         self._service_state_changed = Signal()
-
+        self.queue: Optional[queue.Queue] = None
         self.done = False
 
         if hasattr(handlers, 'add_service'):
@@ -341,6 +346,47 @@ class _ServiceBrowserBase(RecordUpdateListener):
 
         return millis_to_seconds(next_time - now)
 
+    async def async_create_browser_task(self) -> None:
+        """Run the browser task."""
+        await self.zc.async_wait_for_start()
+        assert self.zc.async_condition is not None
+        while True:
+            timeout = self._seconds_to_wait()
+            if timeout:
+                async with self.zc.async_condition:
+                    # We must check again while holding the condition
+                    # in case the other thread has added to _handlers_to_call
+                    # between when we checked above when we were not
+                    # holding the condition
+                    if not self._handlers_to_call:
+                        await wait_condition_or_timeout(self.zc.async_condition, timeout)
+
+            outs = self.generate_ready_queries()
+            for out in outs:
+                self.zc.async_send(out, addr=self.addr, port=self.port)
+
+            if not self._handlers_to_call:
+                continue
+
+            (name_type, state_change) = self._handlers_to_call.popitem(False)
+            if self.queue:
+                self.queue.put((name_type, state_change))
+                return
+
+            self._service_state_changed.fire(
+                zeroconf=self.zc,
+                service_type=name_type[1],
+                name=name_type[0],
+                state_change=state_change,
+            )
+
+    async def _async_cancel_browser(self) -> None:
+        """Cancel the browser."""
+        assert self._browser_task is not None
+        self._browser_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self._browser_task
+
 
 class ServiceBrowser(_ServiceBrowserBase, threading.Thread):
     """Used to browse for a service of a specific type.
@@ -361,42 +407,39 @@ class ServiceBrowser(_ServiceBrowserBase, threading.Thread):
     ) -> None:
         threading.Thread.__init__(self)
         super().__init__(zc, type_, handlers=handlers, listener=listener, addr=addr, port=port, delay=delay)
+        self.queue = queue.SimpleQueue()
         self.daemon = True
         self.start()
         self.name = "zeroconf-ServiceBrowser-%s-%s" % (
             '-'.join([type_[:-7] for type_ in self.types]),
             getattr(self, 'native_id', self.ident),
         )
+        assert self.zc.loop is not None
+        self._browser_task = cast(
+            asyncio.Task,
+            asyncio.run_coroutine_threadsafe(self._async_create_browser_task(), self.zc.loop).result(),
+        )
+
+    async def _async_create_browser_task(self) -> None:
+        asyncio.ensure_future(self.async_create_browser_task())
 
     def cancel(self) -> None:
         """Cancel the browser."""
+        assert self.zc.loop is not None
+        assert self.queue is not None
+        asyncio.run_coroutine_threadsafe(self._async_cancel_browser(), self.zc.loop).result()
         super().cancel()
+        self.queue.put(None)
         self.join()
 
     def run(self) -> None:
         """Run the browser thread."""
+        assert self.queue is not None
         while True:
-            timeout = self._seconds_to_wait()
-            if timeout:
-                with self.zc.condition:
-                    # We must check again while holding the condition
-                    # in case the other thread has added to _handlers_to_call
-                    # between when we checked above when we were not
-                    # holding the condition
-                    if not self._handlers_to_call:
-                        self.zc.condition.wait(timeout)
-
-            if self.zc.done or self.done:
+            event = self.queue.get()
+            if event is None:
                 return
-
-            outs = self.generate_ready_queries()
-            for out in outs:
-                self.zc.send(out, addr=self.addr, port=self.port)
-
-            if not self._handlers_to_call:
-                continue
-
-            (name_type, state_change) = self._handlers_to_call.popitem(False)
+            name_type, state_change = event
             self._service_state_changed.fire(
                 zeroconf=self.zc,
                 service_type=name_type[1],

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -429,7 +429,7 @@ class ServiceBrowser(_ServiceBrowserBase, threading.Thread):
         )
         assert self.zc.loop is not None
         if get_running_loop() == self.zc.loop:
-            self._browser_task = asyncio.ensure_future(self.async_browser_task())
+            self._browser_task = cast(asyncio.Task, asyncio.ensure_future(self.async_browser_task()))
             return
         self._browser_task = cast(
             asyncio.Task,

--- a/zeroconf/_utils/aio.py
+++ b/zeroconf/_utils/aio.py
@@ -22,7 +22,15 @@
 
 import asyncio
 import contextlib
+import queue
 from typing import Optional, Set, cast
+
+
+def get_best_available_queue() -> queue.Queue:
+    """Create the best available queue type."""
+    if hasattr(queue, "SimpleQueue"):
+        return queue.SimpleQueue()  # type: ignore  # pylint: disable=all
+    return queue.Queue()
 
 
 # Switch to asyncio.wait_for once https://bugs.python.org/issue39032 is fixed

--- a/zeroconf/aio.py
+++ b/zeroconf/aio.py
@@ -22,7 +22,7 @@
 import asyncio
 import contextlib
 from types import TracebackType  # noqa # used in type hints
-from typing import Awaitable, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import Awaitable, Callable, Dict, List, Optional, Tuple, Type, Union, cast
 
 from ._core import Zeroconf
 from ._exceptions import NonUniqueNameException
@@ -85,44 +85,12 @@ class AsyncServiceBrowser(_ServiceBrowserBase):
     ) -> None:
         self.aiozc = aiozc
         super().__init__(aiozc.zeroconf, type_, handlers, listener, addr, port, delay)  # type: ignore
-        self._browser_task = asyncio.ensure_future(self.async_run())
+        self._browser_task = cast(asyncio.Task, asyncio.ensure_future(self.async_create_browser_task()))
 
     async def async_cancel(self) -> None:
         """Cancel the browser."""
-        self.cancel()
-        self._browser_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await self._browser_task
-
-    async def async_run(self) -> None:
-        """Run the browser task."""
-        await self.aiozc.zeroconf.async_wait_for_start()
-        assert self.aiozc.zeroconf.async_condition is not None
-        while True:
-            timeout = self._seconds_to_wait()
-            if timeout:
-                async with self.aiozc.zeroconf.async_condition:
-                    # We must check again while holding the condition
-                    # in case the other thread has added to _handlers_to_call
-                    # between when we checked above when we were not
-                    # holding the condition
-                    if not self._handlers_to_call:
-                        await wait_condition_or_timeout(self.aiozc.zeroconf.async_condition, timeout)
-
-            outs = self.generate_ready_queries()
-            for out in outs:
-                self.aiozc.zeroconf.async_send(out, addr=self.addr, port=self.port)
-
-            if not self._handlers_to_call:
-                continue
-
-            (name_type, state_change) = self._handlers_to_call.popitem(False)
-            self._service_state_changed.fire(
-                zeroconf=self.aiozc,
-                service_type=name_type[1],
-                name=name_type[0],
-                state_change=state_change,
-            )
+        await self._async_cancel_browser()
+        super().cancel()
 
 
 class AsyncZeroconfServiceTypes(ZeroconfServiceTypes):

--- a/zeroconf/aio.py
+++ b/zeroconf/aio.py
@@ -29,7 +29,6 @@ from ._exceptions import NonUniqueNameException
 from ._services.browser import _ServiceBrowserBase
 from ._services.info import ServiceInfo, instance_name_from_service_info
 from ._services.types import ZeroconfServiceTypes
-from ._utils.aio import wait_condition_or_timeout
 from ._utils.net import IPVersion, InterfaceChoice, InterfacesType
 from ._utils.time import millis_to_seconds
 from .const import (
@@ -85,7 +84,7 @@ class AsyncServiceBrowser(_ServiceBrowserBase):
     ) -> None:
         self.aiozc = aiozc
         super().__init__(aiozc.zeroconf, type_, handlers, listener, addr, port, delay)  # type: ignore
-        self._browser_task = cast(asyncio.Task, asyncio.ensure_future(self.async_create_browser_task()))
+        self._browser_task = cast(asyncio.Task, asyncio.ensure_future(self.async_browser_task()))
 
     async def async_cancel(self) -> None:
         """Cancel the browser."""

--- a/zeroconf/aio.py
+++ b/zeroconf/aio.py
@@ -82,7 +82,6 @@ class AsyncServiceBrowser(_ServiceBrowserBase):
         port: int = _MDNS_PORT,
         delay: int = _BROWSER_TIME,
     ) -> None:
-        self.aiozc = aiozc
         super().__init__(aiozc.zeroconf, type_, handlers, listener, addr, port, delay)  # type: ignore
         self._browser_task = cast(asyncio.Task, asyncio.ensure_future(self.async_browser_task()))
 


### PR DESCRIPTION
- First step of coordinating multiple ServiceBrowser instances
  to solve the excessive queries documented in:
  https://github.com/jstasiak/python-zeroconf/issues/721

Supports #721