### PR TITLE
Ensure ServiceInfo requests can be answered with the default timeout with network protection

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1382,9 +1382,9 @@ async def test_response_aggregation_timings_multiple(run_isolated):
         # 1000ms  (1s network protection delays)
         # - 900ms (already slept)
         # + 120ms (maximum random delay)
-        # + 500ms (maximum aggregation delay)
+        # + 200ms (maximum protected aggregation delay)
         # +  20ms (execution time)
-        await asyncio.sleep(millis_to_seconds(1000 - 900 + 120 + 500 + 20))
+        await asyncio.sleep(millis_to_seconds(1000 - 900 + 120 + 200 + 20))
         calls = send_mock.mock_calls
         assert len(calls) == 1
         outgoing = send_mock.call_args[0][0]
@@ -1430,7 +1430,7 @@ async def test_response_aggregation_random_delay():
         type_5, registration_name5, 80, 0, 0, desc, "ash-5.local.", addresses=[socket.inet_aton("10.0.1.2")]
     )
     mocked_zc = unittest.mock.MagicMock()
-    outgoing_queue = MulticastOutgoingQueue(mocked_zc, 0)
+    outgoing_queue = MulticastOutgoingQueue(mocked_zc, 0, 500)
 
     now = current_time_millis()
     with unittest.mock.patch.object(_handlers, "_MULTICAST_DELAY_RANDOM_INTERVAL", (500, 600)):

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -83,7 +83,20 @@ from .const import (
 )
 
 _TC_DELAY_RANDOM_INTERVAL = (400, 500)
-
+# The maximum amont of time to delay a multicast
+# response in order to aggregate answers
+_AGGREGATION_DELAY = 500  # ms
+# The maximum amont of time to delay a multicast
+# response in order to aggregate answers after
+# it has already been delayed to protect the network
+# from excessive traffic. We use a shorter time
+# window here as we want to _try_ to answer all
+# queries in under 1350ms while protecting
+# the network from excessive traffic to ensure
+# a service info request with two questions
+# can be answered in the default timeout of
+# 3000ms
+_PROTECTED_AGGREGATION_DELAY = 200  # ms
 
 _CLOSE_TIMEOUT = 3000  # ms
 _REGISTER_BROADCASTS = 3
@@ -403,8 +416,8 @@ class Zeroconf(QuietLogger):
         self.loop: Optional[asyncio.AbstractEventLoop] = None
         self._loop_thread: Optional[threading.Thread] = None
 
-        self._out_queue = MulticastOutgoingQueue(self, 0)
-        self._out_delay_queue = MulticastOutgoingQueue(self, _ONE_SECOND)
+        self._out_queue = MulticastOutgoingQueue(self, 0, _AGGREGATION_DELAY)
+        self._out_delay_queue = MulticastOutgoingQueue(self, _ONE_SECOND, _PROTECTED_AGGREGATION_DELAY)
 
         self.start()
 


### PR DESCRIPTION
- Adjust the time windows to ensure responses that have triggered the
protection against against excessive packet flooding due to
software bugs or malicious attack described in RFC6762 section 6
can respond in under 1350ms to ensure ServiceInfo can ask two
questions within the default timeout of 3000ms