### PR TITLE
Make DNSHinfo and DNSAddress use the same match order as DNSPointer and DNSText

### DIFF
--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -508,9 +508,16 @@ def test_multiple_addresses():
             assert info.parsed_addresses() == [address_parsed, address_v6_parsed, address_v6_ll_parsed]
             assert info.parsed_addresses(r.IPVersion.V4Only) == [address_parsed]
             assert info.parsed_addresses(r.IPVersion.V6Only) == [address_v6_parsed, address_v6_ll_parsed]
-            assert info.parsed_scoped_addresses() == [address_v6_ll_scoped_parsed, address_parsed, address_v6_parsed]
+            assert info.parsed_scoped_addresses() == [
+                address_v6_ll_scoped_parsed,
+                address_parsed,
+                address_v6_parsed,
+            ]
             assert info.parsed_scoped_addresses(r.IPVersion.V4Only) == [address_parsed]
-            assert info.parsed_scoped_addresses(r.IPVersion.V6Only) == [address_v6_ll_scoped_parsed, address_v6_parsed]
+            assert info.parsed_scoped_addresses(r.IPVersion.V6Only) == [
+                address_v6_ll_scoped_parsed,
+                address_v6_parsed,
+            ]
 
 
 # This test uses asyncio because it needs to access the cache directly

--- a/zeroconf/_dns.py
+++ b/zeroconf/_dns.py
@@ -267,9 +267,9 @@ class DNSAddress(DNSRecord):
         """Tests equality on address"""
         return (
             isinstance(other, DNSAddress)
-            and DNSEntry.__eq__(self, other)
             and self.address == other.address
             and self.scope_id == other.scope_id
+            and DNSEntry.__eq__(self, other)
         )
 
     def __hash__(self) -> int:
@@ -310,9 +310,9 @@ class DNSHinfo(DNSRecord):
         """Tests equality on cpu and os"""
         return (
             isinstance(other, DNSHinfo)
-            and DNSEntry.__eq__(self, other)
             and self.cpu == other.cpu
             and self.os == other.os
+            and DNSEntry.__eq__(self, other)
         )
 
     def __hash__(self) -> int:


### PR DESCRIPTION
We want to check the data that is most likely to be unique first
so we can reject the __eq__ as soon as possible.

https://github.com/jstasiak/python-zeroconf/pull/343#discussion_r656397252

closes https://github.com/jstasiak/python-zeroconf/issues/807