### PR TITLE
Ensure zeroconf can be loaded when the system disables IPv6

### DIFF
--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -192,6 +192,8 @@ class TestServiceInfo(unittest.TestCase):
         assert info.properties[b"ci"] == b"2"
         zc.close()
 
+    @unittest.skipIf(not has_working_ipv6(), 'Requires IPv6')
+    @unittest.skipIf(os.environ.get('SKIP_IPV6'), 'IPv6 tests disabled')
     def test_get_info_partial(self):
 
         zc = r.Zeroconf(interfaces=['127.0.0.1'])
@@ -576,6 +578,8 @@ async def test_multiple_a_addresses():
     await aiozc.async_close()
 
 
+@unittest.skipIf(not has_working_ipv6(), 'Requires IPv6')
+@unittest.skipIf(os.environ.get('SKIP_IPV6'), 'IPv6 tests disabled')
 def test_filter_address_by_type_from_service_info():
     """Verify dns_addresses can filter by ipversion."""
     desc = {'path': '/~paulsm/'}

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -5,6 +5,7 @@
 
 import asyncio
 import logging
+import os
 import socket
 import time
 import threading
@@ -32,7 +33,7 @@ import zeroconf._services.browser as _services_browser
 from zeroconf._services.info import ServiceInfo
 from zeroconf._utils.time import current_time_millis
 
-from . import _clear_cache
+from . import _clear_cache, has_working_ipv6
 
 log = logging.getLogger('zeroconf')
 original_logging_level = logging.NOTSET
@@ -349,6 +350,9 @@ async def test_async_wait_unblocks_on_update() -> None:
 @pytest.mark.asyncio
 async def test_service_info_async_request() -> None:
     """Test registering services broadcasts and query with AsyncServceInfo.async_request."""
+    if not has_working_ipv6() or os.environ.get('SKIP_IPV6'):
+        pytest.skip('Requires IPv6')
+
     aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
     type_ = "_test1-srvc-type._tcp.local."
     name = "xxxyyy"

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -4,6 +4,7 @@
 """ Unit tests for zeroconf._dns. """
 
 import logging
+import os
 import socket
 import time
 import unittest
@@ -17,6 +18,8 @@ from zeroconf import (
     DNSText,
     ServiceInfo,
 )
+
+from . import has_working_ipv6
 
 log = logging.getLogger('zeroconf')
 original_logging_level = logging.NOTSET
@@ -52,6 +55,8 @@ class TestDunder(unittest.TestCase):
         pointer = r.DNSPointer('irrelevant', const._TYPE_PTR, const._CLASS_IN, const._DNS_OTHER_TTL, '123')
         repr(pointer)
 
+    @unittest.skipIf(not has_working_ipv6(), 'Requires IPv6')
+    @unittest.skipIf(os.environ.get('SKIP_IPV6'), 'IPv6 tests disabled')
     def test_dns_address_repr(self):
         address = r.DNSAddress('irrelevant', const._TYPE_SOA, const._CLASS_IN, 1, b'a')
         assert repr(address).endswith("b'a'")

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -5,6 +5,7 @@
 
 import asyncio
 import logging
+import os
 import pytest
 import socket
 import time
@@ -19,7 +20,7 @@ from zeroconf._dns import DNSRRSet
 from zeroconf.asyncio import AsyncZeroconf
 
 
-from . import _clear_cache, _inject_response
+from . import _clear_cache, _inject_response, has_working_ipv6
 
 log = logging.getLogger('zeroconf')
 original_logging_level = logging.NOTSET
@@ -274,6 +275,8 @@ def test_ptr_optimization():
     zc.close()
 
 
+@unittest.skipIf(not has_working_ipv6(), 'Requires IPv6')
+@unittest.skipIf(os.environ.get('SKIP_IPV6'), 'IPv6 tests disabled')
 def test_any_query_for_ptr():
     """Test that queries for ANY will return PTR records."""
     zc = Zeroconf(interfaces=['127.0.0.1'])
