### PR TITLE
Implement Multicast Response Aggregation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,10 @@ import threading
 
 import pytest
 
+import unittest
+
+from zeroconf import _core, const
+
 
 @pytest.fixture(autouse=True)
 def verify_threads_ended():
@@ -15,3 +19,12 @@ def verify_threads_ended():
     yield
     threads = frozenset(threading.enumerate()) - threads_before
     assert not threads
+
+
+@pytest.fixture
+def run_isolated():
+    """Change the mDNS port to run the test in isolation."""
+    with unittest.mock.patch.object(_core, "_MDNS_PORT", 5454), unittest.mock.patch.object(
+        const, "_MDNS_PORT", 5454
+    ):
+        yield

--- a/tests/services/test_types.py
+++ b/tests/services/test_types.py
@@ -57,10 +57,10 @@ class ServiceTypesQuery(unittest.TestCase):
             ), patch.object(
                 zeroconf_registrar.engine.protocols[1], "suppress_duplicate_packet", return_value=False
             ):
-                service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=0.5)
+                service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=1)
                 assert type_ in service_types
                 _clear_cache(zeroconf_registrar)
-                service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=0.5)
+                service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=1)
                 assert type_ in service_types
 
         finally:
@@ -94,10 +94,10 @@ class ServiceTypesQuery(unittest.TestCase):
             ), patch.object(
                 zeroconf_registrar.engine.protocols[1], "suppress_duplicate_packet", return_value=False
             ):
-                service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=0.5)
+                service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=1)
                 assert type_ in service_types
                 _clear_cache(zeroconf_registrar)
-                service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=0.5)
+                service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=1)
                 assert type_ in service_types
 
         finally:
@@ -131,10 +131,10 @@ class ServiceTypesQuery(unittest.TestCase):
             ), patch.object(
                 zeroconf_registrar.engine.protocols[1], "suppress_duplicate_packet", return_value=False
             ):
-                service_types = ZeroconfServiceTypes.find(ip_version=r.IPVersion.V6Only, timeout=0.5)
+                service_types = ZeroconfServiceTypes.find(ip_version=r.IPVersion.V6Only, timeout=1)
                 assert type_ in service_types
                 _clear_cache(zeroconf_registrar)
-                service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=0.5)
+                service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=1)
                 assert type_ in service_types
 
         finally:
@@ -167,10 +167,10 @@ class ServiceTypesQuery(unittest.TestCase):
             ), patch.object(
                 zeroconf_registrar.engine.protocols[1], "suppress_duplicate_packet", return_value=False
             ):
-                service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=0.5)
+                service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=1)
                 assert discovery_type in service_types
                 _clear_cache(zeroconf_registrar)
-                service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=0.5)
+                service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=1)
                 assert discovery_type in service_types
 
         finally:

--- a/tests/services/test_types.py
+++ b/tests/services/test_types.py
@@ -57,10 +57,10 @@ class ServiceTypesQuery(unittest.TestCase):
             ), patch.object(
                 zeroconf_registrar.engine.protocols[1], "suppress_duplicate_packet", return_value=False
             ):
-                service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=1)
+                service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=2)
                 assert type_ in service_types
                 _clear_cache(zeroconf_registrar)
-                service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=1)
+                service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=2)
                 assert type_ in service_types
 
         finally:
@@ -94,10 +94,10 @@ class ServiceTypesQuery(unittest.TestCase):
             ), patch.object(
                 zeroconf_registrar.engine.protocols[1], "suppress_duplicate_packet", return_value=False
             ):
-                service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=1)
+                service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=2)
                 assert type_ in service_types
                 _clear_cache(zeroconf_registrar)
-                service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=1)
+                service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=2)
                 assert type_ in service_types
 
         finally:
@@ -131,10 +131,10 @@ class ServiceTypesQuery(unittest.TestCase):
             ), patch.object(
                 zeroconf_registrar.engine.protocols[1], "suppress_duplicate_packet", return_value=False
             ):
-                service_types = ZeroconfServiceTypes.find(ip_version=r.IPVersion.V6Only, timeout=1)
+                service_types = ZeroconfServiceTypes.find(ip_version=r.IPVersion.V6Only, timeout=2)
                 assert type_ in service_types
                 _clear_cache(zeroconf_registrar)
-                service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=1)
+                service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=2)
                 assert type_ in service_types
 
         finally:
@@ -167,10 +167,10 @@ class ServiceTypesQuery(unittest.TestCase):
             ), patch.object(
                 zeroconf_registrar.engine.protocols[1], "suppress_duplicate_packet", return_value=False
             ):
-                service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=1)
+                service_types = ZeroconfServiceTypes.find(interfaces=['127.0.0.1'], timeout=2)
                 assert discovery_type in service_types
                 _clear_cache(zeroconf_registrar)
-                service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=1)
+                service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=2)
                 assert discovery_type in service_types
 
         finally:

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -980,7 +980,7 @@ async def test_legacy_unicast_response():
 
     calls = send_mock.mock_calls
     assert calls == [call(ANY, '127.0.0.1', 6503, ())]
