### PR TITLE
Limit duplicate packet suppression to 1s intervals

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -696,3 +696,21 @@ def test_guard_against_oversized_packets():
     )
 
     zc.close()
+
+
+def test_guard_against_duplicate_packets():
+    """Ensure we do not process duplicate packets.
+    These packets can quickly overwhelm the system.
+    """
+    zc = Zeroconf(interfaces=['127.0.0.1'])
+    listener = _core.AsyncListener(zc)
+    assert listener.suppress_duplicate_packet(b"first packet", current_time_millis()) is False
+    assert listener.suppress_duplicate_packet(b"first packet", current_time_millis()) is True
+    assert listener.suppress_duplicate_packet(b"first packet", current_time_millis()) is True
+    assert listener.suppress_duplicate_packet(b"first packet", current_time_millis() + 1000) is False
+    assert listener.suppress_duplicate_packet(b"first packet", current_time_millis()) is True
+    assert listener.suppress_duplicate_packet(b"other packet", current_time_millis()) is False
+    assert listener.suppress_duplicate_packet(b"other packet", current_time_millis()) is True
+    assert listener.suppress_duplicate_packet(b"other packet", current_time_millis() + 1000) is False
+    assert listener.suppress_duplicate_packet(b"first packet", current_time_millis()) is False
+    zc.close()

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -186,12 +186,21 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
     def __init__(self, zc: 'Zeroconf') -> None:
         self.zc = zc
         self.data: Optional[bytes] = None
+        self.last_time: float = 0
         self.transport: Optional[asyncio.DatagramTransport] = None
 
         self._deferred: Dict[str, List[DNSIncoming]] = {}
         self._timers: Dict[str, asyncio.TimerHandle] = {}
 
         super().__init__()
+
+    def suppress_duplicate_packet(self, data: bytes, now: float) -> bool:
+        """Suppress duplicate packet if the last one was the same in the last second."""
+        if self.data == data and (now - 1000) < self.last_time:
+            return True
+        self.data = data
+        self.last_time = now
+        return False
 
     def datagram_received(
         self, data: bytes, addrs: Union[Tuple[str, int], Tuple[str, int, int, int]]
@@ -210,7 +219,9 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
         else:
             return
 
-        if self.data == data:
+        now = current_time_millis()
+        if self.suppress_duplicate_packet(data, now):
+            # Guard against duplicate packets
             log.debug(
                 'Ignoring duplicate message received from %r:%r (socket %d) (%d bytes) as [%r]',
                 addr,
@@ -220,8 +231,6 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
                 data,
             )
             return
-
-        self.data = data
 
         if len(data) > _MAX_MSG_ABSOLUTE:
             # Guard against oversized packets to ensure bad implementations cannot overwhelm
@@ -234,7 +243,7 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
             )
             return
 
-        msg = DNSIncoming(data, scope)
+        msg = DNSIncoming(data, scope, now)
         if msg.valid:
             log.debug(
                 'Received from %r:%r (socket %d): %r (%d bytes) as [%r]',

--- a/zeroconf/_protocol.py
+++ b/zeroconf/_protocol.py
@@ -79,7 +79,7 @@ class DNSIncoming(DNSMessage, QuietLogger):
 
     """Object representation of an incoming DNS packet"""
 
-    def __init__(self, data: bytes, scope_id: Optional[int] = None) -> None:
+    def __init__(self, data: bytes, scope_id: Optional[int] = None, now: Optional[float] = None) -> None:
         """Constructor from string holding bytes of packet"""
         super().__init__(0)
         self.offset = 0
@@ -92,7 +92,7 @@ class DNSIncoming(DNSMessage, QuietLogger):
         self.num_authorities = 0
         self.num_additionals = 0
         self.valid = False
-        self.now = current_time_millis()
+        self.now = now or current_time_millis()
         self.scope_id = scope_id
 
         try:


### PR DESCRIPTION
- Only suppress duplicate packets that happen within the same
  second. Legitimate queriers will retry the question if they
  are suppressed. The limit was reduced to one second to be
  in line with rfc6762:

  To protect the network against excessive packet flooding due to
  software bugs or malicious attack, a Multicast DNS responder MUST NOT
  (except in the one special case of answering probe queries) multicast
  a record on a given interface until at least one second has elapsed
  since the last time that record was multicast on that particular