### PR TITLE
Make ServiceInfo first question QU

### DIFF
--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -682,8 +682,8 @@ def test_asking_qu_questions():
         zeroconf.close()
 
 
-def test_asking_qm_questions_are_default():
-    """Verify default is QM questions."""
+def test_asking_qm_questions():
+    """Verify explictly asking QM questions."""
     type_ = "_quservice._tcp.local."
     zeroconf = r.Zeroconf(interfaces=['127.0.0.1'])
 
@@ -701,6 +701,6 @@ def test_asking_qm_questions_are_default():
 
     # patch the zeroconf send
     with patch.object(zeroconf, "async_send", send):
-        zeroconf.get_service_info(f"name.{type_}", type_, 500)
+        zeroconf.get_service_info(f"name.{type_}", type_, 500, question_type=r.DNSQuestionType.QM)
         assert first_outgoing.questions[0].unicast == False
         zeroconf.close()

--- a/zeroconf/_services/info.py
+++ b/zeroconf/_services/info.py
@@ -438,6 +438,7 @@ class ServiceInfo(RecordUpdateListener):
         if self.load_from_cache(zc):
             return True
 
+        first_request = True
         now = current_time_millis()
         delay = _LISTENER_TIME
         next_ = now
@@ -449,7 +450,10 @@ class ServiceInfo(RecordUpdateListener):
                 if last <= now:
                     return False
                 if next_ <= now:
-                    out = self.generate_request_query(zc, now, question_type)
+                    out = self.generate_request_query(
+                        zc, now, question_type or DNSQuestionType.QU if first_request else DNSQuestionType.QM
+                    )
+                    first_request = False
                     if not out.questions:
                         return self.load_from_cache(zc)
                     zc.async_send(out)


### PR DESCRIPTION
- We want an immediate response when making a request with ServiceInfo
  by asking a QU question, most responders will not delay the response
  and respond right away to our question. This also improves compatibility
  with split networks as we may not have been able to see the response
  otherwise.  If the responder has not multicast the record recently
  it may still choose to do so in addition to responding via unicast

- Reduces traffic when there are multiple zeroconf instances running
  on the network running ServiceBrowsers

- If we don't get an answer on the first try, we ask a QM question
  in the event we can't receive a unicast response for some reason

- This change puts ServiceInfo inline with ServiceBrowser which
  also asks the first question as QU since ServiceInfo is commonly
  called from ServiceBrowser callbacks

closes #851