-    outgoing = calls[0].args[0]
+    outgoing = send_mock.call_args[0][0]
     assert isinstance(outgoing, DNSOutgoing)
     assert outgoing.questions == [question]
     assert outgoing.id == query.id

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -615,10 +615,10 @@ async def test_async_zeroconf_service_types():
     await asyncio.sleep(0.2)
     _clear_cache(zeroconf_registrar.zeroconf)
     try:
-        service_types = await AsyncZeroconfServiceTypes.async_find(interfaces=['127.0.0.1'], timeout=0.5)
+        service_types = await AsyncZeroconfServiceTypes.async_find(interfaces=['127.0.0.1'], timeout=1)
         assert type_ in service_types
         _clear_cache(zeroconf_registrar.zeroconf)
-        service_types = await AsyncZeroconfServiceTypes.async_find(aiozc=zeroconf_registrar, timeout=0.5)
+        service_types = await AsyncZeroconfServiceTypes.async_find(aiozc=zeroconf_registrar, timeout=1)
         assert type_ in service_types
 
     finally:

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -956,7 +956,7 @@ async def test_async_request_timeout():
 
 
 @pytest.mark.asyncio
-async def test_legacy_unicast_response():
+async def test_legacy_unicast_response(run_isolated):
     """Verify legacy unicast responses include questions and correct id."""
     type_ = "_mservice._tcp.local."
     aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -615,10 +615,10 @@ async def test_async_zeroconf_service_types():
     await asyncio.sleep(0.2)
     _clear_cache(zeroconf_registrar.zeroconf)
     try:
-        service_types = await AsyncZeroconfServiceTypes.async_find(interfaces=['127.0.0.1'], timeout=1)
+        service_types = await AsyncZeroconfServiceTypes.async_find(interfaces=['127.0.0.1'], timeout=2)
         assert type_ in service_types
         _clear_cache(zeroconf_registrar.zeroconf)
-        service_types = await AsyncZeroconfServiceTypes.async_find(aiozc=zeroconf_registrar, timeout=1)
+        service_types = await AsyncZeroconfServiceTypes.async_find(aiozc=zeroconf_registrar, timeout=2)
         assert type_ in service_types
 
     finally:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -696,10 +696,10 @@ def test_guard_against_oversized_packets():
     listener = _core.AsyncListener(zc)
     listener.transport = unittest.mock.MagicMock()
 
-    listener.datagram_received(ok_packet, ('127.0.0.1', 5353))
+    listener.datagram_received(ok_packet, ('127.0.0.1', const._MDNS_PORT))
     assert zc.cache.async_get_unique(okpacket_record) is not None
 
-    listener.datagram_received(over_sized_packet, ('127.0.0.1', 5353))
+    listener.datagram_received(over_sized_packet, ('127.0.0.1', const._MDNS_PORT))
     assert (
         zc.cache.async_get_unique(
             r.DNSText(

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -207,7 +207,7 @@ class TestRegistrar(unittest.TestCase):
         out = r.DNSOutgoing(const._FLAGS_QR_QUERY)
         out.add_question(r.DNSQuestion(type_.upper(), const._TYPE_PTR, const._CLASS_IN))
         zc.send(out)
-        time.sleep(0.5)
+        time.sleep(1)
         info = ServiceInfo(type_, registration_name)
         info.load_from_cache(zc)
         assert info.addresses == [socket.inet_pton(socket.AF_INET, "1.2.3.4")]

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -237,7 +237,7 @@ def test_ptr_optimization():
     # Verify we won't respond for 1s with the same multicast
     query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     query.add_question(r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN))
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], None, const._MDNS_PORT
     )
     assert unicast_out is None
@@ -249,7 +249,7 @@ def test_ptr_optimization():
     # Verify we will now respond
     query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     query.add_question(r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN))
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], None, const._MDNS_PORT
     )
     assert multicast_out.id == query.id
@@ -294,7 +294,7 @@ def test_any_query_for_ptr():
     question = r.DNSQuestion(type_, const._TYPE_ANY, const._CLASS_IN)
     generated.add_question(question)
     packets = generated.packets()
-    _, multicast_out = zc.query_handler.async_response(
+    _, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
     )
     assert multicast_out.answers[0][0].name == type_
@@ -322,7 +322,7 @@ def test_aaaa_query():
     question = r.DNSQuestion(server_name, const._TYPE_AAAA, const._CLASS_IN)
     generated.add_question(question)
     packets = generated.packets()
-    _, multicast_out = zc.query_handler.async_response(
+    _, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
     )
     assert multicast_out.answers[0][0].address == ipv6_address
@@ -356,7 +356,7 @@ def test_a_and_aaaa_record_fate_sharing():
     question = r.DNSQuestion(server_name, const._TYPE_AAAA, const._CLASS_IN)
     generated.add_question(question)
     packets = generated.packets()
-    _, multicast_out = zc.query_handler.async_response(
+    _, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
     )
     answers = DNSRRSet([answer[0] for answer in multicast_out.answers])
@@ -371,7 +371,7 @@ def test_a_and_aaaa_record_fate_sharing():
     question = r.DNSQuestion(server_name, const._TYPE_A, const._CLASS_IN)
     generated.add_question(question)
     packets = generated.packets()
-    _, multicast_out = zc.query_handler.async_response(
+    _, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
     )
     answers = DNSRRSet([answer[0] for answer in multicast_out.answers])
