### PR TITLE
Increase timeout in ServiceInfo.request to handle loaded systems

### DIFF
--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -745,9 +745,9 @@ def test_request_timeout():
     """Test that the timeout does not throw an exception and finishes close to the actual timeout."""
     zeroconf = r.Zeroconf(interfaces=['127.0.0.1'])
     start_time = r.current_time_millis()
-    assert zeroconf.get_service_info("_notfound.local.", "notthere._notfound.local.", 200) is None
+    assert zeroconf.get_service_info("_notfound.local.", "notthere._notfound.local.") is None
     end_time = r.current_time_millis()
     zeroconf.close()
-    # 200ms for the timeout
-    # 100ms for loaded systems + schedule overhead
-    assert (end_time - start_time) < 200 + 100
+    # 3000ms for the default timeout
+    # 1000ms for loaded systems + schedule overhead
+    assert (end_time - start_time) < 3000 + 1000

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -745,7 +745,9 @@ def test_request_timeout():
     """Test that the timeout does not throw an exception and finishes close to the actual timeout."""
     zeroconf = r.Zeroconf(interfaces=['127.0.0.1'])
     start_time = r.current_time_millis()
-    assert zeroconf.get_service_info("_notfound.local.", "notthere._notfound.local.", 100) is None
+    assert zeroconf.get_service_info("_notfound.local.", "notthere._notfound.local.", 200) is None
     end_time = r.current_time_millis()
     zeroconf.close()
-    assert (end_time - start_time) < 120
+    # 200ms for the timeout
+    # 100ms for loaded systems + schedule overhead
+    assert (end_time - start_time) < 200 + 100

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -739,3 +739,13 @@ def test_asking_qm_questions():
         zeroconf.get_service_info(f"name.{type_}", type_, 500, question_type=r.DNSQuestionType.QM)
         assert first_outgoing.questions[0].unicast == False
         zeroconf.close()
+
+
+def test_request_timeout():
+    """Test that the timeout does not throw an exception and finishes close to the actual timeout."""
+    zeroconf = r.Zeroconf(interfaces=['127.0.0.1'])
+    start_time = r.current_time_millis()
+    assert zeroconf.get_service_info("_notfound.local.", "notthere._notfound.local.", 100) is None
+    end_time = r.current_time_millis()
+    zeroconf.close()
+    assert (end_time - start_time) < 120

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -930,6 +930,7 @@ async def test_service_browser_ignores_unrelated_updates():
 async def test_async_request_timeout():
     """Test that the timeout does not throw an exception and finishes close to the actual timeout."""
     aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
+    await aiozc.zeroconf.async_wait_for_start()
     start_time = current_time_millis()
     assert await aiozc.async_get_service_info("_notfound.local.", "notthere._notfound.local.", 200) is None
     end_time = current_time_millis()

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -931,7 +931,9 @@ async def test_async_request_timeout():
     """Test that the timeout does not throw an exception and finishes close to the actual timeout."""
     aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
     start_time = current_time_millis()
-    assert await aiozc.async_get_service_info("_notfound.local.", "notthere._notfound.local.", 100) is None
+    assert await aiozc.async_get_service_info("_notfound.local.", "notthere._notfound.local.", 200) is None
     end_time = current_time_millis()
     await aiozc.async_close()
-    assert (end_time - start_time) < 120
+    # 200ms for the timeout
+    # 100ms for loaded systems + schedule overhead
+    assert (end_time - start_time) < 200 + 100

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -924,3 +924,14 @@ async def test_service_browser_ignores_unrelated_updates():
         ('add', type_, registration_name),
     ]
     await aiozc.async_close()
+
+
+@pytest.mark.asyncio
+async def test_async_request_timeout():
+    """Test that the timeout does not throw an exception and finishes close to the actual timeout."""
+    aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
+    start_time = current_time_millis()
+    assert await aiozc.async_get_service_info("_notfound.local.", "notthere._notfound.local.", 100) is None
+    end_time = current_time_millis()
+    await aiozc.async_close()
+    assert (end_time - start_time) < 120

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -932,9 +932,9 @@ async def test_async_request_timeout():
     aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
     await aiozc.zeroconf.async_wait_for_start()
     start_time = current_time_millis()
-    assert await aiozc.async_get_service_info("_notfound.local.", "notthere._notfound.local.", 200) is None
+    assert await aiozc.async_get_service_info("_notfound.local.", "notthere._notfound.local.") is None
     end_time = current_time_millis()
     await aiozc.async_close()
-    # 200ms for the timeout
-    # 100ms for loaded systems + schedule overhead
-    assert (end_time - start_time) < 200 + 100
+    # 3000ms for the default timeout
+    # 1000ms for loaded systems + schedule overhead
+    assert (end_time - start_time) < 3000 + 1000

