### PR TITLE
Drop AsyncServiceListener

### DIFF
--- a/examples/async_browser.py
+++ b/examples/async_browser.py
@@ -10,8 +10,8 @@ import asyncio
 import logging
 from typing import Any, Optional, cast
 
-from zeroconf import IPVersion, ServiceStateChange
-from zeroconf.aio import AsyncServiceBrowser, AsyncZeroconf, AsyncZeroconfServiceTypes
+from zeroconf import IPVersion, ServiceStateChange, Zeroconf
+from zeroconf.aio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf, AsyncZeroconfServiceTypes
 
 
 def async_on_service_state_change(
@@ -23,8 +23,9 @@ def async_on_service_state_change(
     asyncio.ensure_future(async_display_service_info(zeroconf, service_type, name))
 
 
-async def async_display_service_info(zeroconf: AsyncZeroconf, service_type: str, name: str) -> None:
-    info = await zeroconf.async_get_service_info(service_type, name)
+async def async_display_service_info(zeroconf: Zeroconf, service_type: str, name: str) -> None:
+    info = AsyncServiceInfo(service_type, name)
+    await info.async_request(zeroconf, 3000)
     print("Info from zeroconf.get_service_info: %r" % (info))
     if info:
         addresses = ["%s:%d" % (addr, cast(int, info.port)) for addr in info.parsed_addresses()]

--- a/examples/async_browser.py
+++ b/examples/async_browser.py
@@ -59,7 +59,7 @@ class AsyncRunner:
             )
 
         print("\nBrowsing %s service(s), press Ctrl-C to exit...\n" % services)
-        self.aiobrowser = AsyncServiceBrowser(self.aiozc, services, handlers=[async_on_service_state_change])
+        self.aiobrowser = AsyncServiceBrowser(self.aiozc.zeroconf, services, handlers=[async_on_service_state_change])
         while True:
             await asyncio.sleep(1)
 

--- a/examples/async_browser.py
+++ b/examples/async_browser.py
@@ -59,7 +59,9 @@ class AsyncRunner:
             )
 
         print("\nBrowsing %s service(s), press Ctrl-C to exit...\n" % services)
-        self.aiobrowser = AsyncServiceBrowser(self.aiozc.zeroconf, services, handlers=[async_on_service_state_change])
+        self.aiobrowser = AsyncServiceBrowser(
+            self.aiozc.zeroconf, services, handlers=[async_on_service_state_change]
+        )
         while True:
             await asyncio.sleep(1)
 

--- a/examples/async_browser.py
+++ b/examples/async_browser.py
@@ -15,7 +15,7 @@ from zeroconf.aio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf, A
 
 
 def async_on_service_state_change(
-    zeroconf: AsyncZeroconf, service_type: str, name: str, state_change: ServiceStateChange
+    zeroconf: Zeroconf, service_type: str, name: str, state_change: ServiceStateChange
 ) -> None:
     print("Service %s of type %s state changed: %s" % (name, service_type, state_change))
     if state_change is not ServiceStateChange.Added:

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -12,7 +12,7 @@ import unittest.mock
 
 import pytest
 
-from zeroconf.aio import AsyncServiceInfo, AsyncServiceListener, AsyncZeroconf, AsyncZeroconfServiceTypes
+from zeroconf.aio import AsyncServiceInfo, AsyncZeroconf, AsyncZeroconfServiceTypes
 from zeroconf import Zeroconf
 from zeroconf.const import _LISTENER_TIME
 from zeroconf._exceptions import BadTypeInNameException, NonUniqueNameException, ServiceNameAlreadyRegistered
@@ -433,16 +433,7 @@ async def test_async_service_browser() -> None:
 
     calls = []
 
-    with pytest.raises(NotImplementedError):
-        AsyncServiceListener().add_service(aiozc, "_type", "name._type")
-
-    with pytest.raises(NotImplementedError):
-        AsyncServiceListener().remove_service(aiozc, "_type", "name._type")
-
-    with pytest.raises(NotImplementedError):
-        AsyncServiceListener().update_service(aiozc, "_type", "name._type")
-
-    class MyListener(AsyncServiceListener):
+    class MyListener(ServiceListener):
         def add_service(self, aiozc: AsyncZeroconf, type: str, name: str) -> None:
             calls.append(("add", type, name))
 

--- a/zeroconf/aio.py
+++ b/zeroconf/aio.py
@@ -26,6 +26,7 @@ from typing import Awaitable, Callable, Dict, List, Optional, Tuple, Type, Union
 
 from ._core import Zeroconf
 from ._exceptions import NonUniqueNameException
