### PR TITLE
Remove locking from ServiceRegistry

### DIFF
--- a/tests/services/test_registry.py
+++ b/tests/services/test_registry.py
@@ -23,10 +23,10 @@ class TestServiceRegistry(unittest.TestCase):
         )
 
         registry = r.ServiceRegistry()
-        registry.add(info)
-        self.assertRaises(r.ServiceNameAlreadyRegistered, registry.add, info)
-        registry.remove(info)
-        registry.add(info)
+        registry.async_add(info)
+        self.assertRaises(r.ServiceNameAlreadyRegistered, registry.async_add, info)
+        registry.async_remove(info)
+        registry.async_add(info)
 
     def test_unregister_multiple_times(self):
         """Verify we can unregister a service multiple times.
@@ -46,10 +46,10 @@ class TestServiceRegistry(unittest.TestCase):
         )
 
         registry = r.ServiceRegistry()
-        registry.add(info)
-        self.assertRaises(r.ServiceNameAlreadyRegistered, registry.add, info)
-        registry.remove(info)
-        registry.remove(info)
+        registry.async_add(info)
+        self.assertRaises(r.ServiceNameAlreadyRegistered, registry.async_add, info)
+        registry.async_remove(info)
+        registry.async_remove(info)
 
     def test_lookups(self):
         type_ = "_test-srvc-type._tcp.local."
@@ -62,13 +62,13 @@ class TestServiceRegistry(unittest.TestCase):
         )
 
         registry = r.ServiceRegistry()
-        registry.add(info)
+        registry.async_add(info)
 
-        assert registry.get_service_infos() == [info]
-        assert registry.get_info_name(registration_name) == info
-        assert registry.get_infos_type(type_) == [info]
-        assert registry.get_infos_server("ash-2.local.") == [info]
-        assert registry.get_types() == [type_]
+        assert registry.async_get_service_infos() == [info]
+        assert registry.async_get_info_name(registration_name) == info
+        assert registry.async_get_infos_type(type_) == [info]
+        assert registry.async_get_infos_server("ash-2.local.") == [info]
+        assert registry.async_get_types() == [type_]
 
     def test_lookups_upper_case_by_lower_case(self):
         type_ = "_test-SRVC-type._tcp.local."
@@ -81,13 +81,13 @@ class TestServiceRegistry(unittest.TestCase):
         )
 
         registry = r.ServiceRegistry()
-        registry.add(info)
+        registry.async_add(info)
 
-        assert registry.get_service_infos() == [info]
-        assert registry.get_info_name(registration_name.lower()) == info
-        assert registry.get_infos_type(type_.lower()) == [info]
-        assert registry.get_infos_server("ash-2.local.") == [info]
-        assert registry.get_types() == [type_.lower()]
+        assert registry.async_get_service_infos() == [info]
+        assert registry.async_get_info_name(registration_name.lower()) == info
+        assert registry.async_get_infos_type(type_.lower()) == [info]
+        assert registry.async_get_infos_server("ash-2.local.") == [info]
+        assert registry.async_get_types() == [type_.lower()]
 
     def test_lookups_lower_case_by_upper_case(self):
         type_ = "_test-srvc-type._tcp.local."
@@ -100,10 +100,10 @@ class TestServiceRegistry(unittest.TestCase):
         )
 
         registry = r.ServiceRegistry()
-        registry.add(info)
+        registry.async_add(info)
 
-        assert registry.get_service_infos() == [info]
-        assert registry.get_info_name(registration_name.upper()) == info
-        assert registry.get_infos_type(type_.upper()) == [info]
-        assert registry.get_infos_server("ASH-2.local.") == [info]
-        assert registry.get_types() == [type_]
+        assert registry.async_get_service_infos() == [info]
+        assert registry.async_get_info_name(registration_name.upper()) == info
+        assert registry.async_get_infos_type(type_.upper()) == [info]
+        assert registry.async_get_infos_server("ASH-2.local.") == [info]
+        assert registry.async_get_types() == [type_]

--- a/tests/services/test_types.py
+++ b/tests/services/test_types.py
@@ -50,7 +50,7 @@ class ServiceTypesQuery(unittest.TestCase):
             "ash-2.local.",
             addresses=[socket.inet_aton("10.0.1.2")],
         )
-        zeroconf_registrar.registry.add(info)
+        zeroconf_registrar.registry.async_add(info)
         try:
             with patch.object(
                 zeroconf_registrar.engine.protocols[0], "suppress_duplicate_packet", return_value=False
@@ -87,7 +87,7 @@ class ServiceTypesQuery(unittest.TestCase):
             "ash-2.local.",
             addresses=[socket.inet_pton(socket.AF_INET6, addr)],
         )
-        zeroconf_registrar.registry.add(info)
+        zeroconf_registrar.registry.async_add(info)
         try:
             with patch.object(
                 zeroconf_registrar.engine.protocols[0], "suppress_duplicate_packet", return_value=False
@@ -124,7 +124,7 @@ class ServiceTypesQuery(unittest.TestCase):
             "ash-2.local.",
             addresses=[socket.inet_pton(socket.AF_INET6, addr)],
         )
-        zeroconf_registrar.registry.add(info)
+        zeroconf_registrar.registry.async_add(info)
         try:
             with patch.object(
                 zeroconf_registrar.engine.protocols[0], "suppress_duplicate_packet", return_value=False
@@ -160,7 +160,7 @@ class ServiceTypesQuery(unittest.TestCase):
             "ash-2.local.",
             addresses=[socket.inet_aton("10.0.1.2")],
         )
-        zeroconf_registrar.registry.add(info)
+        zeroconf_registrar.registry.async_add(info)
         try:
             with patch.object(
                 zeroconf_registrar.engine.protocols[0], "suppress_duplicate_packet", return_value=False

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -812,7 +812,7 @@ async def test_info_asking_default_is_asking_qm_questions_after_the_first_qu():
         type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[socket.inet_aton("10.0.1.2")]
     )
 
-    zeroconf_info.registry.add(info)
+    zeroconf_info.registry.async_add(info)
 
     # we are going to patch the zeroconf send to check query transmission
     old_send = zeroconf_info.async_send

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -335,11 +335,11 @@ def test_goodbye_all_services():
     info = r.ServiceInfo(
         type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[socket.inet_aton("10.0.1.2")]
     )
-    zc.registry.add(info)
+    zc.registry.async_add(info)
     out = zc.generate_unregister_all_services()
     assert out is not None
     first_packet = out.packets()
-    zc.registry.add(info)
+    zc.registry.async_add(info)
     out2 = zc.generate_unregister_all_services()
     assert out2 is not None
     second_packet = out.packets()
@@ -348,7 +348,7 @@ def test_goodbye_all_services():
     # Verify the registery is empty
     out3 = zc.generate_unregister_all_services()
     assert out3 is None
-    assert zc.registry.get_service_infos() == []
+    assert zc.registry.async_get_service_infos() == []
 
     zc.close()
 
@@ -438,9 +438,9 @@ def test_tc_bit_defers():
     info3 = r.ServiceInfo(
         type_, registration3_name, 80, 0, 0, desc, server_name3, addresses=[socket.inet_aton("10.0.1.2")]
     )
-    zc.registry.add(info)
-    zc.registry.add(info2)
-    zc.registry.add(info3)
+    zc.registry.async_add(info)
+    zc.registry.async_add(info2)
+    zc.registry.async_add(info3)
 
     protocol = zc.engine.protocols[0]
     now = r.current_time_millis()
@@ -517,9 +517,9 @@ def test_tc_bit_defers_last_response_missing():
     info3 = r.ServiceInfo(
         type_, registration3_name, 80, 0, 0, desc, server_name3, addresses=[socket.inet_aton("10.0.1.2")]
     )
-    zc.registry.add(info)
-    zc.registry.add(info2)
-    zc.registry.add(info3)
+    zc.registry.async_add(info)
+    zc.registry.async_add(info2)
+    zc.registry.async_add(info3)
 
     protocol = zc.engine.protocols[0]
     now = r.current_time_millis()
@@ -581,7 +581,7 @@ def test_tc_bit_defers_last_response_missing():
     assert source_ip not in protocol._timers
 
     # unregister
-    zc.registry.remove(info)
+    zc.registry.async_remove(info)
     zc.close()
 
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -87,7 +87,7 @@ class TestRegistrar(unittest.TestCase):
         expected_ttl = None
         for _ in range(3):
             _process_outgoing_packet(zc.generate_service_query(info))
-        zc.registry.add(info)
+        zc.registry.async_add(info)
         for _ in range(3):
             _process_outgoing_packet(zc.generate_service_broadcast(info, None))
         assert nbr_answers == 12 and nbr_additionals == 0 and nbr_authorities == 3
@@ -112,7 +112,7 @@ class TestRegistrar(unittest.TestCase):
 
         # unregister
         expected_ttl = 0
-        zc.registry.remove(info)
+        zc.registry.async_remove(info)
         for _ in range(3):
             _process_outgoing_packet(zc.generate_service_broadcast(info, 0))
         assert nbr_answers == 12 and nbr_additionals == 0 and nbr_authorities == 0
@@ -121,7 +121,7 @@ class TestRegistrar(unittest.TestCase):
         expected_ttl = None
         for _ in range(3):
             _process_outgoing_packet(zc.generate_service_query(info))
-        zc.registry.add(info)
+        zc.registry.async_add(info)
         # register service with custom TTL
         expected_ttl = const._DNS_HOST_TTL * 2
         assert expected_ttl != const._DNS_HOST_TTL
@@ -147,7 +147,7 @@ class TestRegistrar(unittest.TestCase):
 
         # unregister
         expected_ttl = 0
-        zc.registry.remove(info)
+        zc.registry.async_remove(info)
         for _ in range(3):
             _process_outgoing_packet(zc.generate_service_broadcast(info, 0))
         assert nbr_answers == 12 and nbr_additionals == 0 and nbr_authorities == 0
@@ -284,7 +284,7 @@ def test_any_query_for_ptr():
     server_name = "ash-2.local."
     ipv6_address = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
     info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, server_name, addresses=[ipv6_address])
-    zc.registry.add(info)
+    zc.registry.async_add(info)
 
     _clear_cache(zc)
     generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
@@ -297,7 +297,7 @@ def test_any_query_for_ptr():
     assert multicast_out.answers[0][0].name == type_
     assert multicast_out.answers[0][0].alias == registration_name
     # unregister
-    zc.registry.remove(info)
+    zc.registry.async_remove(info)
     zc.close()
 
 
@@ -311,7 +311,7 @@ def test_aaaa_query():
     server_name = "ash-2.local."
     ipv6_address = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
     info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, server_name, addresses=[ipv6_address])
-    zc.registry.add(info)
+    zc.registry.async_add(info)
 
     generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(server_name, const._TYPE_AAAA, const._CLASS_IN)
@@ -322,7 +322,7 @@ def test_aaaa_query():
     )
     assert multicast_out.answers[0][0].address == ipv6_address
     # unregister
-    zc.registry.remove(info)
+    zc.registry.async_remove(info)
     zc.close()
 
 
@@ -342,7 +342,7 @@ def test_a_and_aaaa_record_fate_sharing():
     aaaa_record = info.dns_addresses(version=r.IPVersion.V6Only)[0]
     a_record = info.dns_addresses(version=r.IPVersion.V4Only)[0]
 
-    zc.registry.add(info)
+    zc.registry.async_add(info)
 
     # Test AAAA query
     generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
@@ -375,7 +375,7 @@ def test_a_and_aaaa_record_fate_sharing():
     assert len(multicast_out.answers) == 1
     assert len(multicast_out.additionals) == 1
     # unregister
-    zc.registry.remove(info)
+    zc.registry.async_remove(info)
     zc.close()
 
 
@@ -393,7 +393,7 @@ def test_unicast_response():
         type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[socket.inet_aton("10.0.1.2")]
     )
     # register
-    zc.registry.add(info)
+    zc.registry.async_add(info)
     _clear_cache(zc)
 
     # query
@@ -420,7 +420,7 @@ def test_unicast_response():
         assert has_srv and has_txt and has_a
 
     # unregister
-    zc.registry.remove(info)
+    zc.registry.async_remove(info)
     zc.close()
 
 
@@ -535,7 +535,7 @@ def test_known_answer_supression():
     info = ServiceInfo(
         type_, registration_name, 80, 0, 0, desc, server_name, addresses=[socket.inet_aton("10.0.1.2")]
     )
-    zc.registry.add(info)
+    zc.registry.async_add(info)
 
     now = current_time_millis()
     _clear_cache(zc)
@@ -631,7 +631,7 @@ def test_known_answer_supression():
     assert not multicast_out or not multicast_out.answers
 
     # unregister
-    zc.registry.remove(info)
+    zc.registry.async_remove(info)
     zc.close()
 
 
@@ -660,9 +660,9 @@ def test_multi_packet_known_answer_supression():
     info3 = ServiceInfo(
         type_, registration3_name, 80, 0, 0, desc, server_name3, addresses=[socket.inet_aton("10.0.1.2")]
     )
-    zc.registry.add(info)
-    zc.registry.add(info2)
-    zc.registry.add(info3)
+    zc.registry.async_add(info)
+    zc.registry.async_add(info2)
+    zc.registry.async_add(info3)
 
     now = current_time_millis()
     _clear_cache(zc)
@@ -683,9 +683,9 @@ def test_multi_packet_known_answer_supression():
     assert unicast_out is None
     assert multicast_out is None
     # unregister
-    zc.registry.remove(info)
-    zc.registry.remove(info2)
-    zc.registry.remove(info3)
+    zc.registry.async_remove(info)
+    zc.registry.async_remove(info2)
+    zc.registry.async_remove(info3)
     zc.close()
 
 
@@ -699,7 +699,7 @@ def test_known_answer_supression_service_type_enumeration_query():
     info = ServiceInfo(
         type_, registration_name, 80, 0, 0, desc, server_name, addresses=[socket.inet_aton("10.0.1.2")]
     )
-    zc.registry.add(info)
+    zc.registry.async_add(info)
 
     type_2 = "_otherknown2._tcp.local."
     name = "knownname"
@@ -709,7 +709,7 @@ def test_known_answer_supression_service_type_enumeration_query():
     info2 = ServiceInfo(
         type_2, registration_name2, 80, 0, 0, desc, server_name2, addresses=[socket.inet_aton("10.0.1.2")]
     )
-    zc.registry.add(info2)
+    zc.registry.async_add(info2)
     now = current_time_millis()
     _clear_cache(zc)
 
@@ -755,8 +755,8 @@ def test_known_answer_supression_service_type_enumeration_query():
     assert not multicast_out or not multicast_out.answers
 
     # unregister
-    zc.registry.remove(info)
-    zc.registry.remove(info2)
+    zc.registry.async_remove(info)
+    zc.registry.async_remove(info2)
     zc.close()
 
 
@@ -777,7 +777,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
     info = ServiceInfo(
         type_, registration_name, 80, 0, 0, desc, server_name, addresses=[socket.inet_aton("10.0.1.2")]
     )
-    zc.registry.add(info)
+    zc.registry.async_add(info)
 
     type_2 = "_addtest2._tcp.local."
     name = "knownname"
@@ -787,7 +787,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
     info2 = ServiceInfo(
         type_2, registration_name2, 80, 0, 0, desc, server_name2, addresses=[socket.inet_aton("10.0.1.2")]
     )
-    zc.registry.add(info2)
+    zc.registry.async_add(info2)
 
     ptr_record = info.dns_pointer()
 
@@ -888,7 +888,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
     assert info2.dns_service() in unicast_out.additionals
 
     # unregister
-    zc.registry.remove(info)
+    zc.registry.async_remove(info)
     await aiozc.async_close()
 
 

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -518,7 +518,7 @@ class Zeroconf(QuietLogger):
 
         await self.async_wait_for_start()
         await self.async_check_service(info, allow_name_change, cooperating_responders)
-        self.registry.add(info)
+        self.registry.async_add(info)
         return asyncio.ensure_future(self._async_broadcast_service(info, _REGISTER_TIME, None))
 
     def update_service(self, info: ServiceInfo) -> None:
@@ -534,7 +534,7 @@ class Zeroconf(QuietLogger):
         """Registers service information to the network with a default TTL.
         Zeroconf will then respond to requests for information for that
         service."""
-        self.registry.update(info)
+        self.registry.async_update(info)
         return asyncio.ensure_future(self._async_broadcast_service(info, _REGISTER_TIME, None))
 
     async def _async_broadcast_service(self, info: ServiceInfo, interval: int, ttl: Optional[int]) -> None:
@@ -587,18 +587,18 @@ class Zeroconf(QuietLogger):
 
     async def async_unregister_service(self, info: ServiceInfo) -> Awaitable:
         """Unregister a service."""
-        self.registry.remove(info)
+        self.registry.async_remove(info)
         return asyncio.ensure_future(self._async_broadcast_service(info, _UNREGISTER_TIME, 0))
 
     def generate_unregister_all_services(self) -> Optional[DNSOutgoing]:
         """Generate a DNSOutgoing goodbye for all services and remove them from the registry."""
-        service_infos = self.registry.get_service_infos()
+        service_infos = self.registry.async_get_service_infos()
         if not service_infos:
             return None
         out = DNSOutgoing(_FLAGS_QR_RESPONSE | _FLAGS_AA)
         for info in service_infos:
             self._add_broadcast_answer(out, info, 0)
-        self.registry.remove(service_infos)
+        self.registry.async_remove(service_infos)
         return out
 
     async def async_unregister_all_services(self) -> None:

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -185,7 +185,7 @@ class QueryHandler:
 
         https://datatracker.ietf.org/doc/html/rfc6763#section-9
         """
