### PR TITLE
Ensure outgoing ServiceBrowser questions are seen by the question history

### DIFF
--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -1045,4 +1045,15 @@ async def test_generate_service_query_suppress_duplicate_questions():
     # We do not suppress QU queries ever
     outs = _services_browser.generate_service_query(zc, now, [name], multicast=False)
     assert outs
+
+    zc.question_history.async_expire(now + 1000)
+    # No suppression after clearing the history
+    outs = _services_browser.generate_service_query(zc, now, [name], multicast=True)
+    assert outs
+
+    # The previous query we just sent is still remembered and
+    # the next one is suppressed
+    outs = _services_browser.generate_service_query(zc, now, [name], multicast=True)
+    assert not outs
+
     await aiozc.async_close()

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -151,6 +151,7 @@ def generate_service_query(
             log.debug("Asking %s was suppressed by the question history", question)
             continue
         questions_with_known_answers[question] = known_answers
+        zc.question_history.add_question_at_time(question, now, cast(Set[DNSRecord], known_answers))
 
     return _group_ptr_queries_with_known_answers(now, multicast, questions_with_known_answers)
 


### PR DESCRIPTION
- Ensures duplicate question suppression between ServiceBrowsers that
  are running in the same zeroconf instances if they become
  synchronized (which is likely due to like TTL expire time)

Fixes #789