--- a/tests/utils/test_asyncio.py
+++ b/tests/utils/test_asyncio.py
@@ -85,7 +85,7 @@ def test_shutdown_loop() -> None:
 
     def _run_coro() -> None:
         runcoro_thread_ready.set()
-        with contextlib.suppress(concurrent.futures._base.TimeoutError):
+        with contextlib.suppress(concurrent.futures.TimeoutError):
             asyncio.run_coroutine_threadsafe(_still_running(), loop).result(1)
 
     runcoro_thread = threading.Thread(target=_run_coro, daemon=True)

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -429,9 +429,7 @@ class Zeroconf(QuietLogger):
     async def async_wait(self, timeout: float) -> None:
         """Calling task waits for a given number of milliseconds or until notified."""
         assert self.notify_event is not None
-        log.debug("Wait event or timeout: %s - start: %s", timeout, current_time_millis())
         await wait_event_or_timeout(self.notify_event, timeout=millis_to_seconds(timeout))
-        log.debug("Done Wait event or timeout: %s - end: %s", timeout, current_time_millis())
 
     def notify_all(self) -> None:
         """Notifies all waiting threads and notify listeners."""
@@ -441,10 +439,8 @@ class Zeroconf(QuietLogger):
     def async_notify_all(self) -> None:
         """Schedule an async_notify_all."""
         assert self.notify_event is not None
-        log.debug("async_notify_all called at: %s", current_time_millis())
         self.notify_event.set()
         self.notify_event.clear()
