### PR TITLE
Centralize running coroutines from threads

### DIFF
--- a/zeroconf/_utils/asyncio.py
+++ b/zeroconf/_utils/asyncio.py
@@ -23,7 +23,10 @@
 import asyncio
 import contextlib
 import queue
-from typing import Any, Awaitable, List, Optional, Set, cast
+from typing import Any, Awaitable, Coroutine, List, Optional, Set, cast
+
+from .time import millis_to_seconds
+from ..const import _LOADED_SYSTEM_TIMEOUT
 
 # The combined timeouts should be lower than _CLOSE_TIMEOUT + _WAIT_FOR_LOOP_TASKS_TIMEOUT
 _TASK_AWAIT_TIMEOUT = 1
@@ -85,6 +88,13 @@ async def await_awaitable(aw: Awaitable) -> None:
     """Wait on an awaitable and the task it returns."""
     task = await aw
     await task
+
+
+def run_coro_with_timeout(aw: Coroutine, loop: asyncio.AbstractEventLoop, timeout: float) -> Any:
+    """Run a coroutine with a timeout."""
+    return asyncio.run_coroutine_threadsafe(aw, loop).result(
+        millis_to_seconds(timeout) + _LOADED_SYSTEM_TIMEOUT
+    )
 
 
 def shutdown_loop(loop: asyncio.AbstractEventLoop) -> None:


### PR DESCRIPTION
- Cleanup to ensure all coros we run from a thread
  use _LOADED_SYSTEM_TIMEOUT