-        for stype in self.registry.get_types():
+        for stype in self.registry.async_get_types():
             dns_pointer = DNSPointer(
                 _SERVICE_TYPE_ENUMERATION_NAME, _TYPE_PTR, _CLASS_IN, _DNS_OTHER_TTL, stype, now
             )
@@ -196,7 +196,7 @@ class QueryHandler:
         self, name: str, answer_set: _AnswerWithAdditionalsType, known_answers: DNSRRSet, now: float
     ) -> None:
         """Answer PTR/ANY question."""
-        for service in self.registry.get_infos_type(name):
+        for service in self.registry.async_get_infos_type(name):
             # Add recommended additional answers according to
             # https://tools.ietf.org/html/rfc6763#section-12.1.
             dns_pointer = service.dns_pointer(created=now)
@@ -216,7 +216,7 @@ class QueryHandler:
         type_: int,
     ) -> None:
         """Answer A/AAAA/ANY question."""
-        for service in self.registry.get_infos_server(name):
+        for service in self.registry.async_get_infos_server(name):
             answers: List[DNSAddress] = []
             additionals: Set[DNSRecord] = set()
             for dns_address in service.dns_addresses(created=now):
@@ -247,7 +247,7 @@ class QueryHandler:
             self._add_address_answers(question.name, answer_set, known_answers, now, type_)
 
         if type_ in (_TYPE_SRV, _TYPE_TXT, _TYPE_ANY):
-            service = self.registry.get_info_name(question.name)  # type: ignore
+            service = self.registry.async_get_info_name(question.name)  # type: ignore
             if service is not None:
                 if type_ in (_TYPE_SRV, _TYPE_ANY):
                     # Add recommended additional answers according to


### PR DESCRIPTION
- All calls to the ServiceRegistry are now done in async context
  which makes them thread safe. Locking is no longer needed.