@@ -406,7 +406,7 @@ def test_unicast_response():
     # query
     query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     query.add_question(r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN))
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], "1.2.3.4", 1234
     )
     for out in (unicast_out, multicast_out):
@@ -483,7 +483,7 @@ def test_qu_response():
     assert question.unicast is True
     query.add_question(question)
 
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], "1.2.3.4", const._MDNS_PORT
     )
     assert multicast_out is None
@@ -496,7 +496,7 @@ def test_qu_response():
     question.unicast = True  # Set the QU bit
     assert question.unicast is True
     query.add_question(question)
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], "1.2.3.4", const._MDNS_PORT
     )
     assert unicast_out is None
@@ -509,7 +509,7 @@ def test_qu_response():
     assert question.unicast is True
     query.add_question(question)
     query.add_authorative_answer(info2.dns_pointer())
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], "1.2.3.4", const._MDNS_PORT
     )
     _validate_complete_response(query, unicast_out)
@@ -522,7 +522,7 @@ def test_qu_response():
     question.unicast = True  # Set the QU bit
     assert question.unicast is True
     query.add_question(question)
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], "1.2.3.4", const._MDNS_PORT
     )
     assert multicast_out is None
@@ -551,7 +551,7 @@ def test_known_answer_supression():
     question = r.DNSQuestion(type_, const._TYPE_PTR, const._CLASS_IN)
     generated.add_question(question)
     packets = generated.packets()
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
     )
     assert unicast_out is None
@@ -562,7 +562,7 @@ def test_known_answer_supression():
     generated.add_question(question)
     generated.add_answer_at_time(info.dns_pointer(), now)
     packets = generated.packets()
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
     )
     assert unicast_out is None
@@ -574,7 +574,7 @@ def test_known_answer_supression():
     question = r.DNSQuestion(server_name, const._TYPE_A, const._CLASS_IN)
     generated.add_question(question)
     packets = generated.packets()
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
     )
     assert unicast_out is None
@@ -586,7 +586,7 @@ def test_known_answer_supression():
     for dns_address in info.dns_addresses():
         generated.add_answer_at_time(dns_address, now)
     packets = generated.packets()
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
     )
     assert unicast_out is None
@@ -597,7 +597,7 @@ def test_known_answer_supression():
     question = r.DNSQuestion(registration_name, const._TYPE_SRV, const._CLASS_IN)
     generated.add_question(question)
     packets = generated.packets()
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
     )
     assert unicast_out is None
@@ -608,7 +608,7 @@ def test_known_answer_supression():
     generated.add_question(question)
     generated.add_answer_at_time(info.dns_service(), now)
     packets = generated.packets()
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
     )
     assert unicast_out is None
@@ -620,7 +620,7 @@ def test_known_answer_supression():
     question = r.DNSQuestion(registration_name, const._TYPE_TXT, const._CLASS_IN)
     generated.add_question(question)
     packets = generated.packets()
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
     )
     assert unicast_out is None
@@ -631,7 +631,7 @@ def test_known_answer_supression():
     generated.add_question(question)
     generated.add_answer_at_time(info.dns_text(), now)
     packets = generated.packets()
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
     )
     assert unicast_out is None
@@ -684,7 +684,7 @@ def test_multi_packet_known_answer_supression():
     generated.add_answer_at_time(info3.dns_pointer(), now)
     packets = generated.packets()
     assert len(packets) > 1
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
     )
     assert unicast_out is None
@@ -725,7 +725,7 @@ def test_known_answer_supression_service_type_enumeration_query():
     question = r.DNSQuestion(const._SERVICE_TYPE_ENUMERATION_NAME, const._TYPE_PTR, const._CLASS_IN)
     generated.add_question(question)
     packets = generated.packets()
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
     )
     assert unicast_out is None
@@ -755,7 +755,7 @@ def test_known_answer_supression_service_type_enumeration_query():
         now,
     )
     packets = generated.packets()
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
     )
     assert unicast_out is None
@@ -815,7 +815,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
     assert question.unicast is True
     query.add_question(question)
 
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], "1.2.3.4", const._MDNS_PORT
     )
     assert multicast_out is None
@@ -835,7 +835,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
     assert question.unicast is True
     query.add_question(question)
 
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], "1.2.3.4", const._MDNS_PORT
     )
     assert multicast_out is None
@@ -855,7 +855,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
     assert question.unicast is True
     query.add_question(question)
 
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], "1.2.3.4", const._MDNS_PORT
     )
     assert multicast_out.answers[0][0] == ptr_record
@@ -881,7 +881,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
     query.add_question(question)
     zc.cache.async_add_records([info2.dns_pointer()])  # Add 100% TTL for info2 to the cache
 
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], "1.2.3.4", const._MDNS_PORT
     )
     assert multicast_out.answers[0][0] == info.dns_pointer()
@@ -1045,7 +1045,7 @@ async def test_questions_query_handler_populates_the_question_history_from_qm_qu
     generated.add_answer_at_time(known_answer, 0)
     now = r.current_time_millis()
     packets = generated.packets()
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
     )
     assert unicast_out is None
@@ -1072,7 +1072,7 @@ async def test_questions_query_handler_does_not_put_qu_questions_in_history():
     generated.add_answer_at_time(known_answer, 0)
     now = r.current_time_millis()
     packets = generated.packets()
