### PR TITLE
Upgrade syntax to python 3.6

### DIFF
--- a/examples/async_apple_scanner.py
+++ b/examples/async_apple_scanner.py
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
 def async_on_service_state_change(
     zeroconf: Zeroconf, service_type: str, name: str, state_change: ServiceStateChange
 ) -> None:
-    print("Service %s of type %s state changed: %s" % (name, service_type, state_change))
+    print(f"Service {name} of type {service_type} state changed: {state_change}")
     if state_change is not ServiceStateChange.Added:
         return
     base_name = name[: -len(service_type) - 1]
@@ -55,11 +55,11 @@ async def _async_show_service_info(zeroconf: Zeroconf, service_type: str, name: 
         print("  Name: %s" % name)
         print("  Addresses: %s" % ", ".join(addresses))
         print("  Weight: %d, priority: %d" % (info.weight, info.priority))
-        print("  Server: %s" % (info.server,))
+        print(f"  Server: {info.server}")
         if info.properties:
             print("  Properties are:")
             for key, value in info.properties.items():
-                print("    %s: %s" % (key, value))
+                print(f"    {key}: {value}")
         else:
             print("  No properties")
     else:

--- a/examples/async_browser.py
+++ b/examples/async_browser.py
@@ -17,7 +17,7 @@ from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZerocon
 def async_on_service_state_change(
     zeroconf: Zeroconf, service_type: str, name: str, state_change: ServiceStateChange
 ) -> None:
-    print("Service %s of type %s state changed: %s" % (name, service_type, state_change))
+    print(f"Service {name} of type {service_type} state changed: {state_change}")
     if state_change is not ServiceStateChange.Added:
         return
     asyncio.ensure_future(async_display_service_info(zeroconf, service_type, name))
@@ -32,11 +32,11 @@ async def async_display_service_info(zeroconf: Zeroconf, service_type: str, name
         print("  Name: %s" % name)
         print("  Addresses: %s" % ", ".join(addresses))
         print("  Weight: %d, priority: %d" % (info.weight, info.priority))
-        print("  Server: %s" % (info.server,))
+        print(f"  Server: {info.server}")
         if info.properties:
             print("  Properties are:")
             for key, value in info.properties.items():
-                print("    %s: %s" % (key, value))
+                print(f"    {key}: {value}")
         else:
             print("  No properties")
     else:

--- a/examples/async_service_info_request.py
+++ b/examples/async_service_info_request.py
@@ -36,11 +36,11 @@ async def async_watch_services(aiozc: AsyncZeroconf) -> None:
                 addresses = ["%s:%d" % (addr, cast(int, info.port)) for addr in info.parsed_addresses()]
                 print("  Addresses: %s" % ", ".join(addresses))
                 print("  Weight: %d, priority: %d" % (info.weight, info.priority))
-                print("  Server: %s" % (info.server,))
+                print(f"  Server: {info.server}")
                 if info.properties:
                     print("  Properties are:")
                     for key, value in info.properties.items():
-                        print("    %s: %s" % (key, value))
+                        print(f"    {key}: {value}")
                 else:
                     print("  No properties")
             else:

--- a/examples/browser.py
+++ b/examples/browser.py
@@ -16,7 +16,7 @@ from zeroconf import IPVersion, ServiceBrowser, ServiceStateChange, Zeroconf, Ze
 def on_service_state_change(
     zeroconf: Zeroconf, service_type: str, name: str, state_change: ServiceStateChange
 ) -> None:
-    print("Service %s of type %s state changed: %s" % (name, service_type, state_change))
+    print(f"Service {name} of type {service_type} state changed: {state_change}")
 
     if state_change is ServiceStateChange.Added:
         info = zeroconf.get_service_info(service_type, name)
@@ -26,11 +26,11 @@ def on_service_state_change(
             addresses = ["%s:%d" % (addr, cast(int, info.port)) for addr in info.parsed_scoped_addresses()]
             print("  Addresses: %s" % ", ".join(addresses))
             print("  Weight: %d, priority: %d" % (info.weight, info.priority))
-            print("  Server: %s" % (info.server,))
+            print(f"  Server: {info.server}")
             if info.properties:
                 print("  Properties are:")
                 for key, value in info.properties.items():
-                    print("    %s: %s" % (key, value))
+                    print(f"    {key}: {value}")
             else:
                 print("  No properties")
         else:

--- a/examples/self_test.py
+++ b/examples/self_test.py
@@ -14,7 +14,7 @@ if __name__ == '__main__':
 
     # Test a few module features, including service registration, service
     # query (for Zoe), and service unregistration.
-    print("Multicast DNS Service Discovery for Python, version %s" % (__version__,))
+    print(f"Multicast DNS Service Discovery for Python, version {__version__}")
     r = Zeroconf()
     print("1. Testing registration of a service...")
     desc = {'version': '0.10', 'a': 'test value', 'b': 'another value'}
@@ -40,7 +40,7 @@ if __name__ == '__main__':
     queried_info = r.get_service_info("_http._tcp.local.", "My Service Name._http._tcp.local.")
     assert queried_info
     assert set(queried_info.parsed_addresses()) == expected
-    print("   Getting self: %s" % (queried_info,))
+    print(f"   Getting self: {queried_info}")
     print("   Query done.")
     print("4. Testing unregister of service information...")
     r.unregister_service(info)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 
 """ conftest for zeroconf tests. """

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 
 """Unit tests for aio.py."""
@@ -57,11 +56,9 @@ def verify_threads_ended():
     yield
     threads_after = frozenset(threading.enumerate())
     non_executor_threads = frozenset(
-        [
-            thread
-            for thread in threads_after
-            if "asyncio" not in thread.name and "ThreadPoolExecutor" not in thread.name
-        ]
+        thread
+        for thread in threads_after
+        if "asyncio" not in thread.name and "ThreadPoolExecutor" not in thread.name
     )
     threads = non_executor_threads - threads_before
     assert not threads
@@ -119,7 +116,7 @@ async def test_async_service_registration() -> None:
     aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
     type_ = "_test1-srvc-type._tcp.local."
     name = "xxxyyy"
-    registration_name = "%s.%s" % (name, type_)
+    registration_name = f"{name}.{type_}"
 
     calls = []
 
@@ -179,7 +176,7 @@ async def test_async_service_registration_name_conflict() -> None:
     aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
     type_ = "_test-srvc2-type._tcp.local."
     name = "xxxyyy"
-    registration_name = "%s.%s" % (name, type_)
+    registration_name = f"{name}.{type_}"
 
     desc = {'path': '/~paulsm/'}
     info = ServiceInfo(
@@ -227,7 +224,7 @@ async def test_async_service_registration_name_does_not_match_type() -> None:
     aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
     type_ = "_test-srvc3-type._tcp.local."
     name = "xxxyyy"
-    registration_name = "%s.%s" % (name, type_)
+    registration_name = f"{name}.{type_}"
 
     desc = {'path': '/~paulsm/'}
     info = ServiceInfo(
@@ -254,7 +251,7 @@ async def test_async_tasks() -> None:
     aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
     type_ = "_test-srvc4-type._tcp.local."
     name = "xxxyyy"
-    registration_name = "%s.%s" % (name, type_)
+    registration_name = f"{name}.{type_}"
 
     calls = []
 
@@ -320,7 +317,7 @@ async def test_async_wait_unblocks_on_update() -> None:
     aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
     type_ = "_test-srvc4-type._tcp.local."
     name = "xxxyyy"
-    registration_name = "%s.%s" % (name, type_)
+    registration_name = f"{name}.{type_}"
 
     desc = {'path': '/~paulsm/'}
     info = ServiceInfo(
@@ -356,8 +353,8 @@ async def test_service_info_async_request() -> None:
     type_ = "_test1-srvc-type._tcp.local."
     name = "xxxyyy"
     name2 = "abc"
-    registration_name = "%s.%s" % (name, type_)
-    registration_name2 = "%s.%s" % (name2, type_)
+    registration_name = f"{name}.{type_}"
+    registration_name2 = f"{name2}.{type_}"
 
     # Start a tasks BEFORE the registration that will keep trying
     # and see the registration a bit later
@@ -454,7 +451,7 @@ async def test_async_service_browser() -> None:
     aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
     type_ = "_test9-srvc-type._tcp.local."
     name = "xxxyyy"
-    registration_name = "%s.%s" % (name, type_)
+    registration_name = f"{name}.{type_}"
 
     calls = []
 
@@ -513,7 +510,7 @@ async def test_async_context_manager() -> None:
     """Test using an async context manager."""
     type_ = "_test10-sr-type._tcp.local."
     name = "xxxyyy"
-    registration_name = "%s.%s" % (name, type_)
+    registration_name = f"{name}.{type_}"
 
     async with AsyncZeroconf(interfaces=['127.0.0.1']) as aiozc:
         info = ServiceInfo(
@@ -539,8 +536,8 @@ async def test_async_unregister_all_services() -> None:
     type_ = "_test1-srvc-type._tcp.local."
     name = "xxxyyy"
     name2 = "abc"
-    registration_name = "%s.%s" % (name, type_)
-    registration_name2 = "%s.%s" % (name2, type_)
+    registration_name = f"{name}.{type_}"
+    registration_name2 = f"{name2}.{type_}"
 
     desc = {'path': '/~paulsm/'}
     info = ServiceInfo(
@@ -594,7 +591,7 @@ async def test_async_unregister_all_services() -> None:
 async def test_async_zeroconf_service_types():
     type_ = "_test-srvc-type._tcp.local."
     name = "xxxyyy"
-    registration_name = "%s.%s" % (name, type_)
+    registration_name = f"{name}.{type_}"
 
     zeroconf_registrar = AsyncZeroconf(interfaces=['127.0.0.1'])
     desc = {'path': '/~paulsm/'}
@@ -808,7 +805,7 @@ async def test_info_asking_default_is_asking_qm_questions_after_the_first_qu():
     zeroconf_info = aiozc.zeroconf
 
     name = "xxxyyy"
-    registration_name = "%s.%s" % (name, type_)
+    registration_name = f"{name}.{type_}"
 
     desc = {'path': '/~paulsm/'}
     info = ServiceInfo(

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 
 """ Unit tests for zeroconf._cache. """
@@ -98,7 +97,7 @@ class TestDNSAsyncCacheAPI(unittest.TestCase):
         record2 = r.DNSAddress('a', const._TYPE_A, const._CLASS_IN, 1, b'b')
         cache = r.DNSCache()
         cache.async_add_records([record1, record2])
-        assert set(cache.async_all_by_details('a', const._TYPE_A, const._CLASS_IN)) == set([record1, record2])
+        assert set(cache.async_all_by_details('a', const._TYPE_A, const._CLASS_IN)) == {record1, record2}
 
     def test_async_entries_with_server(self):
         record1 = r.DNSService(
@@ -109,8 +108,8 @@ class TestDNSAsyncCacheAPI(unittest.TestCase):
         )
         cache = r.DNSCache()
         cache.async_add_records([record1, record2])
-        assert set(cache.async_entries_with_server('ab')) == set([record1, record2])
-        assert set(cache.async_entries_with_server('AB')) == set([record1, record2])
+        assert set(cache.async_entries_with_server('ab')) == {record1, record2}
+        assert set(cache.async_entries_with_server('AB')) == {record1, record2}
 
     def test_async_entries_with_name(self):
         record1 = r.DNSService(
@@ -121,8 +120,8 @@ class TestDNSAsyncCacheAPI(unittest.TestCase):
         )
         cache = r.DNSCache()
         cache.async_add_records([record1, record2])
-        assert set(cache.async_entries_with_name('irrelevant')) == set([record1, record2])
-        assert set(cache.async_entries_with_name('Irrelevant')) == set([record1, record2])
+        assert set(cache.async_entries_with_name('irrelevant')) == {record1, record2}
+        assert set(cache.async_entries_with_name('Irrelevant')) == {record1, record2}
 
 
 # These functions have been seen in other projects so
@@ -152,7 +151,7 @@ class TestDNSCacheAPI(unittest.TestCase):
         record2 = r.DNSAddress('a', const._TYPE_A, const._CLASS_IN, 1, b'b')
         cache = r.DNSCache()
         cache.async_add_records([record1, record2])
-        assert set(cache.get_all_by_details('a', const._TYPE_A, const._CLASS_IN)) == set([record1, record2])
+        assert set(cache.get_all_by_details('a', const._TYPE_A, const._CLASS_IN)) == {record1, record2}
 
     def test_entries_with_server(self):
         record1 = r.DNSService(
@@ -163,8 +162,8 @@ class TestDNSCacheAPI(unittest.TestCase):
         )
         cache = r.DNSCache()
         cache.async_add_records([record1, record2])
-        assert set(cache.entries_with_server('ab')) == set([record1, record2])
-        assert set(cache.entries_with_server('AB')) == set([record1, record2])
+        assert set(cache.entries_with_server('ab')) == {record1, record2}
+        assert set(cache.entries_with_server('AB')) == {record1, record2}
 
     def test_entries_with_name(self):
         record1 = r.DNSService(
@@ -175,8 +174,8 @@ class TestDNSCacheAPI(unittest.TestCase):
         )
         cache = r.DNSCache()
         cache.async_add_records([record1, record2])
-        assert set(cache.entries_with_name('irrelevant')) == set([record1, record2])
-        assert set(cache.entries_with_name('Irrelevant')) == set([record1, record2])
+        assert set(cache.entries_with_name('irrelevant')) == {record1, record2}
+        assert set(cache.entries_with_name('Irrelevant')) == {record1, record2}
 
     def test_current_entry_with_name_and_alias(self):
         record1 = r.DNSPointer(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 
 """ Unit tests for zeroconf._core """
@@ -55,28 +54,26 @@ async def test_reaper():
         aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
         zeroconf = aiozc.zeroconf
         cache = zeroconf.cache
-        original_entries = list(itertools.chain(*[cache.entries_with_name(name) for name in cache.names()]))
+        original_entries = list(itertools.chain(*(cache.entries_with_name(name) for name in cache.names())))
         record_with_10s_ttl = r.DNSAddress('a', const._TYPE_SOA, const._CLASS_IN, 10, b'a')
         record_with_1s_ttl = r.DNSAddress('a', const._TYPE_SOA, const._CLASS_IN, 1, b'b')
         zeroconf.cache.async_add_records([record_with_10s_ttl, record_with_1s_ttl])
         question = r.DNSQuestion("_hap._tcp._local.", const._TYPE_PTR, const._CLASS_IN)
         now = r.current_time_millis()
-        other_known_answers = set(
-            [
-                r.DNSPointer(
-                    "_hap._tcp.local.",
-                    const._TYPE_PTR,
-                    const._CLASS_IN,
-                    10000,
-                    'known-to-other._hap._tcp.local.',
-                )
-            ]
-        )
+        other_known_answers = {
+            r.DNSPointer(
+                "_hap._tcp.local.",
+                const._TYPE_PTR,
+                const._CLASS_IN,
+                10000,
+                'known-to-other._hap._tcp.local.',
+            )
+        }
         zeroconf.question_history.add_question_at_time(question, now, other_known_answers)
         assert zeroconf.question_history.suppresses(question, now, other_known_answers)
-        entries_with_cache = list(itertools.chain(*[cache.entries_with_name(name) for name in cache.names()]))
+        entries_with_cache = list(itertools.chain(*(cache.entries_with_name(name) for name in cache.names())))
         await asyncio.sleep(1.2)
-        entries = list(itertools.chain(*[cache.entries_with_name(name) for name in cache.names()]))
+        entries = list(itertools.chain(*(cache.entries_with_name(name) for name in cache.names())))
         await aiozc.async_close()
         assert not zeroconf.question_history.suppresses(question, now, other_known_answers)
         assert entries != original_entries
@@ -367,7 +364,7 @@ def test_register_service_with_custom_ttl():
     name = "MyTestHome"
     info_service = r.ServiceInfo(
         type_,
-        '%s.%s' % (name, type_),
+        f'{name}.{type_}',
         80,
         0,
         0,
@@ -423,9 +420,9 @@ def test_tc_bit_defers():
     name2 = "knownname2"
     name3 = "knownname3"
 
-    registration_name = "%s.%s" % (name, type_)
-    registration2_name = "%s.%s" % (name2, type_)
-    registration3_name = "%s.%s" % (name3, type_)
+    registration_name = f"{name}.{type_}"
+    registration2_name = f"{name2}.{type_}"
+    registration3_name = f"{name3}.{type_}"
 
     desc = {'path': '/~paulsm/'}
     server_name = "ash-2.local."
@@ -502,9 +499,9 @@ def test_tc_bit_defers_last_response_missing():
     name2 = "knownname2"
     name3 = "knownname3"
 
-    registration_name = "%s.%s" % (name, type_)
-    registration2_name = "%s.%s" % (name2, type_)
-    registration3_name = "%s.%s" % (name3, type_)
+    registration_name = f"{name}.{type_}"
+    registration2_name = f"{name2}.{type_}"
+    registration3_name = f"{name3}.{type_}"
 
     desc = {'path': '/~paulsm/'}
     server_name = "ash-2.local."
@@ -729,7 +726,7 @@ def test_shutdown_while_register_in_process():
     name = "MyTestHome"
     info_service = r.ServiceInfo(
         type_,
-        '%s.%s' % (name, type_),
+        f'{name}.{type_}',
         80,
         0,
         0,

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 
 """ Unit tests for zeroconf._dns. """
@@ -101,7 +100,7 @@ class TestDunder(unittest.TestCase):
     def test_service_info_dunder(self):
         type_ = "_test-srvc-type._tcp.local."
         name = "xxxyyy"
-        registration_name = "%s.%s" % (name, type_)
+        registration_name = f"{name}.{type_}"
         info = ServiceInfo(
             type_,
             registration_name,
@@ -119,7 +118,7 @@ class TestDunder(unittest.TestCase):
     def test_service_info_text_properties_not_given(self):
         type_ = "_test-srvc-type._tcp.local."
         name = "xxxyyy"
-        registration_name = "%s.%s" % (name, type_)
+        registration_name = f"{name}.{type_}"
         info = ServiceInfo(
             type_=type_,
             name=registration_name,
@@ -166,7 +165,7 @@ def test_dns_record_hashablity_does_not_consider_ttl():
     record1 = r.DNSAddress('irrelevant', const._TYPE_A, const._CLASS_IN, const._DNS_OTHER_TTL, b'same')
     record2 = r.DNSAddress('irrelevant', const._TYPE_A, const._CLASS_IN, const._DNS_HOST_TTL, b'same')
 
-    record_set = set([record1, record2])
+    record_set = {record1, record2}
     assert len(record_set) == 1
 
     record_set.add(record1)
@@ -187,7 +186,7 @@ def test_dns_address_record_hashablity():
     address3 = r.DNSAddress('irrelevant', const._TYPE_A, const._CLASS_IN, 1, b'c')
     address4 = r.DNSAddress('irrelevant', const._TYPE_AAAA, const._CLASS_IN, 1, b'c')
 
-    record_set = set([address1, address2, address3, address4])
+    record_set = {address1, address2, address3, address4}
     assert len(record_set) == 4
 
     record_set.add(address1)
@@ -199,9 +198,9 @@ def test_dns_address_record_hashablity():
     assert len(record_set) == 4
 
     # Verify we can remove records
-    additional_set = set([address1, address2])
+    additional_set = {address1, address2}
     record_set -= additional_set
-    assert record_set == set([address3, address4])
+    assert record_set == {address3, address4}
 
 
 def test_dns_hinfo_record_hashablity():
@@ -209,7 +208,7 @@ def test_dns_hinfo_record_hashablity():
     hinfo1 = r.DNSHinfo('irrelevant', const._TYPE_HINFO, 0, 0, 'cpu1', 'os')
     hinfo2 = r.DNSHinfo('irrelevant', const._TYPE_HINFO, 0, 0, 'cpu2', 'os')
 
-    record_set = set([hinfo1, hinfo2])
+    record_set = {hinfo1, hinfo2}
     assert len(record_set) == 2
 
     record_set.add(hinfo1)
@@ -228,7 +227,7 @@ def test_dns_pointer_record_hashablity():
     ptr1 = r.DNSPointer('irrelevant', const._TYPE_PTR, const._CLASS_IN, const._DNS_OTHER_TTL, '123')
     ptr2 = r.DNSPointer('irrelevant', const._TYPE_PTR, const._CLASS_IN, const._DNS_OTHER_TTL, '456')
 
-    record_set = set([ptr1, ptr2])
+    record_set = {ptr1, ptr2}
     assert len(record_set) == 2
 
     record_set.add(ptr1)
@@ -249,7 +248,7 @@ def test_dns_text_record_hashablity():
     text3 = r.DNSText('irrelevant', 0, 1, const._DNS_OTHER_TTL, b'12345678901')
     text4 = r.DNSText('irrelevant', 0, 0, const._DNS_OTHER_TTL, b'ABCDEFGHIJK')
 
-    record_set = set([text1, text2, text3, text4])
+    record_set = {text1, text2, text3, text4}
 
     assert len(record_set) == 4
 
@@ -271,7 +270,7 @@ def test_dns_service_record_hashablity():
     srv3 = r.DNSService('irrelevant', const._TYPE_SRV, const._CLASS_IN, const._DNS_HOST_TTL, 0, 0, 81, 'a')
     srv4 = r.DNSService('irrelevant', const._TYPE_SRV, const._CLASS_IN, const._DNS_HOST_TTL, 0, 0, 80, 'ab')
 
-    record_set = set([srv1, srv2, srv3, srv4])
+    record_set = {srv1, srv2, srv3, srv4}
 
     assert len(record_set) == 4
 
@@ -297,7 +296,7 @@ def test_dns_nsec_record_hashablity():
         'irrelevant', const._TYPE_PTR, const._CLASS_IN, const._DNS_OTHER_TTL, 'irrelevant', [1, 2]
     )
 
-    record_set = set([nsec1, nsec2])
+    record_set = {nsec1, nsec2}
     assert len(record_set) == 2
 
     record_set.add(nsec1)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 
 """ Unit tests for zeroconf._exceptions """
@@ -107,7 +106,7 @@ class Exceptions(unittest.TestCase):
         bad_names_to_try = (
             '._x._tcp.local.',
             'a' * 64 + '._sub._http._tcp.local.',
-            'a' * 62 + u'â._sub._http._tcp.local.',
+            'a' * 62 + 'â._sub._http._tcp.local.',
         )
         for name in bad_names_to_try:
             self.assertRaises(r.BadTypeInNameException, r.service_type_name, name)
@@ -129,7 +128,7 @@ class Exceptions(unittest.TestCase):
             ('_12345-67890-abc._udp.local.', '_12345-67890-abc._udp.local.'),
             ('x._sub._http._tcp.local.', '_http._tcp.local.'),
             ('a' * 63 + '._sub._http._tcp.local.', '_http._tcp.local.'),
-            ('a' * 61 + u'â._sub._http._tcp.local.', '_http._tcp.local.'),
+            ('a' * 61 + 'â._sub._http._tcp.local.', '_http._tcp.local.'),
         )
 
         for name, result in good_names_to_try:
@@ -140,7 +139,7 @@ class Exceptions(unittest.TestCase):
     def test_invalid_addresses(self):
         type_ = "_test-srvc-type._tcp.local."
         name = "xxxyyy"
-        registration_name = "%s.%s" % (name, type_)
+        registration_name = f"{name}.{type_}"
 
         bad = ('127.0.0.1', '::1', 42)
         for addr in bad:

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 
 """ Unit tests for zeroconf._handlers """
@@ -46,7 +45,7 @@ class TestRegistrar(unittest.TestCase):
         # service definition
         type_ = "_test-srvc-type._tcp.local."
         name = "xxxyyy"
-        registration_name = "%s.%s" % (name, type_)
+        registration_name = f"{name}.{type_}"
 
         desc = {'path': '/~paulsm/'}
         info = ServiceInfo(
@@ -160,7 +159,7 @@ class TestRegistrar(unittest.TestCase):
         zc = Zeroconf(interfaces=['127.0.0.1'])
         type_ = "_homeassistant._tcp.local."
         name = "Home"
-        registration_name = "%s.%s" % (name, type_)
+        registration_name = f"{name}.{type_}"
 
         info = ServiceInfo(
             type_,
@@ -189,7 +188,7 @@ class TestRegistrar(unittest.TestCase):
         zc = Zeroconf(interfaces=['127.0.0.1'])
         type_ = "_mylowertype._tcp.local."
         name = "Home"
-        registration_name = "%s.%s" % (name, type_)
+        registration_name = f"{name}.{type_}"
 
         info = ServiceInfo(
             type_,
@@ -224,7 +223,7 @@ def test_ptr_optimization():
     # service definition
     type_ = "_test-srvc-type._tcp.local."
     name = "xxxyyy"
-    registration_name = "%s.%s" % (name, type_)
+    registration_name = f"{name}.{type_}"
 
     desc = {'path': '/~paulsm/'}
     info = ServiceInfo(
@@ -280,7 +279,7 @@ def test_any_query_for_ptr():
     zc = Zeroconf(interfaces=['127.0.0.1'])
     type_ = "_anyptr._tcp.local."
     name = "knownname"
-    registration_name = "%s.%s" % (name, type_)
+    registration_name = f"{name}.{type_}"
     desc = {'path': '/~paulsm/'}
     server_name = "ash-2.local."
     ipv6_address = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
@@ -307,7 +306,7 @@ def test_aaaa_query():
     zc = Zeroconf(interfaces=['127.0.0.1'])
     type_ = "_knownaaaservice._tcp.local."
     name = "knownname"
-    registration_name = "%s.%s" % (name, type_)
+    registration_name = f"{name}.{type_}"
     desc = {'path': '/~paulsm/'}
     server_name = "ash-2.local."
     ipv6_address = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
@@ -332,7 +331,7 @@ def test_a_and_aaaa_record_fate_sharing():
     zc = Zeroconf(interfaces=['127.0.0.1'])
     type_ = "_a-and-aaaa-service._tcp.local."
     name = "knownname"
-    registration_name = "%s.%s" % (name, type_)
+    registration_name = f"{name}.{type_}"
     desc = {'path': '/~paulsm/'}
     server_name = "ash-2.local."
     ipv6_address = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
@@ -388,7 +387,7 @@ def test_unicast_response():
     # service definition
     type_ = "_test-srvc-type._tcp.local."
     name = "xxxyyy"
-    registration_name = "%s.%s" % (name, type_)
+    registration_name = f"{name}.{type_}"
     desc = {'path': '/~paulsm/'}
     info = ServiceInfo(
         type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[socket.inet_aton("10.0.1.2")]
@@ -434,8 +433,8 @@ def test_qu_response():
     type_ = "_test-srvc-type._tcp.local."
     other_type_ = "_notthesame._tcp.local."
     name = "xxxyyy"
-    registration_name = "%s.%s" % (name, type_)
-    registration_name2 = "%s.%s" % (name, other_type_)
+    registration_name = f"{name}.{type_}"
+    registration_name2 = f"{name}.{other_type_}"
     desc = {'path': '/~paulsm/'}
     info = ServiceInfo(
         type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[socket.inet_aton("10.0.1.2")]
@@ -530,7 +529,7 @@ def test_known_answer_supression():
     zc = Zeroconf(interfaces=['127.0.0.1'])
     type_ = "_knownanswersv8._tcp.local."
     name = "knownname"
-    registration_name = "%s.%s" % (name, type_)
+    registration_name = f"{name}.{type_}"
     desc = {'path': '/~paulsm/'}
     server_name = "ash-2.local."
     info = ServiceInfo(
@@ -643,9 +642,9 @@ def test_multi_packet_known_answer_supression():
     name2 = "knownname2"
     name3 = "knownname3"
 
-    registration_name = "%s.%s" % (name, type_)
-    registration2_name = "%s.%s" % (name2, type_)
-    registration3_name = "%s.%s" % (name3, type_)
+    registration_name = f"{name}.{type_}"
+    registration2_name = f"{name2}.{type_}"
+    registration3_name = f"{name3}.{type_}"
 
     desc = {'path': '/~paulsm/'}
     server_name = "ash-2.local."
@@ -694,7 +693,7 @@ def test_known_answer_supression_service_type_enumeration_query():
     zc = Zeroconf(interfaces=['127.0.0.1'])
     type_ = "_otherknown._tcp.local."
     name = "knownname"
-    registration_name = "%s.%s" % (name, type_)
+    registration_name = f"{name}.{type_}"
     desc = {'path': '/~paulsm/'}
     server_name = "ash-2.local."
     info = ServiceInfo(
@@ -704,7 +703,7 @@ def test_known_answer_supression_service_type_enumeration_query():
 
     type_2 = "_otherknown2._tcp.local."
     name = "knownname"
-    registration_name2 = "%s.%s" % (name, type_2)
+    registration_name2 = f"{name}.{type_2}"
     desc = {'path': '/~paulsm/'}
     server_name2 = "ash-3.local."
     info2 = ServiceInfo(
@@ -772,7 +771,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
 
     type_ = "_addtest1._tcp.local."
     name = "knownname"
-    registration_name = "%s.%s" % (name, type_)
+    registration_name = f"{name}.{type_}"
     desc = {'path': '/~paulsm/'}
     server_name = "ash-2.local."
     info = ServiceInfo(
@@ -782,7 +781,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
 
     type_2 = "_addtest2._tcp.local."
     name = "knownname"
-    registration_name2 = "%s.%s" % (name, type_2)
+    registration_name2 = f"{name}.{type_2}"
     desc = {'path': '/~paulsm/'}
     server_name2 = "ash-3.local."
     info2 = ServiceInfo(
@@ -904,7 +903,7 @@ async def test_cache_flush_bit():
 
     type_ = "_cacheflush._tcp.local."
     name = "knownname"
-    registration_name = "%s.%s" % (name, type_)
+    registration_name = f"{name}.{type_}"
     desc = {'path': '/~paulsm/'}
     server_name = "server-uu1.local."
     info = ServiceInfo(
@@ -992,7 +991,7 @@ async def test_record_update_manager_add_listener_callsback_existing_records():
 
     type_ = "_cacheflush._tcp.local."
     name = "knownname"
-    registration_name = "%s.%s" % (name, type_)
+    registration_name = f"{name}.{type_}"
     desc = {'path': '/~paulsm/'}
     server_name = "server-uu1.local."
     info = ServiceInfo(
@@ -1013,11 +1012,11 @@ async def test_record_update_manager_add_listener_callsback_existing_records():
     )
     await asyncio.sleep(0)  # flush out the call_soon_threadsafe
 
-    assert set([record.new for record in updated]) == set([ptr_record, a_record])
+    assert {record.new for record in updated} == {ptr_record, a_record}
 
     # The old records should be None so we trigger Add events
     # in service browsers instead of Update events
-    assert set([record.old for record in updated]) == set([None])
+    assert {record.old for record in updated} == {None}
 
     await aiozc.async_close()
 
@@ -1044,7 +1043,7 @@ async def test_questions_query_handler_populates_the_question_history_from_qm_qu
     )
     assert unicast_out is None
     assert multicast_out is None
-    assert zc.question_history.suppresses(question, now, set([known_answer]))
+    assert zc.question_history.suppresses(question, now, {known_answer})
 
     await aiozc.async_close()
 
@@ -1071,7 +1070,7 @@ async def test_questions_query_handler_does_not_put_qu_questions_in_history():
     )
     assert unicast_out is None
     assert multicast_out is None
-    assert not zc.question_history.suppresses(question, now, set([known_answer]))
+    assert not zc.question_history.suppresses(question, now, {known_answer})
 
     await aiozc.async_close()
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 
 """Unit tests for _history.py."""
@@ -14,20 +13,16 @@ def test_question_suppression():
 
     question = r.DNSQuestion("_hap._tcp._local.", const._TYPE_PTR, const._CLASS_IN)
     now = r.current_time_millis()
-    other_known_answers = set(
-        [
-            r.DNSPointer(
-                "_hap._tcp.local.", const._TYPE_PTR, const._CLASS_IN, 10000, 'known-to-other._hap._tcp.local.'
-            )
-        ]
-    )
-    our_known_answers = set(
-        [
-            r.DNSPointer(
-                "_hap._tcp.local.", const._TYPE_PTR, const._CLASS_IN, 10000, 'known-to-us._hap._tcp.local.'
-            )
-        ]
-    )
+    other_known_answers = {
+        r.DNSPointer(
+            "_hap._tcp.local.", const._TYPE_PTR, const._CLASS_IN, 10000, 'known-to-other._hap._tcp.local.'
+        )
+    }
+    our_known_answers = {
+        r.DNSPointer(
+            "_hap._tcp.local.", const._TYPE_PTR, const._CLASS_IN, 10000, 'known-to-us._hap._tcp.local.'
+        )
+    }
 
     history.add_question_at_time(question, now, other_known_answers)
 
@@ -52,13 +47,11 @@ def test_question_expire():
 
     question = r.DNSQuestion("_hap._tcp._local.", const._TYPE_PTR, const._CLASS_IN)
     now = r.current_time_millis()
-    other_known_answers = set(
-        [
-            r.DNSPointer(
-                "_hap._tcp.local.", const._TYPE_PTR, const._CLASS_IN, 10000, 'known-to-other._hap._tcp.local.'
-            )
-        ]
-    )
+    other_known_answers = {
+        r.DNSPointer(
+            "_hap._tcp.local.", const._TYPE_PTR, const._CLASS_IN, 10000, 'known-to-other._hap._tcp.local.'
+        )
+    }
     history.add_question_at_time(question, now, other_known_answers)
 
     # Verify the question is suppressed if the known answers are the same

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 
 """ Unit tests for zeroconf.py """
@@ -127,7 +126,7 @@ class Names(unittest.TestCase):
         desc = {'path': '/~paulsm/'}
         info_service = ServiceInfo(
             type_,
-            '%s.%s' % (name, type_),
+            f'{name}.{type_}',
             80,
             0,
             0,
@@ -147,7 +146,7 @@ class Names(unittest.TestCase):
         # in the registry
         info_service2 = ServiceInfo(
             type_,
-            '%s.%s' % (name, type_),
+            f'{name}.{type_}',
             80,
             0,
             0,
@@ -160,7 +159,7 @@ class Names(unittest.TestCase):
 
     def generate_many_hosts(self, zc, type_, name, number_hosts):
         block_size = 25
-        number_hosts = int(((number_hosts - 1) / block_size + 1)) * block_size
+        number_hosts = int((number_hosts - 1) / block_size + 1) * block_size
         out = r.DNSOutgoing(const._FLAGS_QR_RESPONSE | const._FLAGS_AA)
         for i in range(1, number_hosts + 1):
             next_name = name if i == 1 else '%s-%d' % (name, i)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 
 """Unit tests for logger.py."""

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 
 """ Unit tests for zeroconf._protocol """
@@ -195,8 +194,8 @@ class PacketGeneration(unittest.TestCase):
         generated.add_additional_answer(DNSHinfo('irrelevant', const._TYPE_HINFO, 0, 0, 'cpu', 'os'))
         parsed = r.DNSIncoming(generated.packets()[0])
         answer = cast(r.DNSHinfo, parsed.answers[0])
-        assert answer.cpu == u'cpu'
-        assert answer.os == u'os'
+        assert answer.cpu == 'cpu'
+        assert answer.os == 'os'
 
         generated = r.DNSOutgoing(0)
         generated.add_additional_answer(DNSHinfo('irrelevant', const._TYPE_HINFO, 0, 0, 'cpu', 'x' * 257))

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 
 """ Unit tests for zeroconf._services. """
@@ -48,7 +47,7 @@ class ListenerTest(unittest.TestCase):
         type_ = "_http._tcp.local."
         subtype = subtype_name + "._sub." + type_
         name = "UPPERxxxyyyæøå"
-        registration_name = "%s.%s" % (name, subtype)
+        registration_name = f"{name}.{subtype}"
 
         class MyListener(r.ServiceListener):
             def add_service(self, zeroconf, type, name):

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 
 """ Unit tests for zeroconf._services. """
@@ -67,7 +66,7 @@ def test_legacy_record_update_listener():
 
     info_service = ServiceInfo(
         type_,
-        '%s.%s' % (name, type_),
+        f'{name}.{type_}',
         80,
         0,
         0,

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -653,7 +653,7 @@ class Zeroconf(QuietLogger):
                     raise NonUniqueNameException
 
                 # change the name and look for a conflict
-                info.name = '%s-%s.%s' % (instance_name, next_instance_number, info.type)
+                info.name = f'{instance_name}-{next_instance_number}.{info.type}'
                 next_instance_number += 1
                 service_type_name(info.name)
                 next_time = now

--- a/zeroconf/_dns.py
+++ b/zeroconf/_dns.py
@@ -100,7 +100,7 @@ class DNSEntry:
 
     def entry_to_string(self, hdr: str, other: Optional[Union[bytes, str]]) -> str:
         """String representation with additional information"""
-        return "%s[%s,%s%s,%s]%s" % (
+        return "{}[{},{}{},{}]{}".format(
             hdr,
             self.get_type(self.type),
             self.get_class_(self.class_),
@@ -142,7 +142,7 @@ class DNSQuestion(DNSEntry):
 
     def __repr__(self) -> str:
         """String representation"""
-        return "%s[question,%s,%s,%s]" % (
+        return "{}[question,{},{},{}]".format(
             self.get_type(self.type),
             "QU" if self.unicast else "QM",
             self.get_class_(self.class_),
@@ -230,7 +230,7 @@ class DNSRecord(DNSEntry):
 
     def to_string(self, other: Union[bytes, str]) -> str:
         """String representation with additional information"""
-        arg = "%s/%s,%s" % (self.ttl, int(self.get_remaining_ttl(current_time_millis())), cast(Any, other))
+        arg = f"{self.ttl}/{int(self.get_remaining_ttl(current_time_millis()))},{cast(Any, other)}"
         return DNSEntry.entry_to_string(self, "record", arg)
 
 
@@ -439,7 +439,7 @@ class DNSService(DNSRecord):
 
     def __repr__(self) -> str:
         """String representation"""
-        return self.to_string("%s:%s" % (self.server, self.port))
+        return self.to_string(f"{self.server}:{self.port}")
 
 
 class DNSNsec(DNSRecord):

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -140,11 +140,11 @@ class _QueryResponse:
 
     def _additionals_from_answers_rrset(self, rrset: Set[DNSRecord]) -> Set[DNSRecord]:
         additionals: Set[DNSRecord] = set()
-        return additionals.union(*[self._additionals[record] for record in rrset])
+        return additionals.union(*(self._additionals[record] for record in rrset))
 
     def _suppress_mcasts_from_last_second(self, rrset: Set[DNSRecord]) -> None:
         """Remove any records that were already sent in the last second."""
-        rrset -= set(record for record in rrset if self._has_mcast_record_in_last_second(record))
+        rrset -= {record for record in rrset if self._has_mcast_record_in_last_second(record)}
 
     def _has_mcast_within_one_quarter_ttl(self, record: DNSRecord) -> bool:
         """Check to see if a record has been mcasted recently.
@@ -201,13 +201,11 @@ class QueryHandler:
             # https://tools.ietf.org/html/rfc6763#section-12.1.
             dns_pointer = service.dns_pointer(created=now)
             if not known_answers.suppresses(dns_pointer):
-                answer_set[dns_pointer] = set(
-                    [
-                        service.dns_service(created=now),
-                        service.dns_text(created=now),
-                        *service.dns_addresses(created=now),
-                    ]
-                )
+                answer_set[dns_pointer] = {
+                    service.dns_service(created=now),
+                    service.dns_text(created=now),
+                    *service.dns_addresses(created=now),
+                }
 
     def _add_address_answers(
         self,
@@ -271,7 +269,7 @@ class QueryHandler:
         threadsafe.
         """
         ucast_source = port != _MDNS_PORT
-        known_answers = DNSRRSet(itertools.chain(*[msg.answers for msg in msgs]))
+        known_answers = DNSRRSet(itertools.chain(*(msg.answers for msg in msgs)))
         query_res = _QueryResponse(self.cache, msgs[0], ucast_source)
 
         for msg in msgs:

--- a/zeroconf/_protocol.py
+++ b/zeroconf/_protocol.py
@@ -259,10 +259,10 @@ class DNSIncoming(DNSMessage, QuietLogger):
                     next_ = off + 1
                 off = ((length & 0x3F) << 8) | self.data[off]
                 if off >= first:
-                    raise IncomingDecodeError("Bad domain name (circular) at %s" % (off,))
+                    raise IncomingDecodeError(f"Bad domain name (circular) at {off}")
                 first = off
             else:
-                raise IncomingDecodeError("Bad domain name at %s" % (off,))
+                raise IncomingDecodeError(f"Bad domain name at {off}")
 
         if next_ >= 0:
             self.offset = next_
@@ -523,7 +523,7 @@ class DNSOutgoing(DNSMessage):
         self.write_short(0)  # Will get replaced with the actual size
         record.write(self)
         # Adjust size for the short we will write before this record
-        length = sum((len(d) for d in self.data[index + 1 :]))
+        length = sum(len(d) for d in self.data[index + 1 :])
         # Here we replace the 0 length short we wrote
         # before with the actual length
         self._replace_short(index, length)

--- a/zeroconf/asyncio.py
+++ b/zeroconf/asyncio.py
@@ -251,7 +251,7 @@ class AsyncZeroconf:
     async def async_remove_all_service_listeners(self) -> None:
         """Removes a listener from the set that is currently listening."""
         await asyncio.gather(
-            *[self.async_remove_service_listener(listener) for listener in list(self.async_browsers)]
+            *(self.async_remove_service_listener(listener) for listener in list(self.async_browsers))
         )
 
     async def __aenter__(self) -> 'AsyncZeroconf':


### PR DESCRIPTION
- Remove older python syntax as the minimum supported version is 3.6

`pyupgrade --py36-plus tests/*.py zeroconf/*.py examples/*.py`