### PR TITLE
Add support for requesting QU questions to ServiceBrowser and ServiceInfo

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -33,6 +33,7 @@ from ._dns import (  # noqa # import needed for backwards compat
     DNSRecord,
     DNSService,
     DNSText,
+    DNSQuestionType,
 )
 from ._logger import QuietLogger, log  # noqa # import needed for backwards compat
 from ._exceptions import (  # noqa # import needed for backwards compat
@@ -84,7 +85,7 @@ __license__ = 'LGPL'
 
 __all__ = [
     "__version__",
-    "DNSOutgoing",
+    "DNSQuestionType",
     "Zeroconf",
     "ServiceInfo",
     "ServiceBrowser",

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -32,7 +32,7 @@ from types import TracebackType  # noqa # used in type hints
 from typing import Dict, List, Optional, Tuple, Type, Union, cast
 
 from ._cache import DNSCache
-from ._dns import DNSQuestion
+from ._dns import DNSQuestion, DNSQuestionType
 from ._exceptions import NonUniqueNameException
 from ._handlers import QueryHandler, RecordManager
 from ._history import QuestionHistory
@@ -360,12 +360,14 @@ class Zeroconf(QuietLogger):
         self.notify_event.set()
         self.notify_event.clear()
 
-    def get_service_info(self, type_: str, name: str, timeout: int = 3000) -> Optional[ServiceInfo]:
+    def get_service_info(
+        self, type_: str, name: str, timeout: int = 3000, question_type: Optional[DNSQuestionType] = None
+    ) -> Optional[ServiceInfo]:
         """Returns network's service information for a particular
         name and type, or None if no service matches by the timeout,
         which defaults to 3 seconds."""
         info = ServiceInfo(type_, name)
-        if info.request(self, timeout):
+        if info.request(self, timeout, question_type):
             return info
         return None
 

--- a/zeroconf/_dns.py
+++ b/zeroconf/_dns.py
@@ -20,6 +20,7 @@
     USA
 """
 
+import enum
 import socket
 from typing import Any, Dict, Iterable, Optional, TYPE_CHECKING, Tuple, Union, cast
 
@@ -47,6 +48,19 @@ _NAME_COMPRESSION_MIN_SIZE = _LEN_BYTE * 2
 if TYPE_CHECKING:
     # https://github.com/PyCQA/pylint/issues/3525
     from ._protocol import DNSIncoming, DNSOutgoing  # pylint: disable=cyclic-import
+
+
+@enum.unique
+class DNSQuestionType(enum.Enum):
+    """An MDNS question type.
+
+    "QU" - questions requesting unicast responses
+    "QM" - questions requesting multicast responses
+    https://datatracker.ietf.org/doc/html/rfc6762#section-5.4
+    """
+
+    QU = 1
+    QM = 2
 
 
 def dns_entry_matches(record: 'DNSEntry', key: str, type_: int, class_: int) -> bool:

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -30,7 +30,7 @@ from collections import OrderedDict
 from typing import Callable, Dict, List, Optional, Set, TYPE_CHECKING, Tuple, Union, cast
 
 from .._cache import _UniqueRecordsType
-from .._dns import DNSAddress, DNSPointer, DNSQuestion, DNSRecord
+from .._dns import DNSAddress, DNSPointer, DNSQuestion, DNSQuestionType, DNSRecord
 from .._logger import log
 from .._protocol import DNSOutgoing
 from .._services import (
@@ -130,12 +130,18 @@ def _group_ptr_queries_with_known_answers(
 
 
 def generate_service_query(
-    zc: 'Zeroconf', now: float, types_: List[str], multicast: bool = True
+    zc: 'Zeroconf',
+    now: float,
+    types_: List[str],
+    multicast: bool = True,
+    question_type: Optional[DNSQuestionType] = None,
 ) -> List[DNSOutgoing]:
     """Generate a service query for sending with zeroconf.send."""
     questions_with_known_answers: _QuestionWithKnownAnswers = {}
+    qu_question = not multicast if question_type is None else question_type == DNSQuestionType.QU
     for type_ in types_:
         question = DNSQuestion(type_, _TYPE_PTR, _CLASS_IN)
+        question.unicast = qu_question
         known_answers = set(
             cast(DNSPointer, record)
             for record in zc.cache.get_all_by_details(type_, _TYPE_PTR, _CLASS_IN)
@@ -186,8 +192,25 @@ class _ServiceBrowserBase(RecordUpdateListener):
         addr: Optional[str] = None,
         port: int = _MDNS_PORT,
         delay: int = _BROWSER_TIME,
+        question_type: Optional[DNSQuestionType] = None,
     ) -> None:
-        """Creates a browser for a specific type"""
+        """Used to browse for a service for specific type(s).
+
+        Constructor parameters are as follows:
+
+        * `zc`: A Zeroconf instance
+        * `type_`: fully qualified service type name
+        * `handler`: ServiceListener or Callable that knows how to process ServiceStateChange events
+        * `listener`: ServiceListener
+        * `addr`: address to send queries (will default to multicast)
+        * `port`: port to send queries (will default to mdns 5353)
+        * `delay`: The initial delay between answering questions
+        * `question_type`: The type of questions to ask (DNSQuestionType.QM or DNSQuestionType.QU)
+
+        The listener object will have its add_service() and
+        remove_service() methods called when this browser
+        discovers changes in the services availability.
+        """
         assert handlers or listener, 'You need to specify at least one handler'
         self.types: Set[str] = set(type_ if isinstance(type_, list) else [type_])
         for check_type_ in self.types:
@@ -198,6 +221,7 @@ class _ServiceBrowserBase(RecordUpdateListener):
         self.addr = addr
         self.port = port
         self.multicast = self.addr in (None, _MDNS_ADDR, _MDNS_ADDR6)
+        self.question_type = question_type
         self._next_time: Dict[str, float] = {}
         self._delay: Dict[str, float] = {check_type_: delay for check_type_ in self.types}
         self._pending_handlers: OrderedDict[Tuple[str, str], ServiceStateChange] = OrderedDict()
@@ -370,7 +394,7 @@ class _ServiceBrowserBase(RecordUpdateListener):
             self._next_time[type_] = now + self._delay[type_]
             self._delay[type_] = min(_BROWSER_BACKOFF_LIMIT * 1000, self._delay[type_] * 2)
 
-        return generate_service_query(self.zc, now, ready_types, self.multicast)
+        return generate_service_query(self.zc, now, ready_types, self.multicast, self.question_type)
 
     def _millis_to_wait(self, now: float) -> Optional[float]:
         """Returns the number of milliseconds to wait for the next event."""
@@ -416,12 +440,13 @@ class ServiceBrowser(_ServiceBrowserBase, threading.Thread):
         addr: Optional[str] = None,
         port: int = _MDNS_PORT,
         delay: int = _BROWSER_TIME,
+        question_type: Optional[DNSQuestionType] = None,
     ) -> None:
         assert zc.loop is not None
         if not zc.loop.is_running():
             raise RuntimeError("The event loop is not running")
         threading.Thread.__init__(self)
-        super().__init__(zc, type_, handlers=handlers, listener=listener, addr=addr, port=port, delay=delay)
+        super().__init__(zc, type_, handlers, listener, addr, port, delay, question_type)
         # Add the queue before the listener is installed in _setup
         # to ensure that events run in the dedicated thread and do
         # not block the event loop


### PR DESCRIPTION
Callers may wish to ask "QU" questions as described in
https://datatracker.ietf.org/doc/html/rfc6762#section-5.4

Supports https://github.com/jstasiak/python-zeroconf/issues/702