### PR TITLE
Drop utf cache from _dns

### DIFF
--- a/zeroconf/_protocol.py
+++ b/zeroconf/_protocol.py
@@ -93,7 +93,6 @@ class DNSIncoming(DNSMessage, QuietLogger):
         self.num_additionals = 0
         self.valid = False
         self.now = current_time_millis()
-        self._utf_cache: Dict[Tuple[int, int], str] = {}
 
         try:
             self.read_header()
@@ -210,13 +209,7 @@ class DNSIncoming(DNSMessage, QuietLogger):
 
     def read_utf(self, offset: int, length: int) -> str:
         """Reads a UTF-8 string of a given length from the packet"""
-        key = (offset, length)
-        cached = self._utf_cache.get(key)
-        if cached is not None:
-            return cached
-        decoded = str(self.data[offset : offset + length], 'utf-8', 'replace')
-        self._utf_cache[key] = decoded
-        return decoded
+        return str(self.data[offset : offset + length], 'utf-8', 'replace')
 
     def read_name(self) -> str:
         """Reads a domain name from the packet"""


### PR DESCRIPTION
- The cache did not make enough difference to justify the additional
  complexity after additional testing was done