### PR TITLE
Fix ineffective patching on PyPy

### DIFF
--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -11,6 +11,7 @@ import time
 import os
 import unittest
 from threading import Event
+from unittest.mock import patch
 
 import pytest
 
@@ -382,7 +383,7 @@ class TestServiceBrowserMultipleTypes(unittest.TestCase):
                 return self.created + (percent * self.ttl * 10)
 
             # Set an expire time that will force a refresh
-            with unittest.mock.patch("zeroconf.DNSRecord.get_expiration_time", new=_mock_get_expiration_time):
+            with patch("zeroconf.DNSRecord.get_expiration_time", new=_mock_get_expiration_time):
                 _inject_response(
                     zeroconf,
                     mock_incoming_msg(r.ServiceStateChange.Added, service_types[0], service_names[0], 120),
@@ -430,8 +431,7 @@ class TestServiceBrowserMultipleTypes(unittest.TestCase):
             zeroconf.close()
 
 
-@unittest.mock.patch("zeroconf._core.QuestionHistory.suppresses", return_value=False)
-def test_backoff(suppresses_mock):
+def test_backoff():
     got_query = Event()
 
     type_ = "_http._tcp.local."
@@ -457,11 +457,11 @@ def test_backoff(suppresses_mock):
     # patch the zeroconf send
     # patch the zeroconf current_time_millis
     # patch the backoff limit to prevent test running forever
-    with unittest.mock.patch.object(zeroconf_browser, "async_send", send), unittest.mock.patch.object(
-        _services_browser, "current_time_millis", current_time_millis
-    ), unittest.mock.patch.object(
+    with patch.object(zeroconf_browser, "async_send", send), patch.object(
+        zeroconf_browser.question_history, "suppresses", return_value=False
+    ), patch.object(_services_browser, "current_time_millis", current_time_millis), patch.object(
         _services_browser, "_BROWSER_BACKOFF_LIMIT", 10
-    ), unittest.mock.patch.object(
+    ), patch.object(
         _services_browser, "_FIRST_QUERY_DELAY_RANDOM_INTERVAL", (0, 0)
     ):
         # dummy service callback
@@ -525,7 +525,7 @@ def test_first_query_delay():
         old_send(out, addr=addr, port=port)
 
     # patch the zeroconf send
-    with unittest.mock.patch.object(zeroconf_browser, "async_send", send):
+    with patch.object(zeroconf_browser, "async_send", send):
         # dummy service callback
         def on_service_state_change(zeroconf, service_type, state_change, name):
             pass
@@ -564,7 +564,7 @@ def test_asking_default_is_asking_qm_questions_after_the_first_qu():
         old_send(out, addr=addr, port=port)
 
     # patch the zeroconf send
-    with unittest.mock.patch.object(zeroconf_browser, "async_send", send):
+    with patch.object(zeroconf_browser, "async_send", send):
         # dummy service callback
         def on_service_state_change(zeroconf, service_type, state_change, name):
             pass
@@ -597,7 +597,7 @@ def test_asking_qm_questions():
         old_send(out, addr=addr, port=port)
 
     # patch the zeroconf send
-    with unittest.mock.patch.object(zeroconf_browser, "async_send", send):
+    with patch.object(zeroconf_browser, "async_send", send):
         # dummy service callback
         def on_service_state_change(zeroconf, service_type, state_change, name):
             pass
@@ -631,7 +631,7 @@ def test_asking_qu_questions():
         old_send(out, addr=addr, port=port)
 
     # patch the zeroconf send
-    with unittest.mock.patch.object(zeroconf_browser, "async_send", send):
+    with patch.object(zeroconf_browser, "async_send", send):
         # dummy service callback
         def on_service_state_change(zeroconf, service_type, state_change, name):
             pass

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -9,6 +9,7 @@ import socket
 import threading
 import os
 import unittest
+from unittest.mock import patch
 from threading import Event
 from typing import List
 
@@ -218,7 +219,7 @@ class TestServiceInfo(unittest.TestCase):
             send_event.set()
 
         # patch the zeroconf send
-        with unittest.mock.patch.object(zc, "async_send", send):
+        with patch.object(zc, "async_send", send):
 
             def mock_incoming_msg(records) -> r.DNSIncoming:
 
@@ -363,7 +364,7 @@ class TestServiceInfo(unittest.TestCase):
             send_event.set()
 
         # patch the zeroconf send
-        with unittest.mock.patch.object(zc, "async_send", send):
+        with patch.object(zc, "async_send", send):
 
             def mock_incoming_msg(records) -> r.DNSIncoming:
 
@@ -675,7 +676,7 @@ def test_asking_qu_questions():
         old_send(out, addr=addr, port=port)
 
     # patch the zeroconf send
-    with unittest.mock.patch.object(zeroconf, "async_send", send):
+    with patch.object(zeroconf, "async_send", send):
         zeroconf.get_service_info(f"name.{type_}", type_, 500, question_type=r.DNSQuestionType.QU)
         assert first_outgoing.questions[0].unicast == True
         zeroconf.close()
@@ -699,7 +700,7 @@ def test_asking_qm_questions_are_default():
         old_send(out, addr=addr, port=port)
 
     # patch the zeroconf send
-    with unittest.mock.patch.object(zeroconf, "async_send", send):
+    with patch.object(zeroconf, "async_send", send):
         zeroconf.get_service_info(f"name.{type_}", type_, 500)
         assert first_outgoing.questions[0].unicast == False
         zeroconf.close()

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -9,7 +9,8 @@ import logging
 import socket
 import time
 import threading
-import unittest.mock
+from unittest.mock import patch
+
 
 import pytest
 
@@ -411,7 +412,7 @@ async def test_service_info_async_request() -> None:
     _clear_cache(aiozc.zeroconf)
     # Generating the race condition is almost impossible
     # without patching since its a TOCTOU race
-    with unittest.mock.patch("zeroconf.aio.AsyncServiceInfo._is_complete", False):
+    with patch("zeroconf.aio.AsyncServiceInfo._is_complete", False):
         await aiosinfo.async_request(aiozc.zeroconf, 3000)
     assert aiosinfo is not None
     assert aiosinfo.addresses == [socket.inet_aton("10.0.1.3")]
@@ -662,10 +663,7 @@ async def test_service_browser_instantiation_generates_add_events_from_cache():
 
 
 @pytest.mark.asyncio
-# Disable duplicate question suppression for this test as it works
-# by asking the same question over and over
-@unittest.mock.patch("zeroconf._core.QuestionHistory.suppresses", return_value=False)
-async def test_integration(suppresses_mock):
+async def test_integration():
     service_added = asyncio.Event()
     service_removed = asyncio.Event()
     unexpected_ttl = asyncio.Event()
@@ -711,19 +709,39 @@ async def test_integration(suppresses_mock):
 
         old_send(out, addr=addr, port=port, v6_flow_scope=v6_flow_scope)
 
+    assert len(zeroconf_browser.engine.protocols) == 2
+
+    aio_zeroconf_registrar = AsyncZeroconf(interfaces=['127.0.0.1'])
+    zeroconf_registrar = aio_zeroconf_registrar.zeroconf
+    await aio_zeroconf_registrar.zeroconf.async_wait_for_start()
+
+    assert len(zeroconf_registrar.engine.protocols) == 2
     # patch the zeroconf send
     # patch the zeroconf current_time_millis
     # patch the backoff limit to ensure we always get one query every 1/4 of the DNS TTL
-    with unittest.mock.patch.object(zeroconf_browser, "async_send", send), unittest.mock.patch(
+    # Disable duplicate question suppression and duplicate packet suppression for this test as it works
+    # by asking the same question over and over
+    with patch.object(
+        zeroconf_registrar.engine.protocols[0], "suppress_duplicate_packet", return_value=False
+    ), patch.object(
+        zeroconf_registrar.engine.protocols[1], "suppress_duplicate_packet", return_value=False
+    ), patch.object(
+        zeroconf_browser.engine.protocols[0], "suppress_duplicate_packet", return_value=False
+    ), patch.object(
+        zeroconf_browser.engine.protocols[1], "suppress_duplicate_packet", return_value=False
+    ), patch.object(
+        zeroconf_browser.question_history, "suppresses", return_value=False
+    ), patch.object(
+        zeroconf_browser, "async_send", send
+    ), patch(
         "zeroconf._services.browser.current_time_millis", current_time_millis
-    ), unittest.mock.patch.object(_services_browser, "_BROWSER_BACKOFF_LIMIT", int(expected_ttl / 4)):
+    ), patch.object(
+        _services_browser, "_BROWSER_BACKOFF_LIMIT", int(expected_ttl / 4)
+    ):
         service_added = asyncio.Event()
         service_removed = asyncio.Event()
 
         browser = AsyncServiceBrowser(zeroconf_browser, type_, [on_service_state_change])
-
-        aio_zeroconf_registrar = AsyncZeroconf(interfaces=['127.0.0.1'])
-        await aio_zeroconf_registrar.zeroconf.async_wait_for_start()
 
         desc = {'path': '/~paulsm/'}
         info = ServiceInfo(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -15,6 +15,7 @@ import time
 import unittest
 import unittest.mock
 from typing import cast
+from unittest.mock import patch
 
 import zeroconf as r
 from zeroconf import _core, _protocol, const, Zeroconf, current_time_millis
@@ -48,7 +49,7 @@ def threadsafe_query(zc, protocol, *args):
 # which is not threadsafe
 @pytest.mark.asyncio
 async def test_reaper():
-    with unittest.mock.patch.object(_core, "_CACHE_CLEANUP_INTERVAL", 10):
+    with patch.object(_core, "_CACHE_CLEANUP_INTERVAL", 10):
         assert _core._CACHE_CLEANUP_INTERVAL == 10
         aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
         zeroconf = aiozc.zeroconf
@@ -652,7 +653,7 @@ def test_guard_against_oversized_packets():
         )
 
     # We are patching to generate an oversized packet
-    with unittest.mock.patch.object(_protocol, "_MAX_MSG_ABSOLUTE", 100000), unittest.mock.patch.object(
+    with patch.object(_protocol, "_MAX_MSG_ABSOLUTE", 100000), patch.object(
         _protocol, "_MAX_MSG_TYPICAL", 100000
     ):
         over_sized_packet = generated.packets()[0]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,6 +10,7 @@ import time
 import unittest
 import unittest.mock
 from typing import Optional  # noqa # used in type hints
+from unittest.mock import patch
 
 import zeroconf as r
 from zeroconf import DNSOutgoing, ServiceBrowser, ServiceInfo, Zeroconf, const
@@ -90,7 +91,7 @@ class Names(unittest.TestCase):
         # instantiate a zeroconf instance
         zc = Zeroconf(interfaces=['127.0.0.1'])
 
-        with unittest.mock.patch('zeroconf._logger.log.warning') as mocked_log_warn, unittest.mock.patch(
+        with patch('zeroconf._logger.log.warning') as mocked_log_warn, patch(
             'zeroconf._logger.log.debug'
         ) as mocked_log_debug:
             # now that we have a long packet in our possession, let's verify the

--- a/tests/utils/test_aio.py
+++ b/tests/utils/test_aio.py
@@ -6,7 +6,7 @@
 
 import asyncio
 import contextlib
-import unittest.mock
+from unittest.mock import patch
 
 import pytest
 
@@ -23,7 +23,7 @@ async def test_async_get_all_tasks() -> None:
     await aioutils._async_get_all_tasks(aioutils.get_running_loop())
     if not hasattr(asyncio, 'all_tasks'):
         return
-    with unittest.mock.patch("zeroconf._utils.aio.asyncio.all_tasks", side_effect=RuntimeError):
+    with patch("zeroconf._utils.aio.asyncio.all_tasks", side_effect=RuntimeError):
         await aioutils._async_get_all_tasks(aioutils.get_running_loop())
 
 


### PR DESCRIPTION
- Use patch in all places so its easier to find where we need
  to clean up

`test_integration` was failing often on PyPy since the patching was not effective.  The MacOS github CI runners are very slow so its likely to still fail since we don't wait long enough, but this will make it much more reliable since we won't drop duplicates now in the test.