@@ -301,6 +304,8 @@ def test_any_query_for_ptr():
     zc.close()
 
 
+@unittest.skipIf(not has_working_ipv6(), 'Requires IPv6')
+@unittest.skipIf(os.environ.get('SKIP_IPV6'), 'IPv6 tests disabled')
 def test_aaaa_query():
     """Test that queries for AAAA records work."""
     zc = Zeroconf(interfaces=['127.0.0.1'])
@@ -326,6 +331,8 @@ def test_aaaa_query():
     zc.close()
 
 
+@unittest.skipIf(not has_working_ipv6(), 'Requires IPv6')
+@unittest.skipIf(os.environ.get('SKIP_IPV6'), 'IPv6 tests disabled')
 def test_a_and_aaaa_record_fate_sharing():
     """Test that queries for AAAA always return A records in the additionals."""
     zc = Zeroconf(interfaces=['127.0.0.1'])

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -5,6 +5,7 @@
 
 import copy
 import logging
+import os
 import socket
 import struct
 import unittest
@@ -17,6 +18,8 @@ from zeroconf import (
     DNSHinfo,
     DNSText,
 )
+
+from . import has_working_ipv6
 
 log = logging.getLogger('zeroconf')
 original_logging_level = logging.NOTSET
@@ -468,6 +471,8 @@ class TestDnsIncoming(unittest.TestCase):
             )
         ).valid
 
+    @unittest.skipIf(not has_working_ipv6(), 'Requires IPv6')
+    @unittest.skipIf(os.environ.get('SKIP_IPV6'), 'IPv6 tests disabled')
     def test_incoming_ipv6(self):
         addr = "2606:2800:220:1:248:1893:25c8:1946"  # example.com
         packed = socket.inet_pton(socket.AF_INET6, addr)

--- a/tests/utils/test_net.py
+++ b/tests/utils/test_net.py
@@ -190,6 +190,10 @@ def test_add_multicast_member():
     with patch("socket.socket.setsockopt", side_effect=OSError(errno.ENODEV, None)):
         assert netutils.add_multicast_member(sock, ('2001:db8::', 1, 1)) is False
 
+    # No IPv6 support should return False for IPv6
+    with patch("socket.inet_pton", side_effect=OSError()):
+        assert netutils.add_multicast_member(sock, ('2001:db8::', 1, 1)) is False
+
     # No error should return True
     with patch("socket.socket.setsockopt"):
         assert netutils.add_multicast_member(sock, interface) is True