+from ._services.services import ServiceListener
 from ._services.browser import _ServiceBrowserBase
 from ._services.info import ServiceInfo, instance_name_from_service_info
 from ._services.types import ZeroconfServiceTypes
@@ -45,20 +46,8 @@ __all__ = [
     "AsyncZeroconf",
     "AsyncServiceInfo",
     "AsyncServiceBrowser",
-    "AsyncServiceListener",
     "AsyncZeroconfServiceTypes",
 ]
-
-
-class AsyncServiceListener:
-    def add_service(self, aiozc: 'AsyncZeroconf', type_: str, name: str) -> None:
-        raise NotImplementedError()
-
-    def remove_service(self, aiozc: 'AsyncZeroconf', type_: str, name: str) -> None:
-        raise NotImplementedError()
-
-    def update_service(self, aiozc: 'AsyncZeroconf', type_: str, name: str) -> None:
-        raise NotImplementedError()
 
 
 class AsyncServiceInfo(ServiceInfo):
@@ -74,15 +63,15 @@ class AsyncServiceBrowser(_ServiceBrowserBase):
 
     def __init__(
         self,
-        aiozc: 'AsyncZeroconf',
+        zeroconf: 'Zeroconf',
         type_: Union[str, list],
-        handlers: Optional[Union[AsyncServiceListener, List[Callable[..., None]]]] = None,
-        listener: Optional[AsyncServiceListener] = None,
+        handlers: Optional[Union[ServiceListener, List[Callable[..., None]]]] = None,
+        listener: Optional[ServiceListener] = None,
         addr: Optional[str] = None,
         port: int = _MDNS_PORT,
         delay: int = _BROWSER_TIME,
     ) -> None:
-        super().__init__(aiozc.zeroconf, type_, handlers, listener, addr, port, delay)  # type: ignore
+        super().__init__(zeroconf, type_, handlers, listener, addr, port, delay)
         self._browser_task = cast(asyncio.Task, asyncio.ensure_future(self.async_browser_task()))
 
     async def async_cancel(self) -> None:
@@ -115,7 +104,7 @@ class AsyncZeroconfServiceTypes(ZeroconfServiceTypes):
         local_zc = aiozc or AsyncZeroconf(interfaces=interfaces, ip_version=ip_version)
         listener = cls()
         async_browser = AsyncServiceBrowser(
-            local_zc, _SERVICE_TYPE_ENUMERATION_NAME, listener=listener  # type: ignore
+            local_zc.zeroconf, _SERVICE_TYPE_ENUMERATION_NAME, listener=listener
         )
 
         # wait for responses
@@ -168,7 +157,7 @@ class AsyncZeroconf:
             ip_version=ip_version,
             apple_p2p=apple_p2p,
         )
-        self.async_browsers: Dict[AsyncServiceListener, AsyncServiceBrowser] = {}
+        self.async_browsers: Dict[ServiceListener, AsyncServiceBrowser] = {}
 
     async def _async_broadcast_service(self, info: ServiceInfo, interval: int, ttl: Optional[int]) -> None:
         """Send a broadcasts to announce a service at intervals."""
@@ -269,14 +258,14 @@ class AsyncZeroconf:
             return info
         return None
 
-    async def async_add_service_listener(self, type_: str, listener: AsyncServiceListener) -> None:
+    async def async_add_service_listener(self, type_: str, listener: ServiceListener) -> None:
         """Adds a listener for a particular service type.  This object
         will then have its add_service and remove_service methods called when
         services of that type become available and unavailable."""
         await self.async_remove_service_listener(listener)
-        self.async_browsers[listener] = AsyncServiceBrowser(self, type_, listener)
+        self.async_browsers[listener] = AsyncServiceBrowser(self.zeroconf, type_, listener)
 
-    async def async_remove_service_listener(self, listener: AsyncServiceListener) -> None:
+    async def async_remove_service_listener(self, listener: ServiceListener) -> None:
         """Removes a listener from the set that is currently listening."""
         if listener in self.async_browsers:
             await self.async_browsers[listener].async_cancel()

--- a/zeroconf/aio.py
+++ b/zeroconf/aio.py
@@ -26,7 +26,7 @@ from typing import Awaitable, Callable, Dict, List, Optional, Tuple, Type, Union
 
 from ._core import Zeroconf
 from ._exceptions import NonUniqueNameException
-from ._services.services import ServiceListener
+from ._services import ServiceListener
 from ._services.browser import _ServiceBrowserBase
 from ._services.info import ServiceInfo, instance_name_from_service_info
 from ._services.types import ZeroconfServiceTypes


### PR DESCRIPTION
- These are no longer needed as the base ServiceListener can
  now handle both cases

Closes https://github.com/jstasiak/python-zeroconf/issues/753

This is not a breaking change since these never shipped