### PR TITLE
Revert: Fix thread safety in _ServiceBrowser.update_records_complete (#708)

### DIFF
--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -296,15 +296,8 @@ class _ServiceBrowserBase(RecordUpdateListener):
 
         This method will be run in the event loop.
         """
-        # Cannot use .update here since can fail with
-        # RuntimeError: dictionary changed size during iteration
-        # for threaded ServiceBrowsers
-        while self._pending_handlers:
-            try:
-                (name_type, state_change) = self._pending_handlers.popitem(False)
-            except KeyError:
-                return
-            self._handlers_to_call[name_type] = state_change
+        self._handlers_to_call.update(self._pending_handlers)
+        self._pending_handlers.clear()
 
     def cancel(self) -> None:
         """Cancel the browser."""


### PR DESCRIPTION
- This guarding is no longer needed as the ServiceBrowser loop
  now runs in the event loop and the thread safety guard is no
  longer needed