-    unicast_out, multicast_out = zc.query_handler.async_response(
+    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
     )
     assert unicast_out is None

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1219,7 +1219,7 @@ async def test_duplicate_goodbye_answers_in_packet():
 
 
 @pytest.mark.asyncio
-async def test_response_aggregation_timings():
+async def test_response_aggregation_timings(run_isolated):
     """Verify multicast respones are aggregated."""
     type_ = "_mservice._tcp.local."
     type_2 = "_mservice2._tcp.local."
@@ -1258,13 +1258,13 @@ async def test_response_aggregation_timings():
     protocol = zc.engine.protocols[0]
 
     with unittest.mock.patch.object(aiozc.zeroconf, "async_send") as send_mock:
-        protocol.datagram_received(query.packets()[0], ('127.0.0.1', 5353))
+        protocol.datagram_received(query.packets()[0], ('127.0.0.1', const._MDNS_PORT))
         await asyncio.sleep(0.1)
-        protocol.datagram_received(query2.packets()[0], ('127.0.0.1', 5353))
+        protocol.datagram_received(query2.packets()[0], ('127.0.0.1', const._MDNS_PORT))
         await asyncio.sleep(0.1)
-        protocol.datagram_received(query.packets()[0], ('127.0.0.1', 5353))
+        protocol.datagram_received(query.packets()[0], ('127.0.0.1', const._MDNS_PORT))
         await asyncio.sleep(0.1)
-        protocol.datagram_received(query2.packets()[0], ('127.0.0.1', 5353))
+        protocol.datagram_received(query2.packets()[0], ('127.0.0.1', const._MDNS_PORT))
         await asyncio.sleep(0.3)
 
         calls = send_mock.mock_calls
@@ -1278,7 +1278,9 @@ async def test_response_aggregation_timings():
 
         # Because the response was sent in the last second we need to make
         # sure the next answer is delayed at least a second
-        aiozc.zeroconf.engine.protocols[0].datagram_received(query3.packets()[0], ('127.0.0.1', 5353))
+        aiozc.zeroconf.engine.protocols[0].datagram_received(
+            query3.packets()[0], ('127.0.0.1', const._MDNS_PORT)
+        )
         await asyncio.sleep(0.5)
 
         # After 0.5 seconds it should not have been sent

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -554,34 +554,33 @@ def test_known_answer_supression():
     question = r.DNSQuestion(type_, const._TYPE_PTR, const._CLASS_IN)
     generated.add_question(question)
     packets = generated.packets()
-    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
-        [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
-    )
-    assert unicast_out is None
-    assert multicast_out is not None and multicast_out.answers
+    question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert not question_answers.ucast
+    assert not question_answers.mcast_now
+    assert question_answers.mcast_aggregate
+    assert not question_answers.mcast_aggregate_last_second
 
     generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(type_, const._TYPE_PTR, const._CLASS_IN)
     generated.add_question(question)
     generated.add_answer_at_time(info.dns_pointer(), now)
     packets = generated.packets()
-    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
-        [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
-    )
-    assert unicast_out is None
-    # If the answer is suppressed, the additional should be suppresed as well
-    assert not multicast_out or not multicast_out.answers
+    question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert not question_answers.ucast
+    assert not question_answers.mcast_now
+    assert not question_answers.mcast_aggregate
+    assert not question_answers.mcast_aggregate_last_second
 
     # Test A supression
     generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(server_name, const._TYPE_A, const._CLASS_IN)
     generated.add_question(question)
     packets = generated.packets()
-    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
-        [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
-    )
-    assert unicast_out is None
-    assert multicast_out is not None and multicast_out.answers
+    question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert not question_answers.ucast
+    assert question_answers.mcast_now
+    assert not question_answers.mcast_aggregate
+    assert not question_answers.mcast_aggregate_last_second
 
     generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(server_name, const._TYPE_A, const._CLASS_IN)
@@ -589,56 +588,55 @@ def test_known_answer_supression():
     for dns_address in info.dns_addresses():
         generated.add_answer_at_time(dns_address, now)
     packets = generated.packets()
-    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
-        [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
-    )
-    assert unicast_out is None
-    assert not multicast_out or not multicast_out.answers
+    question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert not question_answers.ucast
+    assert not question_answers.mcast_now
+    assert not question_answers.mcast_aggregate
+    assert not question_answers.mcast_aggregate_last_second
 
     # Test SRV supression
     generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(registration_name, const._TYPE_SRV, const._CLASS_IN)
     generated.add_question(question)
     packets = generated.packets()
-    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
-        [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
-    )
-    assert unicast_out is None
-    assert multicast_out is not None and multicast_out.answers
+    question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert not question_answers.ucast
+    assert question_answers.mcast_now
+    assert not question_answers.mcast_aggregate
+    assert not question_answers.mcast_aggregate_last_second
 
     generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(registration_name, const._TYPE_SRV, const._CLASS_IN)
     generated.add_question(question)
     generated.add_answer_at_time(info.dns_service(), now)
     packets = generated.packets()
