### PR TITLE
Add test for running sync code within executor

### DIFF
--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -102,6 +102,17 @@ async def test_async_with_sync_passed_in_closed_in_async() -> None:
 
 
 @pytest.mark.asyncio
+async def test_sync_within_event_loop_executor() -> None:
+    """Test sync version still works from an executor within an event loop."""
+    def sync_code():
+        zc = Zeroconf(interfaces=['127.0.0.1'])
+        assert zc.get_service_info("_neverused._tcp.local.", "xneverused._neverused._tcp.local.", 10) is None
+        zc.close()
+
+    await asyncio.get_event_loop().run_in_executor(None, sync_code)
+
+
+@pytest.mark.asyncio
 async def test_async_service_registration() -> None:
     """Test registering services broadcasts the registration by default."""
     aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])


### PR DESCRIPTION
While playing around with the workaround suggested by @bdraco in #893 I wrote a quick test to see if it would work.

Thought I'd submit the test in case it is a useful addition to the suite.