### PR TITLE
Fix Responding to Address Queries (RFC6762 section 6.2)

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -16,7 +16,9 @@ from typing import List
 import zeroconf as r
 from zeroconf import ServiceInfo, Zeroconf, current_time_millis
 from zeroconf import const
+from zeroconf._dns import DNSRRSet
 from zeroconf.aio import AsyncZeroconf
+
 
 from . import _clear_cache, _inject_response
 
@@ -321,6 +323,57 @@ def test_aaaa_query():
     )
     assert multicast_out.answers[0][0].address == ipv6_address
     # unregister
+    zc.registry.remove(info)
+    zc.close()
+
+
+def test_a_and_aaaa_record_fate_sharing():
+    """Test that queries for AAAA always return A records in the additionals."""
+    zc = Zeroconf(interfaces=['127.0.0.1'])
+    type_ = "_a-and-aaaa-service._tcp.local."
+    name = "knownname"
+    registration_name = "%s.%s" % (name, type_)
+    desc = {'path': '/~paulsm/'}
+    server_name = "ash-2.local."
+    ipv6_address = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
+    ipv4_address = socket.inet_aton("10.0.1.2")
+    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, server_name, addresses=[ipv6_address, ipv4_address])
+    aaaa_record = info.dns_addresses(version=r.IPVersion.V6Only)[0]
+    a_record = info.dns_addresses(version=r.IPVersion.V4Only)[0]
+
+    zc.registry.add(info)
+
+    # Test AAAA query
+    generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
+    question = r.DNSQuestion(server_name, const._TYPE_AAAA, const._CLASS_IN)
+    generated.add_question(question)
+    packets = generated.packets()
+    _, multicast_out = zc.query_handler.async_response(
+        [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
+    )
+    answers = DNSRRSet([answer[0] for answer in multicast_out.answers])
+    additionals = DNSRRSet(multicast_out.additionals)
+    assert aaaa_record in answers
+    assert a_record in additionals
+    assert len(multicast_out.answers) == 1
+    assert len(multicast_out.additionals) == 1
+
+    # Test A query
+    generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
+    question = r.DNSQuestion(server_name, const._TYPE_A, const._CLASS_IN)
+    generated.add_question(question)
+    packets = generated.packets()
+    _, multicast_out = zc.query_handler.async_response(
+        [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
+    )
+    answers = DNSRRSet([answer[0] for answer in multicast_out.answers])
+    additionals = DNSRRSet(multicast_out.additionals)
+
+    assert a_record in answers
+    assert aaaa_record in additionals
+    assert len(multicast_out.answers) == 1
+    assert len(multicast_out.additionals) == 1
+    # unregister    
     zc.registry.remove(info)
     zc.close()
 

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -204,13 +204,13 @@ class QueryHandler:
     ) -> None:
         """Answer A/AAAA/ANY question."""
         for service in self.registry.get_infos_server(name):
-            answers = set()
-            additionals = set()
+            answers: List[DNSAddress] = []
+            additionals: Set[DNSRecord] = set()
             for dns_address in service.dns_addresses(created=now):
                 if dns_address.type != type_:
                     additionals.add(dns_address)
                 elif not known_answers.suppresses(dns_address):
-                    answers.add(dns_address)
+                    answers.append(dns_address)
             for answer in answers:
                 answer_set[answer] = additionals
 

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -204,9 +204,15 @@ class QueryHandler:
     ) -> None:
         """Answer A/AAAA/ANY question."""
         for service in self.registry.get_infos_server(name):
-            for dns_address in service.dns_addresses(version=_TYPE_TO_IP_VERSION[type_], created=now):
-                if not known_answers.suppresses(dns_address):
-                    answer_set[dns_address] = set()
+            answers = set()
+            additionals = set()
+            for dns_address in service.dns_addresses(created=now):
+                if dns_address.type != type_:
+                    additionals.add(dns_address)
+                elif not known_answers.suppresses(dns_address):
+                    answers.add(dns_address)
+            for answer in answers:
+                answer_set[answer] = additionals
 
     def _answer_question(
         self,


### PR DESCRIPTION
- When responding to address queries we now always include
  other record types (AAAA when asked A, A when asked AAAA)
  in the additionals field to provide fate sharing

- This does not implement NSEC records

fixes #771