-    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
-        [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
-    )
-    assert unicast_out is None
-    # If the answer is suppressed, the additional should be suppresed as well
-    assert not multicast_out or not multicast_out.answers
+    question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert not question_answers.ucast
+    assert not question_answers.mcast_now
+    assert not question_answers.mcast_aggregate
+    assert not question_answers.mcast_aggregate_last_second
 
     # Test TXT supression
     generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(registration_name, const._TYPE_TXT, const._CLASS_IN)
     generated.add_question(question)
     packets = generated.packets()
-    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
-        [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
-    )
-    assert unicast_out is None
-    assert multicast_out is not None and multicast_out.answers
+    question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert not question_answers.ucast
+    assert not question_answers.mcast_now
+    assert question_answers.mcast_aggregate
+    assert not question_answers.mcast_aggregate_last_second
 
     generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(registration_name, const._TYPE_TXT, const._CLASS_IN)
     generated.add_question(question)
     generated.add_answer_at_time(info.dns_text(), now)
     packets = generated.packets()
-    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
-        [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
-    )
-    assert unicast_out is None
-    assert not multicast_out or not multicast_out.answers
+    question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert not question_answers.ucast
+    assert not question_answers.mcast_now
+    assert not question_answers.mcast_aggregate
+    assert not question_answers.mcast_aggregate_last_second
 
     # unregister
     zc.registry.async_remove(info)
@@ -687,11 +685,11 @@ def test_multi_packet_known_answer_supression():
     generated.add_answer_at_time(info3.dns_pointer(), now)
     packets = generated.packets()
     assert len(packets) > 1
-    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
-        [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
-    )
-    assert unicast_out is None
-    assert multicast_out is None
+    question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert not question_answers.ucast
+    assert not question_answers.mcast_now
+    assert not question_answers.mcast_aggregate
+    assert not question_answers.mcast_aggregate_last_second
     # unregister
     zc.registry.async_remove(info)
     zc.registry.async_remove(info2)
@@ -728,11 +726,11 @@ def test_known_answer_supression_service_type_enumeration_query():
     question = r.DNSQuestion(const._SERVICE_TYPE_ENUMERATION_NAME, const._TYPE_PTR, const._CLASS_IN)
     generated.add_question(question)
     packets = generated.packets()
-    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
-        [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
-    )
-    assert unicast_out is None
-    assert multicast_out is not None and multicast_out.answers
+    question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert not question_answers.ucast
+    assert not question_answers.mcast_now
+    assert question_answers.mcast_aggregate
+    assert not question_answers.mcast_aggregate_last_second
 
     generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(const._SERVICE_TYPE_ENUMERATION_NAME, const._TYPE_PTR, const._CLASS_IN)
@@ -758,11 +756,11 @@ def test_known_answer_supression_service_type_enumeration_query():
         now,
     )
     packets = generated.packets()
-    unicast_out, multicast_out, delayed, delayed_mcast_last_second = zc.query_handler.async_response(
-        [r.DNSIncoming(packet) for packet in packets], "1.2.3.4", const._MDNS_PORT
-    )
-    assert unicast_out is None
-    assert not multicast_out or not multicast_out.answers
+    question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert not question_answers.ucast
+    assert not question_answers.mcast_now
+    assert not question_answers.mcast_aggregate
+    assert not question_answers.mcast_aggregate_last_second
 
     # unregister
     zc.registry.async_remove(info)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1269,7 +1269,8 @@ async def test_response_aggregation_timings():
 
         calls = send_mock.mock_calls
         assert len(calls) == 1
-        incoming = r.DNSIncoming(calls[0].args[0].packets()[0])
+        outgoing = send_mock.call_args[0][0]
+        incoming = r.DNSIncoming(outgoing.packets()[0])
         zc.handle_response(incoming)
         assert info.dns_pointer() in incoming.answers
         assert info2.dns_pointer() in incoming.answers
@@ -1290,7 +1291,8 @@ async def test_response_aggregation_timings():
         await asyncio.sleep(1.2)
         calls = send_mock.mock_calls
         assert len(calls) == 1
-        incoming = r.DNSIncoming(calls[0].args[0].packets()[0])
+        outgoing = send_mock.call_args[0][0]
+        incoming = r.DNSIncoming(outgoing.packets()[0])
         assert info.dns_pointer() in incoming.answers
 
     await aiozc.async_close()

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -767,6 +767,8 @@ class Zeroconf(QuietLogger):
         v6_flow_scope: Union[Tuple[()], Tuple[int, int]] = (),
     ) -> None:
         """Sends an outgoing packet."""
+        if self._GLOBAL_DONE:
+            return
         for packet_num, packet in enumerate(out.packets()):
             if len(packet) > _MAX_MSG_ABSOLUTE:
                 self.log_warning_once("Dropping %r over-sized packet (%d bytes) %r", out, len(packet), packet)
@@ -781,8 +783,6 @@ class Zeroconf(QuietLogger):
                 packet,
             )
             for transport in self.engine.senders:
-                if self._GLOBAL_DONE:
-                    return
                 s = transport.get_extra_info('socket')
                 if addr is None:
                     real_addr = _MDNS_ADDR6 if s.family == socket.AF_INET6 else _MDNS_ADDR

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -27,8 +27,7 @@ import socket
 import sys
 import threading
 from types import TracebackType  # noqa # used in type hints
