### PR TITLE
Disable duplicate question suppression for test_integration

### DIFF
--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -662,7 +662,10 @@ async def test_service_browser_instantiation_generates_add_events_from_cache():
 
 
 @pytest.mark.asyncio
-async def test_integration():
+# Disable duplicate question suppression for this test as it works
+# by asking the same question over and over
+@unittest.mock.patch("zeroconf._core.QuestionHistory.suppresses", return_value=False)
+async def test_integration(suppresses_mock):
     service_added = asyncio.Event()
     service_removed = asyncio.Event()
     unexpected_ttl = asyncio.Event()


### PR DESCRIPTION
- This test waits until we get 50 known answers. It would
  sometimes fail because it could not ask enough
  unsuppressed questions in the allowed time.

Fix additional flapper cases seen during CI runs.