### PR TITLE
Only run linters on Linux in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,14 @@ jobs:
           python -m venv env
           ${{ matrix.venvcmd }}
           pip install --upgrade -r requirements-dev.txt pytest-github-actions-annotate-failures
+      - name: Run lint
+        if: runner.os == "Linux"
+        run: |
+          ${{ matrix.venvcmd }}
+          make lint
       - name: Run tests
         run: |
           ${{ matrix.venvcmd }}
-          make ci
+          make test_coverage          
       - name: Report coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Set up GCC
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: egor-tensin/setup-gcc@v1          
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           ${{ matrix.venvcmd }}
           pip install --upgrade -r requirements-dev.txt pytest-github-actions-annotate-failures
       - name: Run lint
-        if: runner.os == "Linux"
+        if: ${{ runner.os == "Linux" }}
         run: |
           ${{ matrix.venvcmd }}
           make lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,20 +24,17 @@ jobs:
             venvcmd: env\Scripts\Activate.ps1
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}          
       - uses: actions/cache@v2
         id: cache
         with:
           path: env
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/requirements-dev.txt') }}-${{ hashFiles('**/Makefile') }}
           restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Set up GCC
-        if: ${{ steps.cache.outputs.cache-hit != 'true' && runner.os == 'Linux' }}
-        uses: egor-tensin/setup-gcc@v1          
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-           
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up GCC
-        if: ${{ steps.cache.outputs.cache-hit != 'true' && runner.os != "macOS" }}
+        if: ${{ steps.cache.outputs.cache-hit != 'true' && runner.os != 'macOS' }}
         uses: egor-tensin/setup-gcc@v1          
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up GCC
-        if: ${{ steps.cache.outputs.cache-hit != 'true' && runner.os != 'macOS' }}
+        if: ${{ steps.cache.outputs.cache-hit != 'true' && runner.os == 'Linux' }}
         uses: egor-tensin/setup-gcc@v1          
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           ${{ matrix.venvcmd }}
           pip install --upgrade -r requirements-dev.txt pytest-github-actions-annotate-failures
       - name: Run flake8
-        if: ${{ runner.os == 'Linux' }}
+        if: ${{ runner.os == 'Linux' && matrix.python-version != 'pypy3' }}
         run: |
           ${{ matrix.venvcmd }}
           make flake8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           ${{ matrix.venvcmd }}
           pip install --upgrade -r requirements-dev.txt pytest-github-actions-annotate-failures
       - name: Run lint
-        if: ${{ runner.os == "Linux" }}
+        if: ${{ runner.os == 'Linux' }}
         run: |
           ${{ matrix.venvcmd }}
           make lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
         id: cache
         with:
           path: env
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/requirements-dev.txt') }}-${{ hashFiles('**/Makefile') }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/requirements-dev.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-           
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/Makefile') }}        
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up GCC
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: ${{ steps.cache.outputs.cache-hit != 'true' && runner.os != "macOS" }}
         uses: egor-tensin/setup-gcc@v1          
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,17 +47,17 @@ jobs:
           ${{ matrix.venvcmd }}
           make flake8
       - name: Run mypy
-        if: ${{ runner.os == 'Linux' and matrix.python-version != "pypy3" }}
+        if: ${{ runner.os == 'Linux' && matrix.python-version != "pypy3" }}
         run: |
           ${{ matrix.venvcmd }}
           make mypy
       - name: Run black_check
-        if: ${{ runner.os == 'Linux' and matrix.python-version != "pypy3" }}
+        if: ${{ runner.os == 'Linux' && matrix.python-version != "pypy3" }}
         run: |
           ${{ matrix.venvcmd }}
           make black_check
       - name: Run pylint
-        if: ${{ runner.os == 'Linux' and matrix.python-version != "pypy3" }}
+        if: ${{ runner.os == 'Linux' && matrix.python-version != "pypy3" }}
         run: |
           ${{ matrix.venvcmd }}
           make pylint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,14 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}          
+          python-version: ${{ matrix.python-version }}
       - uses: actions/cache@v2
         id: cache
         with:
           path: env
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/Makefile') }}-${{ hashFiles('**/requirements-dev.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/Makefile') }}        
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/Makefile') }}
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
@@ -64,6 +64,6 @@ jobs:
       - name: Run tests
         run: |
           ${{ matrix.venvcmd }}
-          make test_coverage          
+          make test_coverage
       - name: Report coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,17 +47,17 @@ jobs:
           ${{ matrix.venvcmd }}
           make flake8
       - name: Run mypy
-        if: ${{ runner.os == 'Linux' && matrix.python-version != "pypy3" }}
+        if: ${{ runner.os == 'Linux' && matrix.python-version != 'pypy3' }}
         run: |
           ${{ matrix.venvcmd }}
           make mypy
       - name: Run black_check
-        if: ${{ runner.os == 'Linux' && matrix.python-version != "pypy3" }}
+        if: ${{ runner.os == 'Linux' && matrix.python-version != 'pypy3' }}
         run: |
           ${{ matrix.venvcmd }}
           make black_check
       - name: Run pylint
-        if: ${{ runner.os == 'Linux' && matrix.python-version != "pypy3" }}
+        if: ${{ runner.os == 'Linux' && matrix.python-version != 'pypy3' }}
         run: |
           ${{ matrix.venvcmd }}
           make pylint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,26 @@ jobs:
           python -m venv env
           ${{ matrix.venvcmd }}
           pip install --upgrade -r requirements-dev.txt pytest-github-actions-annotate-failures
-      - name: Run lint
+      - name: Run flake8
         if: ${{ runner.os == 'Linux' }}
         run: |
           ${{ matrix.venvcmd }}
-          make lint
+          make flake8
+      - name: Run mypy
+        if: ${{ runner.os == 'Linux' and matrix.python-version != "pypy3" }}
+        run: |
+          ${{ matrix.venvcmd }}
+          make mypy
+      - name: Run black_check
+        if: ${{ runner.os == 'Linux' and matrix.python-version != "pypy3" }}
+        run: |
+          ${{ matrix.venvcmd }}
+          make black_check
+      - name: Run pylint
+        if: ${{ runner.os == 'Linux' and matrix.python-version != "pypy3" }}
+        run: |
+          ${{ matrix.venvcmd }}
+          make pylint
       - name: Run tests
         run: |
           ${{ matrix.venvcmd }}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
 autopep8
-black;implementation_name=="cpython"
+black
 coveralls
 coverage
 # Version restricted because of https://github.com/PyCQA/pycodestyle/issues/741 - is fixed
 flake8>=3.6.0
 flake8-import-order
 ifaddr
-mypy;implementation_name=="cpython"
+mypy
 # 0.11.0 breaks things https://github.com/PyCQA/pep8-naming/issues/152
 pep8-naming!=0.6.0,!=0.11.0
 pylint

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
 autopep8
-black
+black;implementation_name=="cpython"
 coveralls
 coverage
 # Version restricted because of https://github.com/PyCQA/pycodestyle/issues/741 - is fixed
 flake8>=3.6.0
 flake8-import-order
 ifaddr
-mypy
+mypy;implementation_name=="cpython"
 # 0.11.0 breaks things https://github.com/PyCQA/pep8-naming/issues/152
 pep8-naming!=0.6.0,!=0.11.0
 pylint


### PR DESCRIPTION
- The github MacOS and Windows runners are slower and
  will have the same results as the Linux runners so there
  is no need to wait for them.

closes #854