-from typing import Awaitable, Deque, Dict, List, Optional, Set, Tuple, Type, Union, cast
-from collections import deque
+from typing import Awaitable, Dict, List, Optional, Tuple, Type, Union, cast
 
 from ._cache import DNSCache
 from ._dns import DNSQuestion, DNSQuestionType

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -397,7 +397,7 @@ class Zeroconf(QuietLogger):
         self.loop: Optional[asyncio.AbstractEventLoop] = None
         self._loop_thread: Optional[threading.Thread] = None
 
-        self.outgoing = MulticastOutgoingQueue(self)
+        self._out_queue = MulticastOutgoingQueue(self)
 
         self.start()
 
@@ -730,9 +730,9 @@ class Zeroconf(QuietLogger):
         if multicast_out:
             self.async_send(multicast_out)
         if delayed:
-            self.outgoing.async_add(packets[0].now, delayed, False)
+            self._out_queue.async_add(packets[0].now, delayed, False)
         if delayed_mcast_last_second:
-            self.outgoing.async_add(packets[0].now, delayed_mcast_last_second, True)
+            self._out_queue.async_add(packets[0].now, delayed_mcast_last_second, True)
 
     def send(
         self,

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -730,17 +730,17 @@ class Zeroconf(QuietLogger):
         packet will be in packets.
         """
         now = packets[0].now
+        ucast_source = port != _MDNS_PORT
         (
             ucast_now,
             mcast_now,
             mcast_aggregate,
             mcast_aggregate_last_second,
-        ) = self.query_handler.async_response(packets, addr, port)
+        ) = self.query_handler.async_response(packets, ucast_source)
         if ucast_now:
-            unicast_source = port != _MDNS_PORT
             questions = packets[0].questions
             id_ = packets[0].id
-            out = construct_outgoing_unicast_answers(ucast_now, unicast_source, questions, id_)
+            out = construct_outgoing_unicast_answers(ucast_now, ucast_source, questions, id_)
             self.async_send(out, addr, port, v6_flow_scope)
         if mcast_now:
             out = construct_outgoing_multicast_answers(mcast_aggregate)

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -769,6 +769,7 @@ class Zeroconf(QuietLogger):
         """Sends an outgoing packet."""
         if self._GLOBAL_DONE:
             return
+
         for packet_num, packet in enumerate(out.packets()):
             if len(packet) > _MAX_MSG_ABSOLUTE:
                 self.log_warning_once("Dropping %r over-sized packet (%d bytes) %r", out, len(packet), packet)

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -58,6 +58,7 @@ _AnswerWithAdditionalsType = Dict[DNSRecord, Set[DNSRecord]]
 _MULTICAST_DELAY_RANDOM_INTERVAL = (20, 120)
 _MAX_MULTICAST_DELAY = 500  # ms
 _ONE_SECOND = 1000  # ms
+_RESPOND_IMMEDIATE_TYPES = {_TYPE_SRV, _TYPE_A, _TYPE_AAAA}
 
 
 def construct_outgoing_answers_and_additionals(
@@ -131,7 +132,7 @@ class _QueryResponse:
                 self._mcast.add(answer)
             if self._has_mcast_record_in_last_second(answer):
                 self._mcast_delayed_last_second.add(answer)
-            elif len(self._msg.questions) == 1:
+            elif len(self._msg.questions) == 1 and self._msg.questions[0].type in _RESPOND_IMMEDIATE_TYPES:
                 self._mcast.add(answer)
             else:
                 self._mcast_delayed.add(answer)

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -544,7 +544,7 @@ class MulticastOutgoingQueue:
             self.zc.loop.call_later(
                 millis_to_seconds(self._queue[0].send_after - now), self._async_check_ready
             )
-        log.log("Ready: %s & %s", answer_set)
+        log.log("Ready: %s", answer_set)
 
         if not answer_set:
             return

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -129,7 +129,7 @@ class _QueryResponse:
             if self._is_probe:
                 self._ucast.add(record)
             if not self._has_mcast_within_one_quarter_ttl(record):
-                self._mcast.add(record)
+                self._mcast_now.add(record)
             elif not self._is_probe:
                 self._ucast.add(record)
 

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -538,6 +538,7 @@ class MulticastOutgoingQueue:
                     "There is more in the queue, delaying until send_before: %s",
                     millis_to_seconds(self._queue[0].send_before - now),
                 )
+                assert self.zc.loop is not None
                 self.zc.loop.call_later(
                     millis_to_seconds(self._queue[0].send_before - now), self._async_check_ready
                 )

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -518,7 +518,7 @@ class MulticastOutgoingQueue:
         assert self.zc.loop is not None
         now = current_time_millis()
 
-        if len(self.queue) and self.queue[0].send_before > now:
+        if len(self.queue) > 1 and self.queue[0].send_before > now:
             # There is more than one answer in the queue,
             # delay until we have to send it (first answer group reaches send_before)
             self.zc.loop.call_later(millis_to_seconds(self.queue[0].send_before - now), self._async_ready)

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -534,15 +534,14 @@ class MulticastOutgoingQueue:
 
         now = current_time_millis()
         if queue_len > 1 and self._queue[0].send_before > now:
-            if now > self._queue[1].send_after:
-                log.warning(
-                    "There is more in the queue, delaying until send_before: %s",
-                    millis_to_seconds(self._queue[0].send_before - now),
-                )
-                assert self.zc.loop is not None
-                self.zc.loop.call_later(
-                    millis_to_seconds(self._queue[0].send_before - now), self._async_check_ready
-                )
+            log.warning(
+                "There is more in the queue, delaying until send_before: %s",
+                millis_to_seconds(self._queue[0].send_before - now),
+            )
+            assert self.zc.loop is not None
+            self.zc.loop.call_later(
+                millis_to_seconds(self._queue[0].send_before - now), self._async_check_ready
+            )
             return
 
         answer_set = set()

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -97,7 +97,7 @@ def construct_outgoing_unicast_answers(
 
 def _add_answers_additionals(out: DNSOutgoing, answers: _AnswerWithAdditionalsType) -> None:
     # Find additionals and suppress any additionals that are already in answers
-    additionals: Set[DNSRecord] = set(*(answers.values()))
+    additionals: Set[DNSRecord] = set().union(*answers.values())
     additionals -= answers.keys()
     for answer in answers:
         out.add_answer_at_time(answer, 0)

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -491,19 +491,13 @@ class MulticastOutgoingQueue:
 
     def __init__(self, zeroconf: 'Zeroconf') -> None:
         self.zc = zeroconf
-        self._cache = zeroconf.cache
         self._queue: deque = deque()
 
     def async_add(self, now: float, answers: _AnswerWithAdditionalsType, additional_delay: int) -> None:
         assert self.zc.loop is not None
-        delay = random.randint(*_MULTICAST_DELAY_RANDOM_INTERVAL)
-        send_after = now + delay
-        send_before = now + _MAX_MULTICAST_DELAY
-        if additional_delay:
-            delay += additional_delay
-            send_after += additional_delay
-            send_before += additional_delay
-
+        delay = random.randint(*_MULTICAST_DELAY_RANDOM_INTERVAL) + additional_delay
+        send_after = now + delay + additional_delay
+        send_before = now + _MAX_MULTICAST_DELAY + additional_delay
         log.warning(
             "!!!Called async_add with now:%s send_after:%s, send_before:%s, answers:%s -- last_second: %s",
             now,

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -75,7 +75,7 @@ class AnswerGroup(NamedTuple):
     answers: _AnswerWithAdditionalsType
 
 
-def _message_is_probe(msg: DNSIncoming):
+def _message_is_probe(msg: DNSIncoming) -> bool:
     return msg.num_authorities > 0
 
 
@@ -101,7 +101,7 @@ def construct_outgoing_unicast_answers(
 
 def _add_answers_additionals(out: DNSOutgoing, answers: _AnswerWithAdditionalsType) -> None:
     # Find additionals and suppress any additionals that are already in answers
-    additionals: Set[DNSRecord] = set().union(*answers.values())
+    additionals: Set[DNSRecord] = set().union(*answers.values())  # type: ignore
     additionals -= answers.keys()
     for answer in answers:
         out.add_answer_at_time(answer, 0)
@@ -273,7 +273,7 @@ class QueryHandler:
         question: DNSQuestion,
         known_answers: DNSRRSet,
         now: float,
-    ) -> None:
+    ) -> _AnswerWithAdditionalsType:
         answer_set: _AnswerWithAdditionalsType = {}
 
         if question.type == _TYPE_PTR and question.name.lower() == _SERVICE_TYPE_ENUMERATION_NAME:

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -501,7 +501,7 @@ class MulticastOutgoingQueue:
         send_before = now + _MAX_MULTICAST_DELAY + additional_delay
         if not len(self.queue):
             self.zc.loop.call_later(millis_to_seconds(random_delay), self._async_ready)
-        self._queue.append(AnswerGroup(send_after, send_before, answers))
+        self.queue.append(AnswerGroup(send_after, send_before, answers))
 
     def _async_ready(self) -> None:
         """Process anything in the queue that is ready."""

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -281,7 +281,7 @@ class QueryHandler:
                         answer_set[dns_text] = set()
 
     def async_response(  # pylint: disable=unused-argument
-        self, msgs: List[DNSIncoming], addr: Optional[str], port: int
+        self, msgs: List[DNSIncoming], ucast_source: bool
     ) -> Tuple[
         Optional[DNSOutgoing], Optional[DNSOutgoing], _AnswerWithAdditionalsType, _AnswerWithAdditionalsType
     ]:

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -526,7 +526,7 @@ class MulticastOutgoingQueue:
 
         if answers:
             # If we have the same answer scheduled to go out, remove it
-            for pending in self._queue:
+            for pending in self.queue:
                 for record in answers:
                     pending.answers.pop(record, None)
 

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -129,7 +129,7 @@ class _QueryResponse:
         """Build a query response."""
         self._is_probe = any(msg.num_authorities > 0 for msg in msgs)
         self._msg = msgs[0]
-        self._now = current_time_millis()
+        self._now = self._msg.now
         self._cache = cache
         self._additionals: _AnswerWithAdditionalsType = {}
         self._ucast: Set[DNSRecord] = set()

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -517,7 +517,7 @@ class MulticastOutgoingQueue:
         answers: _AnswerWithAdditionalsType = {}
         # Add all groups that can be sent now
         while len(self.queue) and self.queue[0].send_after <= now:
-            answers.update(self._queue.popleft().answers)
+            answers.update(self.queue.popleft().answers)
 
         if len(self.queue):
             # If there are still groups in the queue that are not ready to send

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -20,7 +20,6 @@
     USA
 """
 
-import asyncio
 import itertools
 import random
 from collections import deque

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -530,23 +530,23 @@ class MulticastOutgoingQueue:
             )
             return
 
