### PR TITLE
Add a guard against the task list changing when shutting down

### DIFF
--- a/zeroconf/_utils/aio.py
+++ b/zeroconf/_utils/aio.py
@@ -23,7 +23,7 @@
 import asyncio
 import contextlib
 import queue
-from typing import Optional, List, Set, cast
+from typing import List, Optional, Set, cast
 
 
 def get_best_available_queue() -> queue.Queue:

--- a/zeroconf/_utils/aio.py
+++ b/zeroconf/_utils/aio.py
@@ -23,7 +23,7 @@
 import asyncio
 import contextlib
 import queue
-from typing import Optional, Set, cast
+from typing import Optional, List, Set, cast
 
 
 def get_best_available_queue() -> queue.Queue:
@@ -62,12 +62,13 @@ async def wait_event_or_timeout(event: asyncio.Event, timeout: float) -> None:
             await event_wait
 
 
-async def _get_all_tasks(loop: asyncio.AbstractEventLoop) -> Set[asyncio.Task]:
+async def _get_all_tasks(loop: asyncio.AbstractEventLoop) -> List[asyncio.Task]:
     """Return all tasks running."""
     await asyncio.sleep(0)  # flush out any call_soon_threadsafe
+    # Make a copy of the tasks in case they change during iteration
     if hasattr(asyncio, 'all_tasks'):
-        return cast(Set[asyncio.Task], asyncio.all_tasks(loop))  # type: ignore  # pylint: disable=no-member
-    return cast(Set[asyncio.Task], asyncio.Task.all_tasks(loop))  # type: ignore  # pylint: disable=no-member
+        return list(asyncio.all_tasks(loop))  # type: ignore  # pylint: disable=no-member
+    return list(asyncio.Task.all_tasks(loop))  # type: ignore  # pylint: disable=no-member
 
 
 async def _wait_for_loop_tasks(wait_tasks: Set[asyncio.Task]) -> None:
@@ -77,7 +78,7 @@ async def _wait_for_loop_tasks(wait_tasks: Set[asyncio.Task]) -> None:
 
 def shutdown_loop(loop: asyncio.AbstractEventLoop) -> None:
     """Wait for pending tasks and stop an event loop."""
-    pending_tasks = asyncio.run_coroutine_threadsafe(_get_all_tasks(loop), loop).result()
+    pending_tasks = set(asyncio.run_coroutine_threadsafe(_get_all_tasks(loop), loop).result())
     done_tasks = set(task for task in pending_tasks if not task.done())
     pending_tasks -= done_tasks
     if pending_tasks:


### PR DESCRIPTION
We try to shutdown tasks cleanly, but thats not always possible when shutting
down an asyncio event loop from sync since the task list can change and we
need to balance that with waiting too longer for shutdown. 

Its not too important that we wait for tasks since nothing is being stored or written, but
it is nice to have a clean shutdown when possible.

In this case we value fast shutdown over waiting for every task since shutdown
is expected to be idempotent and irreversible anyways.

Seen in the CI here https://github.com/jstasiak/python-zeroconf/pull/774/checks?check_run_id=2870615273

Fixes
```
zeroconf/_core.py:660: in close
    self._shutdown_threads()
zeroconf/_core.py:647: in _shutdown_threads
    shutdown_loop(self.loop)
zeroconf/_utils/aio.py:80: in shutdown_loop
    pending_tasks = asyncio.run_coroutine_threadsafe(_get_all_tasks(loop), loop).result()
/opt/hostedtoolcache/PyPy/3.6.12/x64/lib-python/3/concurrent/futures/_base.py:432: in result
    return self.__get_result()
/opt/hostedtoolcache/PyPy/3.6.12/x64/lib-python/3/concurrent/futures/_base.py:384: in __get_result
    raise self._exception
/opt/hostedtoolcache/PyPy/3.6.12/x64/lib-python/3/asyncio/tasks.py:180: in _step
    result = coro.send(None)
zeroconf/_utils/aio.py:70: in _get_all_tasks
    return cast(Set[asyncio.Task], asyncio.Task.all_tasks(loop))  # type: ignore  # pylint: disable=no-member
/opt/hostedtoolcache/PyPy/3.6.12/x64/lib-python/3/asyncio/tasks.py:66: in all_tasks
    return {t for t in cls._all_tasks if t._loop is loop}
/opt/hostedtoolcache/PyPy/3.6.12/x64/lib-python/3/asyncio/tasks.py:66: in <setcomp>
    return {t for t in cls._all_tasks if t._loop is loop}
```