### PR TITLE
Skip dependencies install in CI on cache hit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           python -m venv env
           ${{ matrix.venvcmd }}


### PR DESCRIPTION
There is no need to reinstall dependencies in the CI when we have a cache hit.