--- a/zeroconf/_utils/net.py
+++ b/zeroconf/_utils/net.py
@@ -260,6 +260,12 @@ def add_multicast_member(
     try:
         if is_v6:
             iface_bin = struct.pack('@I', cast(int, interface[1]))
+            if _MDNS_ADDR6_BYTES is None:
+                log.info(
+                    'Failed to add %s to multicast group, system has no IPv6 support',
+                    interface,
+                )
+                return False
             _value = _MDNS_ADDR6_BYTES + iface_bin
             listen_socket.setsockopt(_IPPROTO_IPV6, socket.IPV6_JOIN_GROUP, _value)
         else:

--- a/zeroconf/const.py
+++ b/zeroconf/const.py
@@ -20,7 +20,6 @@
     USA
 """
 
-import contextlib
 import re
 import socket
 
@@ -46,8 +45,10 @@ _LOADED_SYSTEM_TIMEOUT = 10  # s
 _MDNS_ADDR = '224.0.0.251'
 _MDNS_ADDR_BYTES = socket.inet_aton(_MDNS_ADDR)
 _MDNS_ADDR6 = 'ff02::fb'
-with contextlib.suppress(OSError):  # can't use AF_INET6, IPv6 is disabled
+try:
     _MDNS_ADDR6_BYTES = socket.inet_pton(socket.AF_INET6, _MDNS_ADDR6)
+except OSError:  # can't use AF_INET6, IPv6 is disabled
+    _MDNS_ADDR6_BYTES = b'\xff\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xfb'
 _MDNS_PORT = 5353
 _DNS_PORT = 53
 _DNS_HOST_TTL = 120  # two minute for host records (A, SRV etc) as-per RFC6762

--- a/zeroconf/const.py
+++ b/zeroconf/const.py
@@ -48,7 +48,7 @@ _MDNS_ADDR6 = 'ff02::fb'
 try:
     _MDNS_ADDR6_BYTES = socket.inet_pton(socket.AF_INET6, _MDNS_ADDR6)
 except OSError:  # can't use AF_INET6, IPv6 is disabled
-    _MDNS_ADDR6_BYTES = b'\xff\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xfb'
+    _MDNS_ADDR6_BYTES = None
 _MDNS_PORT = 5353
 _DNS_PORT = 53
 _DNS_HOST_TTL = 120  # two minute for host records (A, SRV etc) as-per RFC6762

--- a/zeroconf/const.py
+++ b/zeroconf/const.py
@@ -22,6 +22,7 @@
 
 import re
 import socket
+from typing import Union
 
 # Some timing constants
 
@@ -46,7 +47,7 @@ _MDNS_ADDR = '224.0.0.251'
 _MDNS_ADDR_BYTES = socket.inet_aton(_MDNS_ADDR)
 _MDNS_ADDR6 = 'ff02::fb'
 try:
-    _MDNS_ADDR6_BYTES = socket.inet_pton(socket.AF_INET6, _MDNS_ADDR6)
+    _MDNS_ADDR6_BYTES = socket.inet_pton(socket.AF_INET6, _MDNS_ADDR6)  # type: Union[bytes, None]
 except OSError:  # can't use AF_INET6, IPv6 is disabled
     _MDNS_ADDR6_BYTES = None
 _MDNS_PORT = 5353

--- a/zeroconf/const.py
+++ b/zeroconf/const.py
@@ -22,7 +22,6 @@
 
 import re
 import socket
-from typing import Union
 
 # Some timing constants
 
@@ -44,12 +43,7 @@ _LOADED_SYSTEM_TIMEOUT = 10  # s
 # Some DNS constants
 
 _MDNS_ADDR = '224.0.0.251'
-_MDNS_ADDR_BYTES = socket.inet_aton(_MDNS_ADDR)
 _MDNS_ADDR6 = 'ff02::fb'
-try:
-    _MDNS_ADDR6_BYTES = socket.inet_pton(socket.AF_INET6, _MDNS_ADDR6)  # type: Union[bytes, None]
-except OSError:  # can't use AF_INET6, IPv6 is disabled
-    _MDNS_ADDR6_BYTES = None
 _MDNS_PORT = 5353
 _DNS_PORT = 53
 _DNS_HOST_TTL = 120  # two minute for host records (A, SRV etc) as-per RFC6762


### PR DESCRIPTION
related to #234

The current error on 0.32.1 up to 0.33.2:

```
>>> import zeroconf
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.9/site-packages/zeroconf/__init__.py", line 25, in <module>
    from ._cache import DNSCache  # noqa # import needed for backwards compat
  File "/usr/lib/python3.9/site-packages/zeroconf/_cache.py", line 26, in <module>
    from ._dns import (
  File "/usr/lib/python3.9/site-packages/zeroconf/_dns.py", line 28, in <module>
    from ._utils.net import _is_v6_address
  File "/usr/lib/python3.9/site-packages/zeroconf/_utils/net.py", line 34, in <module>
    from ..const import _IPPROTO_IPV6, _MDNS_ADDR6_BYTES, _MDNS_ADDR_BYTES, _MDNS_PORT
ImportError: cannot import name '_MDNS_ADDR6_BYTES' from 'zeroconf.const' (/usr/lib/python3.9/site-packages/zeroconf/const.py)
```