### PR TITLE
Improve performance of parsing DNSIncoming by caching read_utf

### DIFF
--- a/zeroconf/_protocol.py
+++ b/zeroconf/_protocol.py
@@ -22,6 +22,7 @@
 
 import enum
 import struct
+from functools import lru_cache
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, Tuple, Union, cast
 
 
@@ -207,6 +208,7 @@ class DNSIncoming(DNSMessage, QuietLogger):
             if rec is not None:
                 self.answers.append(rec)
 
+    @lru_cache(maxsize=None)
     def read_utf(self, offset: int, length: int) -> str:
         """Reads a UTF-8 string of a given length from the packet"""
         return str(self.data[offset : offset + length], 'utf-8', 'replace')


### PR DESCRIPTION
Most packets have a lot of name compression so we can cache reading the
name.

#766