-        log.debug("async_notify_all finished at: %s", current_time_millis())
 
     def get_service_info(
         self, type_: str, name: str, timeout: int = 3000, question_type: Optional[DNSQuestionType] = None

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -429,7 +429,9 @@ class Zeroconf(QuietLogger):
     async def async_wait(self, timeout: float) -> None:
         """Calling task waits for a given number of milliseconds or until notified."""
         assert self.notify_event is not None
+        log.debug("Wait event or timeout: %s - start: %s", timeout, current_time_millis())
         await wait_event_or_timeout(self.notify_event, timeout=millis_to_seconds(timeout))
+        log.debug("Done Wait event or timeout: %s - end: %s", timeout, current_time_millis())
 
     def notify_all(self) -> None:
         """Notifies all waiting threads and notify listeners."""

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -441,8 +441,10 @@ class Zeroconf(QuietLogger):
     def async_notify_all(self) -> None:
         """Schedule an async_notify_all."""
         assert self.notify_event is not None
+        log.debug("async_notify_all called at: %s", current_time_millis())
         self.notify_event.set()
         self.notify_event.clear()
+        log.debug("async_notify_all finished at: %s", current_time_millis())
 
     def get_service_info(
         self, type_: str, name: str, timeout: int = 3000, question_type: Optional[DNSQuestionType] = None

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -62,6 +62,7 @@ from .const import (
     _FLAGS_AA,
     _FLAGS_QR_QUERY,
     _FLAGS_QR_RESPONSE,
+    _LOADED_SYSTEM_TIMEOUT,
     _MAX_MSG_ABSOLUTE,
     _MDNS_ADDR,
     _MDNS_ADDR6,
@@ -172,7 +173,9 @@ class AsyncEngine:
             return
         if not self.loop.is_running():
             return
-        asyncio.run_coroutine_threadsafe(self._async_close(), self.loop).result(_CLOSE_TIMEOUT)
+        asyncio.run_coroutine_threadsafe(self._async_close(), self.loop).result(
+            _CLOSE_TIMEOUT + _LOADED_SYSTEM_TIMEOUT
+        )
 
 
 class AsyncListener(asyncio.Protocol, QuietLogger):

--- a/zeroconf/_services/info.py
+++ b/zeroconf/_services/info.py
@@ -462,10 +462,8 @@ class ServiceInfo(RecordUpdateListener):
                     next_ = now + delay
                     delay *= 2
 
-                log.debug("Waiting: %s @ %s", min(next_, last) - now, current_time_millis())
                 await zc.async_wait(min(next_, last) - now)
                 now = current_time_millis()
-                log.debug("Finished waiting: %s", now)
         finally:
             zc.async_remove_listener(self)
 

--- a/zeroconf/_services/info.py
+++ b/zeroconf/_services/info.py
@@ -27,7 +27,6 @@ from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union, cast
 
 from .._dns import DNSAddress, DNSPointer, DNSQuestionType, DNSRecord, DNSService, DNSText
 from .._exceptions import BadTypeInNameException
-from .._logger import log
 from .._protocol import DNSOutgoing
 from .._updates import RecordUpdate, RecordUpdateListener
 from .._utils.asyncio import get_running_loop

--- a/zeroconf/_services/info.py
+++ b/zeroconf/_services/info.py
@@ -462,9 +462,10 @@ class ServiceInfo(RecordUpdateListener):
                     next_ = now + delay
                     delay *= 2
 
-                log.debug("Waiting: %s", min(next_, last) - now)
+                log.debug("Waiting: %s @ %s", min(next_, last) - now, current_time_millis())
                 await zc.async_wait(min(next_, last) - now)
                 now = current_time_millis()
+                log.debug("Finished waiting: %s", now)
         finally:
             zc.async_remove_listener(self)
 

--- a/zeroconf/_services/info.py
+++ b/zeroconf/_services/info.py
@@ -45,6 +45,7 @@ from ..const import (
     _DNS_OTHER_TTL,
     _FLAGS_QR_QUERY,
     _LISTENER_TIME,
+    _LOADED_SYSTEM_TIMEOUT,
     _TYPE_A,
     _TYPE_AAAA,
     _TYPE_PTR,
@@ -427,7 +428,7 @@ class ServiceInfo(RecordUpdateListener):
             raise RuntimeError("Use AsyncServiceInfo.async_request from the event loop")
         return asyncio.run_coroutine_threadsafe(
             self.async_request(zc, timeout, question_type), zc.loop
-        ).result(millis_to_seconds(timeout) + 1)
+        ).result(millis_to_seconds(timeout) + _LOADED_SYSTEM_TIMEOUT)
 
     async def async_request(
         self, zc: 'Zeroconf', timeout: float, question_type: Optional[DNSQuestionType] = None

--- a/zeroconf/_services/info.py
+++ b/zeroconf/_services/info.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union, cast
 
 from .._dns import DNSAddress, DNSPointer, DNSQuestionType, DNSRecord, DNSService, DNSText
 from .._exceptions import BadTypeInNameException
+from .._logger import log
 from .._protocol import DNSOutgoing
 from .._updates import RecordUpdate, RecordUpdateListener
 from .._utils.asyncio import get_running_loop
@@ -461,6 +462,7 @@ class ServiceInfo(RecordUpdateListener):
                     next_ = now + delay
                     delay *= 2
 
+                log.debug("Waiting: %s", min(next_, last) - now)
                 await zc.async_wait(min(next_, last) - now)
                 now = current_time_millis()
         finally:

--- a/zeroconf/_utils/asyncio.py
+++ b/zeroconf/_utils/asyncio.py
@@ -26,8 +26,8 @@ import queue
 from typing import Any, List, Optional, Set, cast
 
 _TASK_AWAIT_TIMEOUT = 1
-_GET_ALL_TASKS_TIMEOUT = 1
-_WAIT_FOR_LOOP_TASKS_TIMEOUT = 2  # Must be larger than _TASK_AWAIT_TIMEOUT
+_GET_ALL_TASKS_TIMEOUT = 3
+_WAIT_FOR_LOOP_TASKS_TIMEOUT = 3  # Must be larger than _TASK_AWAIT_TIMEOUT
 
 
 def get_best_available_queue() -> queue.Queue:

--- a/zeroconf/const.py
+++ b/zeroconf/const.py
@@ -34,6 +34,12 @@ _BROWSER_TIME = 1000  # ms
 _DUPLICATE_QUESTION_INTERVAL = _BROWSER_TIME - 1  # ms
 _BROWSER_BACKOFF_LIMIT = 3600  # s
 _CACHE_CLEANUP_INTERVAL = 10000  # ms
+_LOADED_SYSTEM_TIMEOUT = 10  # s
+# If the system is loaded or the event
+# loop was blocked by another task that was doing I/O in the loop
+# (shouldn't happen but it does in practice) we need to give
+# a buffer timeout to ensure a coroutine can finish before
+# the future times out
 
 # Some DNS constants
 


### PR DESCRIPTION
It can take a few seconds for a loaded system to run the `async_request` coroutine when the event loop is busy or the system is CPU bound (example being Home Assistant startup).  We now add
an additional `_LOADED_SYSTEM_TIMEOUT` (10s) to the `run_coroutine_threadsafe` calls to ensure the coroutine has the total amount of time to run up to its internal timeout (default of 3000ms). 

Ten seconds is a bit large of a timeout; however, its only unused in cases where we wrap other timeouts. We now expect the only instance the `run_coroutine_threadsafe` result timeout will happen in a production circumstance is when someone is running a `ServiceInfo.request()` in a thread and another thread calls `Zeroconf.close()` at just the right moment that the future is never completed unless the system is so loaded that it is nearly unresponsive.

The timeout for `run_coroutine_threadsafe` is the maximum time a thread can cleanly shut down when zeroconf is closed out in another thread, which should always be longer than the underlying thread operation.