### PR TITLE
Disable N818 in flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ testpaths = tests
 show-source = 1
 application-import-names=zeroconf
 max-line-length=110
-ignore=E203,W503
+ignore=E203,W503,N818
 
 [mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
- We cannot rename these exceptions now without a breaking change
  as they have existed for many years