-        answer_set: _AnswerWithAdditionalsType = {}
+        answers: _AnswerWithAdditionalsType = {}
         log.warning("Next send is %s and now=%s", self._queue[0].send_after, now)
         while len(self._queue) and self._queue[0].send_after <= now:
-            answer_set.update(self._queue.popleft().answers)
+            answers.update(self._queue.popleft().answers)
 
         if len(self._queue):
             self.zc.loop.call_later(
                 millis_to_seconds(self._queue[0].send_after - now), self._async_check_ready
             )
-        log.warning("Ready: %s", answer_set)
+        log.warning("Ready: %s", answers)
 
-        if not answer_set:
+        if not answers:
             return
 
         # If we have the same answer scheduled to go out, remove it
         for pending in self._queue:
-            for record in answer_set:
+            for record in answers:
                 pending.answers.pop(record, None)
 
-        self.zc.async_send(construct_outgoing_multicast_answers(answer_set))
+        self.zc.async_send(construct_outgoing_multicast_answers(answers))

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -514,10 +514,10 @@ class MulticastOutgoingQueue:
         assert self.zc.loop is not None
         log.warning("!!!Called _async_send_ready at %s with %s", current_time_millis(), list(self._queue))
         now = current_time_millis()
-        # There is more than one answer in the queue,
-        # delay until we have to send it (first answer group
-        # reaches send_before)
+
         if len(self._queue) and self._queue[0].send_before > now:
+            # There is more than one answer in the queue,
+            # delay until we have to send it (first answer group reaches send_before)
             self.zc.loop.call_later(
                 millis_to_seconds(self._queue[0].send_before - now), self._async_check_ready
             )
@@ -525,8 +525,8 @@ class MulticastOutgoingQueue:
 
         answers: _AnswerWithAdditionalsType = {}
         log.warning("Next send is %s and now=%s", self._queue[0].send_after, now)
+        # Add all groups that can be sent now
         while len(self._queue) and self._queue[0].send_after <= now:
-            # Add all groups that can be sent now
             answers.update(self._queue.popleft().answers)
 
         if len(self._queue):

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -517,7 +517,7 @@ class MulticastOutgoingQueue:
         # There is more than one answer in the queue,
         # delay until we have to send it (first answer group
         # reaches send_before)
-        if len(self._queue) > 1 and self._queue[0].send_before > now:
+        if len(self._queue) and self._queue[0].send_before > now:
             self.zc.loop.call_later(
                 millis_to_seconds(self._queue[0].send_before - now), self._async_check_ready
             )
@@ -526,20 +526,21 @@ class MulticastOutgoingQueue:
         answers: _AnswerWithAdditionalsType = {}
         log.warning("Next send is %s and now=%s", self._queue[0].send_after, now)
         while len(self._queue) and self._queue[0].send_after <= now:
+            # Add all groups that can be sent now
             answers.update(self._queue.popleft().answers)
 
         if len(self._queue):
+            # If there are still groups in the queue that are not ready to send
+            # be sure we schedule them to go out later
             self.zc.loop.call_later(
                 millis_to_seconds(self._queue[0].send_after - now), self._async_check_ready
             )
-        log.warning("Ready: %s", answers)
 
-        if not answers:
-            return
+        if answers:
+            log.warning("Ready: %s", answers)
+            # If we have the same answer scheduled to go out, remove it
+            for pending in self._queue:
+                for record in answers:
+                    pending.answers.pop(record, None)
 
-        # If we have the same answer scheduled to go out, remove it
-        for pending in self._queue:
-            for record in answers:
-                pending.answers.pop(record, None)
-
-        self.zc.async_send(construct_outgoing_multicast_answers(answers))
+            self.zc.async_send(construct_outgoing_multicast_answers(answers))

--- a/zeroconf/const.py
+++ b/zeroconf/const.py
@@ -34,6 +34,8 @@ _DUPLICATE_QUESTION_INTERVAL = _BROWSER_TIME - 1  # ms
 _BROWSER_BACKOFF_LIMIT = 3600  # s
 _CACHE_CLEANUP_INTERVAL = 10000  # ms
 _LOADED_SYSTEM_TIMEOUT = 10  # s
+_ONE_SECOND = 1000  # ms
+
 # If the system is loaded or the event
 # loop was blocked by another task that was doing I/O in the loop
 # (shouldn't happen but it does in practice) we need to give


### PR DESCRIPTION
- Responses are now aggregated when possible per rules in RFC6762 section 6.4
- Responses that trigger the protection against against excessive packet flooding due to
   software bugs or malicious attack described in RFC6762 section 6 are delayed instead of discarding as it was causing responders that implement Passive Observation Of Failures (POOF) to evict the records. 
- Probe responses are now always sent immediately as there were cases where they would fail to be answered in time to defend a name.

closes #939