### PR TITLE
Cache dependency installs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          make env
+          python -m venv env
           . env/bin/activate
           pip install --upgrade -r requirements-dev.txt
       - name: Install pytest-github-actions-annotate-failures plugin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
-        include:
-          - os: ubuntu-latest
-            path: ~/.cache/pip
-          - os: macos-latest
-            path: ~/Library/Caches/pip
-          - os: windows-latest
-            path: ~\AppData\Local\pip\Cache
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         id: cache
         with:
-          path: ${{ matrix.path }}
+          path: env
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/requirements-dev.txt') }}-${{ hashFiles('**/Makefile') }}
           restore-keys: |
             ${{ runner.os }}-pip-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           - os: macos-latest
             venvcmd: . env/bin/activate
           - os: windows-latest
-            venvcmd: env\Scripts\activate
+            venvcmd: env\Scripts\Activate.ps1
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        include:
+          - os: ubuntu-latest
+            venvcmd: . env/bin/activate
+          - os: macos-latest
+            venvcmd: . env/bin/activate
+          - os: windows-latest
+            venvcmd: env\Scripts\activate.bat
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -32,13 +39,13 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           python -m venv env
-          . env/bin/activate
+          ${{ matrix.venvcmd }}
           pip install --upgrade -r requirements-dev.txt
       - name: Install pytest-github-actions-annotate-failures plugin
         run: pip install pytest-github-actions-annotate-failures               
       - name: Run tests
         run: |
-          . env/bin/activate
+          ${{ matrix.venvcmd }}
           make ci
       - name: Report coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest]
-#        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
         include:
-#          - os: ubuntu-latest
-#            venvcmd: . env/bin/activate
-#          - os: macos-latest
-#            venvcmd: . env/bin/activate
+          - os: ubuntu-latest
+            venvcmd: . env/bin/activate
+          - os: macos-latest
+            venvcmd: . env/bin/activate
           - os: windows-latest
             venvcmd: env\Scripts\activate.bat
     steps:
@@ -37,7 +36,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+#        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           python -m venv env
           ${{ matrix.venvcmd }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,13 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
+#        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
         include:
-          - os: ubuntu-latest
-            venvcmd: . env/bin/activate
-          - os: macos-latest
-            venvcmd: . env/bin/activate
+#          - os: ubuntu-latest
+#            venvcmd: . env/bin/activate
+#          - os: macos-latest
+#            venvcmd: . env/bin/activate
           - os: windows-latest
             venvcmd: env\Scripts\activate.bat
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,14 @@ jobs:
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
+          make env
+          . env/bin/activate
           pip install --upgrade -r requirements-dev.txt
-          pip install .
       - name: Install pytest-github-actions-annotate-failures plugin
         run: pip install pytest-github-actions-annotate-failures               
       - name: Run tests
-        run: make ci
+        run: |
+        . env/bin/activate
+        make ci
       - name: Report coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: pip install pytest-github-actions-annotate-failures               
       - name: Run tests
         run: |
-        . env/bin/activate
-        make ci
+          . env/bin/activate
+          make ci
       - name: Report coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
+#
+# macos is very slow without using a cache (4-5m), however
+# its usually < 10s with a cache even without skipping
+# this step
+#
 #        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           python -m venv env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
         include:
           - os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-#
-# macos is very slow without using a cache (4-5m), however
-# its usually < 10s with a cache even without skipping
-# this step
-#
-#        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           python -m venv env
           ${{ matrix.venvcmd }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,7 @@ jobs:
         run: |
           python -m venv env
           ${{ matrix.venvcmd }}
-          pip install --upgrade -r requirements-dev.txt
-      - name: Install pytest-github-actions-annotate-failures plugin
-        run: pip install pytest-github-actions-annotate-failures               
+          pip install --upgrade -r requirements-dev.txt pytest-github-actions-annotate-failures
       - name: Run tests
         run: |
           ${{ matrix.venvcmd }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,32 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        include:
+          - os: ubuntu-latest
+            path: ~/.cache/pip
+          - os: macos-latest
+            path: ~/Library/Caches/pip
+          - os: windows-latest
+            path: ~\AppData\Local\pip\Cache
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        pip install --upgrade -r requirements-dev.txt
-        pip install .
-    - name: Run tests
-      run: make ci
-    - name: Report coverage to Codecov
-      uses: codecov/codecov-action@v1
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: ${{ matrix.path }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/requirements-dev.txt') }}-${{ hashFiles('**/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          pip install --upgrade -r requirements-dev.txt
+          pip install .
+      - name: Run tests
+        run: make ci
+      - name: Report coverage to Codecov
+        uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           - os: macos-latest
             venvcmd: . env/bin/activate
           - os: windows-latest
-            venvcmd: env\Scripts\activate.bat
+            venvcmd: env\Scripts\activate
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 virtualenv: ./env/requirements.built
 
 env:
-	virtualenv env
+	python -m venv env
 
 ./env/requirements.built: env requirements-dev.txt
 	./env/bin/pip install -r requirements-dev.txt

--- a/Makefile
+++ b/Makefile
@@ -48,4 +48,3 @@ test_coverage:
 
 autopep8:
 	autopep8 --max-line-length=$(MAX_LINE_LENGTH) -i setup.py examples zeroconf
-

--- a/Makefile
+++ b/Makefile
@@ -48,3 +48,4 @@ test_coverage:
 
 autopep8:
 	autopep8 --max-line-length=$(MAX_LINE_LENGTH) -i setup.py examples zeroconf
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ autopep8
 black;implementation_name=="cpython"
 coveralls
 coverage
-# Version restricted because of https://github.com/PyCQA/pycodestyle/issues/741
+# Version restricted because of https://github.com/PyCQA/pycodestyle/issues/741 - is fixed
 flake8>=3.6.0
 flake8-import-order
 ifaddr


### PR DESCRIPTION
Installing deps was taking much longer than running the tests so we now cache them when possible.