### PR TITLE
Only wake up the query loop when there is a change in the next query time

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,31 @@ See examples directory for more.
 Changelog
 =========
 
+0.32.0 Beta 4
+=============
+
+* Simplify wait_event_or_timeout (#810) @bdraco
+
+  This function always did the same thing on timeout and
+  wait complete so we can use the same callback.  This
+  solves the CI failing due to the test coverage flapping
+  back and forth as the timeout would rarely happen.
+
+* Make DNSHinfo and DNSAddress use the same match order as DNSPointer and DNSText (#808) @bdraco
+
+  We want to check the data that is most likely to be unique first
+  so we can reject the __eq__ as soon as possible.
+
+* Qualify IPv6 link-local addresses with scope_id (#343) @ibygrave
+
+  When a service is advertised on an IPv6 address where
+  the scope is link local, i.e. fe80::/64 (see RFC 4007)
+  the resolved IPv6 address must be extended with the
+  scope_id that identifies through the "%" symbol the
+  local interface to be used when routing to that address.
+  A new API `parsed_scoped_addresses()` is provided to
+  return qualified addresses to avoid breaking compatibility
+  on the existing parsed_addresses().
 
 0.32.0 Beta 3
 =============

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -475,15 +475,7 @@ def test_backoff(suppresses_mock):
             expected_query_time = 0.0
             while True:
                 sleep_count += 1
-                for _ in range(2):
-                    # If the browser thread is starting up
-                    # its possible we notify before the initial sleep
-                    # which means the test will fail so we need to d
-                    # this twice to eliminate the race condition
-                    zeroconf_browser.loop.call_soon_threadsafe(
-                        browser.query_scheduler.reschedule_type, type_, 0
-                    )
-                    got_query.wait(0.1)
+                got_query.wait(0.1)
                 if time_offset == expected_query_time:
                     assert got_query.is_set()
                     got_query.clear()
@@ -502,6 +494,7 @@ def test_backoff(suppresses_mock):
                 else:
                     assert not got_query.is_set()
                 time_offset += initial_query_interval
+                zeroconf_browser.loop.call_soon_threadsafe(browser.query_scheduler.set_schedule_changed)
 
         finally:
             browser.cancel()
@@ -725,7 +718,7 @@ def test_integration():
             while nbr_answers < test_iterations:
                 # Increase simulated time shift by 1/4 of the TTL in seconds
                 time_offset += expected_ttl / 4
-                zeroconf_browser.loop.call_soon_threadsafe(browser.query_scheduler.reschedule_type, type_, 0)
+                zeroconf_browser.loop.call_soon_threadsafe(browser.query_scheduler.set_schedule_changed)
                 sleep_count += 1
                 got_query.wait(0.5)
                 # Prevent the test running indefinitely in an error condition

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -480,8 +480,10 @@ def test_backoff(suppresses_mock):
                     # its possible we notify before the initial sleep
                     # which means the test will fail so we need to d
                     # this twice to eliminate the race condition
-                    zeroconf_browser.notify_all()
-                    got_query.wait(0.05)
+                    zeroconf_browser.loop.call_soon_threadsafe(
+                        browser.query_scheduler.reschedule_type, type_, 0
+                    )
+                    got_query.wait(0.1)
                 if time_offset == expected_query_time:
                     assert got_query.is_set()
                     got_query.clear()
@@ -718,7 +720,7 @@ def test_integration():
             while nbr_answers < test_iterations:
                 # Increase simulated time shift by 1/4 of the TTL in seconds
                 time_offset += expected_ttl / 4
-                zeroconf_browser.notify_all()
+                zeroconf_browser.loop.call_soon_threadsafe(browser.query_scheduler.reschedule_type, type_, 0)
                 sleep_count += 1
                 got_query.wait(0.5)
                 # Prevent the test running indefinitely in an error condition

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -223,7 +223,8 @@ class QueryScheduler:
         self._next_time[type_] = next_time
         self.set_schedule_changed()
 
-    def set_schedule_changed(self):
+    def set_schedule_changed(self) -> None:
+        """Set the event to unblock async_wait_ready to make sure the adjusted next time is seen."""
         assert self._schedule_changed_event is not None
         self._schedule_changed_event.set()
         self._schedule_changed_event.clear()

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -194,7 +194,7 @@ class QueryScheduler:
         self,
         types: Set[str],
         delay: int = _BROWSER_TIME,
-        first_delay_interval=_FIRST_QUERY_DELAY_RANDOM_INTERVAL,
+        first_delay_interval: Tuple[int, int] = _FIRST_QUERY_DELAY_RANDOM_INTERVAL,
     ):
         self._schedule_changed_event: Optional[asyncio.Event] = None
         self._types = types

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -228,7 +228,7 @@ class QueryScheduler:
         return None if next_time <= now else next_time - now
 
     def reschedule_type(self, type_: str, next_time: float) -> None:
-        """Rescheudle the query for a type to happen sooner."""
+        """Reschedule the query for a type to happen sooner."""
         if next_time >= self._next_time[type_]:
             return
 

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -194,12 +194,12 @@ class QueryScheduler:
         self,
         types: Set[str],
         delay: int,
-        first_delay_interval: Tuple[int, int],
+        first_random_delay_interval: Tuple[int, int],
     ):
         self._schedule_changed_event: Optional[asyncio.Event] = None
         self._types = types
         self._next_time: Dict[str, float] = {}
-        self._first_delay_interval = first_delay_interval
+        self._first_random_delay_interval = first_random_delay_interval
         self._delay: Dict[str, float] = {check_type_: delay for check_type_ in self._types}
 
     def start(self, now: float) -> None:
@@ -217,7 +217,7 @@ class QueryScheduler:
         also delay the first query of the series by a randomly chosen amount
         in the range 20-120 ms.
         """
-        delay = millis_to_seconds(random.randint(*self._first_delay_interval))
+        delay = millis_to_seconds(random.randint(*self._first_random_delay_interval))
         next_time = now + delay
         self._next_time = {check_type_: next_time for check_type_ in self._types}
 

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -221,6 +221,9 @@ class QueryScheduler:
             return
 
         self._next_time[type_] = next_time
+        self.set_schedule_changed()
+
+    def set_schedule_changed(self):
         assert self._schedule_changed_event is not None
         self._schedule_changed_event.set()
         self._schedule_changed_event.clear()

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -439,7 +439,7 @@ class _ServiceBrowserBase(RecordUpdateListener):
         now = current_time_millis()
         ready_types = self.query_scheduler.ready_types(now)
         if not ready_types:
-            return
+            return []
 
         # If they did not specify and this is the first request, ask QU questions
         # https://datatracker.ietf.org/doc/html/rfc6762#section-5.4 since we are
@@ -455,10 +455,12 @@ class _ServiceBrowserBase(RecordUpdateListener):
         while True:
             await self.query_scheduler.async_wait_ready()
             outs = self._generate_ready_queries(first_request)
-            if outs:
-                first_request = False
-                for out in outs:
-                    self.zc.async_send(out, addr=self.addr, port=self.port)
+            if not outs:
+                continue
+
+            first_request = False
+            for out in outs:
+                self.zc.async_send(out, addr=self.addr, port=self.port)
 
     async def _async_cancel_browser(self) -> None:
         """Cancel the browser."""

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -184,6 +184,12 @@ def _service_state_changed_from_listener(listener: ServiceListener) -> Callable[
 
 
 class QueryScheduler:
+    """Schedule outgoing PTR queries for Continuous Multicast DNS Querying
+
+    https://datatracker.ietf.org/doc/html/rfc6762#section-5.2
+
+    """
+
     def __init__(self, types: Set[str], delay: int = _BROWSER_TIME):
         self._schedule_changed_event: Optional[asyncio.Event] = None
         self._types = types

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -193,8 +193,8 @@ class QueryScheduler:
     def __init__(
         self,
         types: Set[str],
-        delay: int = _BROWSER_TIME,
-        first_delay_interval: Tuple[int, int] = _FIRST_QUERY_DELAY_RANDOM_INTERVAL,
+        delay: int,
+        first_delay_interval: Tuple[int, int],
     ):
         self._schedule_changed_event: Optional[asyncio.Event] = None
         self._types = types
@@ -310,7 +310,7 @@ class _ServiceBrowserBase(RecordUpdateListener):
         self.question_type = question_type
         self._pending_handlers: OrderedDict[Tuple[str, str], ServiceStateChange] = OrderedDict()
         self._service_state_changed = Signal()
-        self.query_scheduler = QueryScheduler(self.types, delay)
+        self.query_scheduler = QueryScheduler(self.types, delay, _FIRST_QUERY_DELAY_RANDOM_INTERVAL)
         self.queue: Optional[queue.Queue] = None
         self.done = False
 

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -242,7 +242,7 @@ class QueryScheduler:
         self._schedule_changed_event.clear()
 
     def process_ready_types(self, now: float) -> List[str]:
-        """Generate the service browser query for any type that is due and schedule the next time."""
+        """Generate a list of ready types that is due and schedule the next time."""
         if self.millis_to_wait(now):
             return []
 


### PR DESCRIPTION
The ServiceBrowser query loop (async_browser_task) was being awoken on
every packet because it was using `zeroconf.async_wait` which wakes
up on every new packet.  We only need to awaken the loop when the next time
we are going to send a query has changed.

fixes #814 fixes #768