### PR TITLE
Fix deadlock when event loop is shutdown during service registration

### DIFF
--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -72,7 +72,7 @@ from .const import (
 )
 
 _TC_DELAY_RANDOM_INTERVAL = (400, 500)
-_CLOSE_TIMEOUT = 2
+_CLOSE_TIMEOUT = 3
 
 
 class AsyncEngine:

--- a/zeroconf/_services/info.py
+++ b/zeroconf/_services/info.py
@@ -37,7 +37,7 @@ from .._utils.net import (
     _is_v6_address,
 )
 from .._utils.struct import int2byte
-from .._utils.time import current_time_millis
+from .._utils.time import current_time_millis, millis_to_seconds
 from ..const import (
     _CLASS_IN,
     _CLASS_UNIQUE,
@@ -427,7 +427,7 @@ class ServiceInfo(RecordUpdateListener):
             raise RuntimeError("Use AsyncServiceInfo.async_request from the event loop")
         return asyncio.run_coroutine_threadsafe(
             self.async_request(zc, timeout, question_type), zc.loop
-        ).result()
+        ).result(millis_to_seconds(timeout) + 1)
 
     async def async_request(
         self, zc: 'Zeroconf', timeout: float, question_type: Optional[DNSQuestionType] = None

--- a/zeroconf/_utils/aio.py
+++ b/zeroconf/_utils/aio.py
@@ -25,6 +25,10 @@ import contextlib
 import queue
 from typing import Any, List, Optional, Set, cast
 
+_TASK_AWAIT_TIMEOUT = 1
+_GET_ALL_TASKS_TIMEOUT = 1
+_WAIT_FOR_LOOP_TASKS_TIMEOUT = 2  # Must be larger than _TASK_AWAIT_TIMEOUT
+
 
 def get_best_available_queue() -> queue.Queue:
     """Create the best available queue type."""
@@ -73,15 +77,19 @@ async def _async_get_all_tasks(loop: asyncio.AbstractEventLoop) -> List[asyncio.
 
 async def _wait_for_loop_tasks(wait_tasks: Set[asyncio.Task]) -> None:
     """Wait for the event loop thread we started to shutdown."""
-    await asyncio.wait(wait_tasks, timeout=1)
+    await asyncio.wait(wait_tasks, timeout=_TASK_AWAIT_TIMEOUT)
 
 
 def shutdown_loop(loop: asyncio.AbstractEventLoop) -> None:
     """Wait for pending tasks and stop an event loop."""
-    pending_tasks = set(asyncio.run_coroutine_threadsafe(_async_get_all_tasks(loop), loop).result())
+    pending_tasks = set(
+        asyncio.run_coroutine_threadsafe(_async_get_all_tasks(loop), loop).result(_GET_ALL_TASKS_TIMEOUT)
+    )
     pending_tasks -= set(task for task in pending_tasks if task.done())
     if pending_tasks:
-        asyncio.run_coroutine_threadsafe(_wait_for_loop_tasks(pending_tasks), loop).result()
+        asyncio.run_coroutine_threadsafe(_wait_for_loop_tasks(pending_tasks), loop).result(
+            _WAIT_FOR_LOOP_TASKS_TIMEOUT
+        )
     loop.call_soon_threadsafe(loop.stop)
 
 

--- a/zeroconf/_utils/aio.py
+++ b/zeroconf/_utils/aio.py
@@ -79,8 +79,7 @@ async def _wait_for_loop_tasks(wait_tasks: Set[asyncio.Task]) -> None:
 def shutdown_loop(loop: asyncio.AbstractEventLoop) -> None:
     """Wait for pending tasks and stop an event loop."""
     pending_tasks = set(asyncio.run_coroutine_threadsafe(_async_get_all_tasks(loop), loop).result())
-    done_tasks = set(task for task in pending_tasks if not task.done())
-    pending_tasks -= done_tasks
+    pending_tasks -= set(task for task in pending_tasks if task.done())
     if pending_tasks:
         asyncio.run_coroutine_threadsafe(_wait_for_loop_tasks(pending_tasks), loop).result()
     loop.call_soon_threadsafe(loop.stop)


### PR DESCRIPTION
- Add timeouts in all places where the event loop might get shutdown from under us.