### PR TITLE
Let connection_lost close the underlying socket

### DIFF
--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -324,7 +324,6 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         self.transport = cast(asyncio.DatagramTransport, transport)
-        assert self.zc.loop is not None
 
     def connection_lost(self, exc: Optional[Exception]) -> None:
         """Handle connection lost.

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -331,7 +331,7 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
         self.transport = cast(asyncio.DatagramTransport, transport)
 
     def connection_lost(self, exc: Optional[Exception]) -> None:
-        """Log connection lost.
+        """Handle connection lost and set the closed future.
 
         This should only happen at shutdown.
         """

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -192,8 +192,8 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
     the read() method called when a socket is available for reading."""
 
     def __init__(self, zc: 'Zeroconf') -> None:
-        assert zc.loop is not None
         self.zc = zc
+        assert self.zc.loop is not None
         self.data: Optional[bytes] = None
         self.last_time: float = 0
         self.transport: Optional[asyncio.DatagramTransport] = None

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -192,6 +192,7 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
     the read() method called when a socket is available for reading."""
 
     def __init__(self, zc: 'Zeroconf') -> None:
+        assert zc.loop is not None
         self.zc = zc
         self.data: Optional[bytes] = None
         self.last_time: float = 0

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -193,6 +193,7 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
         self.data: Optional[bytes] = None
         self.last_time: float = 0
         self.transport: Optional[asyncio.DatagramTransport] = None
+
         self._deferred: Dict[str, List[DNSIncoming]] = {}
         self._timers: Dict[str, asyncio.TimerHandle] = {}
 

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -328,6 +328,16 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         self.transport = cast(asyncio.DatagramTransport, transport)
 
+    def connection_lost(self, exc: Optional[Exception]) -> None:
+        """Log connection lost.
+
+        This should only happen at shutdown.
+        """
+        assert self.transport is not None
+        log.debug(
+            "Lost connection with socket: %d: %s", self.transport.get_extra_info('socket').fileno(), exc
+        )
+
 
 class Zeroconf(QuietLogger):
 

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -326,15 +326,7 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
         self.transport = cast(asyncio.DatagramTransport, transport)
 
     def connection_lost(self, exc: Optional[Exception]) -> None:
-        """Handle connection lost.
-
-        This should only happen at shutdown.
-        """
-        if exc:
-            assert self.transport is not None
-            log.debug(
-                "Lost connection with socket: %d: %s", self.transport.get_extra_info('socket').fileno(), exc
-            )
+        """Handle connection lost."""
 
 
 class Zeroconf(QuietLogger):

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -336,9 +336,10 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
 
         This should only happen at shutdown.
         """
-        assert self.transport is not None
-        assert self.closed is not None
+        if self.closed:
+            self.closed.set_result(None)
         if exc:
+            assert self.transport is not None
             log.debug(
                 "Lost connection with socket: %d: %s", self.transport.get_extra_info('socket').fileno(), exc
             )

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -337,8 +337,7 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
         This should only happen at shutdown.
         """
         assert self.transport is not None
-        if self.closed:
-            self.closed.set_result(None)
+        assert self.closed is not None
         if exc:
             log.debug(
                 "Lost connection with socket: %d: %s", self.transport.get_extra_info('socket').fileno(), exc


### PR DESCRIPTION
Fixes #917

- The socket was closed during shutdown before asyncio's connection_lost
  handler had a chance to close it which resulted in a traceback on
  win32.