### PR TITLE
Ensure the queue is created before adding listeners to ServiceBrowser

### DIFF
--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -417,11 +417,11 @@ class ServiceBrowser(_ServiceBrowserBase, threading.Thread):
         port: int = _MDNS_PORT,
         delay: int = _BROWSER_TIME,
     ) -> None:
+        threading.Thread.__init__(self)
+        super().__init__(zc, type_, handlers=handlers, listener=listener, addr=addr, port=port, delay=delay)
         assert self.zc.loop is not None
         if not self.zc.loop.is_running():
             raise RuntimeError("The event loop is not running")
-        threading.Thread.__init__(self)
-        super().__init__(zc, type_, handlers=handlers, listener=listener, addr=addr, port=port, delay=delay)
         # Add the queue before the listener is installed in _setup
         # to ensure that events run in the dedicated thread and do
         # not block the event loop

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -419,7 +419,7 @@ class ServiceBrowser(_ServiceBrowserBase, threading.Thread):
     ) -> None:
         assert zc.loop is not None
         if not zc.loop.is_running():
-            raise RuntimeError("The event loop is not running")    
+            raise RuntimeError("The event loop is not running")
         threading.Thread.__init__(self)
         super().__init__(zc, type_, handlers=handlers, listener=listener, addr=addr, port=port, delay=delay)
         # Add the queue before the listener is installed in _setup

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -430,7 +430,7 @@ class ServiceBrowser(_ServiceBrowserBase, threading.Thread):
         self.start()
         self._setup()
         # Start queries after the listener is installed in _setup
-        self.zc.loop.call_soon_threadsafe(self._async_start_browser)
+        zc.loop.call_soon_threadsafe(self._async_start_browser)
         self.name = "zeroconf-ServiceBrowser-%s-%s" % (
             '-'.join([type_[:-7] for type_ in self.types]),
             getattr(self, 'native_id', self.ident),

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -417,11 +417,11 @@ class ServiceBrowser(_ServiceBrowserBase, threading.Thread):
         port: int = _MDNS_PORT,
         delay: int = _BROWSER_TIME,
     ) -> None:
+        assert zc.loop is not None
+        if not zc.loop.is_running():
+            raise RuntimeError("The event loop is not running")    
         threading.Thread.__init__(self)
         super().__init__(zc, type_, handlers=handlers, listener=listener, addr=addr, port=port, delay=delay)
-        assert self.zc.loop is not None
-        if not self.zc.loop.is_running():
-            raise RuntimeError("The event loop is not running")
         # Add the queue before the listener is installed in _setup
         # to ensure that events run in the dedicated thread and do
         # not block the event loop

--- a/zeroconf/aio.py
+++ b/zeroconf/aio.py
@@ -72,8 +72,9 @@ class AsyncServiceBrowser(_ServiceBrowserBase):
         delay: int = _BROWSER_TIME,
     ) -> None:
         super().__init__(zeroconf, type_, handlers, listener, addr, port, delay)
-        self._browser_task = cast(asyncio.Task, asyncio.ensure_future(self.async_browser_task()))
         self._setup()
+        # Start queries after the listener is installed in _setup
+        self._browser_task = cast(asyncio.Task, asyncio.ensure_future(self.async_browser_task()))
 
     async def async_cancel(self) -> None:
         """Cancel the browser."""

--- a/zeroconf/aio.py
+++ b/zeroconf/aio.py
@@ -73,6 +73,7 @@ class AsyncServiceBrowser(_ServiceBrowserBase):
     ) -> None:
         super().__init__(zeroconf, type_, handlers, listener, addr, port, delay)
         self._browser_task = cast(asyncio.Task, asyncio.ensure_future(self.async_browser_task()))
+        self._setup()
 
     async def async_cancel(self) -> None:
         """Cancel the browser."""


### PR DESCRIPTION
- The callback from the listener could generate an event that would
  fire in async context that should have gone to the queue which
  could result in the consumer running a sync call in the event loop
  and blocking it.

Fixes #783