### PR TITLE
Send to the v4 compatibility address when using dual v4/v6 sockets

### DIFF
--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -69,6 +69,7 @@ from .const import (
     _MAX_MSG_ABSOLUTE,
     _MDNS_ADDR,
     _MDNS_ADDR6,
+    _MDNS_ADDR6_V4_COMPAT,
     _MDNS_PORT,
     _REGISTER_TIME,
     _TYPE_PTR,
@@ -371,6 +372,7 @@ class Zeroconf(QuietLogger):
         """
         if ip_version is None:
             ip_version = autodetect_ip_version(interfaces)
+        self.ip_version = ip_version
 
         # hook for threads
         self._GLOBAL_DONE = False
@@ -760,7 +762,10 @@ class Zeroconf(QuietLogger):
                     return
                 s = transport.get_extra_info('socket')
                 if addr is None:
-                    real_addr = _MDNS_ADDR6 if s.family == socket.AF_INET6 else _MDNS_ADDR
+                    if s.family == socket.AF_INET6:
+                        real_addr = _MDNS_ADDR6 if self.ip_version.V6Only else _MDNS_ADDR6_V4_COMPAT
+                    else:
+                        real_addr = _MDNS_ADDR
                 elif not can_send_to(s, addr):
                     continue
                 else:

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -763,7 +763,8 @@ class Zeroconf(QuietLogger):
                 s = transport.get_extra_info('socket')
                 if addr is None:
                     if s.family == socket.AF_INET6:
-                        real_addr = _MDNS_ADDR6 if self.ip_version.V6Only else _MDNS_ADDR6_V4_COMPAT
+                        #real_addr = _MDNS_ADDR6 if self.ip_version.V6Only else _MDNS_ADDR6_V4_COMPAT
+                        real_addr = _MDNS_ADDR6_V4_COMPAT
                     else:
                         real_addr = _MDNS_ADDR
                 elif not can_send_to(s, addr):

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -763,7 +763,7 @@ class Zeroconf(QuietLogger):
                 s = transport.get_extra_info('socket')
                 if addr is None:
                     if s.family == socket.AF_INET6:
-                        #real_addr = _MDNS_ADDR6 if self.ip_version.V6Only else _MDNS_ADDR6_V4_COMPAT
+                        # real_addr = _MDNS_ADDR6 if self.ip_version.V6Only else _MDNS_ADDR6_V4_COMPAT
                         real_addr = _MDNS_ADDR6_V4_COMPAT
                     else:
                         real_addr = _MDNS_ADDR

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -763,8 +763,7 @@ class Zeroconf(QuietLogger):
                 s = transport.get_extra_info('socket')
                 if addr is None:
                     if s.family == socket.AF_INET6:
-                        # real_addr = _MDNS_ADDR6 if self.ip_version.V6Only else _MDNS_ADDR6_V4_COMPAT
-                        real_addr = _MDNS_ADDR6_V4_COMPAT
+                        real_addr = _MDNS_ADDR6_V4_COMPAT if self.ip_version == IPVersion.All else _MDNS_ADDR6
                     else:
                         real_addr = _MDNS_ADDR
                 elif not can_send_to(s, addr):

--- a/zeroconf/const.py
+++ b/zeroconf/const.py
@@ -43,6 +43,7 @@ _LOADED_SYSTEM_TIMEOUT = 10  # s
 # Some DNS constants
 
 _MDNS_ADDR = '224.0.0.251'
+_MDNS_ADDR6_V4_COMPAT = f"::ffff:{_MDNS_ADDR}"
 _MDNS_ADDR6 = 'ff02::fb'
 _MDNS_PORT = 5353
 _DNS_PORT = 53


### PR DESCRIPTION
I setup a network with ipv6 enabled on Home Assistant, and disabled on the network gear.

Sending to `::ffff:224.0.0.251` on the ipv6 socket allowed both the ipv6 internal network on the device and and the local network ipv4 devices to see the responses.

Maybe fixes https://github.com/home-assistant/core/issues/54196