### PR TITLE
New ServiceBrowsers now request QU in the first outgoing when unspecified

### DIFF
--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -571,7 +571,7 @@ def test_asking_default_is_asking_qm_questions_after_the_first_qu():
         def on_service_state_change(zeroconf, service_type, state_change, name):
             pass
 
-        browser = ServiceBrowser(zeroconf_browser, type_, [on_service_state_change], delay=100)
+        browser = ServiceBrowser(zeroconf_browser, type_, [on_service_state_change], delay=5)
         time.sleep(millis_to_seconds(_services_browser._FIRST_QUERY_DELAY_RANDOM_INTERVAL[1] + 120 + 5))
         try:
             assert first_outgoing.questions[0].unicast == True


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc6762#section-5.4

When we start a ServiceBrowser and zeroconf has just started up, the known
answer list will be small. By asking a QU question first, it is likely
that we have a large known answer list by the time we ask the QM question
a second later (current default which is likely too low but would be
a breaking change to increase). This reduces the amount of traffic on
the network, and has the secondary advantage that most responders will
answer a QU question without the typical delay answering QM questions.