### PR TITLE
Send unicast replies on the same socket the query was received

### DIFF
--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -979,7 +979,7 @@ async def test_legacy_unicast_response(run_isolated):
         aiozc.zeroconf.engine.protocols[0].datagram_received(query.packets()[0], ('127.0.0.1', 6503))
 
     calls = send_mock.mock_calls
-    assert calls == [call(ANY, '127.0.0.1', 6503, ())]
+    assert calls == [call(ANY, '127.0.0.1', 6503, (), ANY)]
     outgoing = send_mock.call_args[0][0]
     assert isinstance(outgoing, DNSOutgoing)
     assert outgoing.questions == [question]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -695,6 +695,7 @@ def test_guard_against_oversized_packets():
     # will guard against the oversized packet and we won't see it.
     listener = _core.AsyncListener(zc)
     listener.transport = unittest.mock.MagicMock()
+    listener.sock_fileno = 1
 
     listener.datagram_received(ok_packet, ('127.0.0.1', const._MDNS_PORT))
     assert zc.cache.async_get_unique(okpacket_record) is not None

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -695,7 +695,6 @@ def test_guard_against_oversized_packets():
     # will guard against the oversized packet and we won't see it.
     listener = _core.AsyncListener(zc)
     listener.transport = unittest.mock.MagicMock()
-    listener.sock_fileno = 1
 
     listener.datagram_received(ok_packet, ('127.0.0.1', const._MDNS_PORT))
     assert zc.cache.async_get_unique(okpacket_record) is not None

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -480,28 +480,28 @@ def test_tc_bit_defers():
 
     next_packet = r.DNSIncoming(packets.pop(0))
     expected_deferred.append(next_packet)
-    threadsafe_query(zc, protocol, next_packet, source_ip, const._MDNS_PORT)
+    threadsafe_query(zc, protocol, next_packet, source_ip, const._MDNS_PORT, None)
     assert protocol._deferred[source_ip] == expected_deferred
     assert source_ip in protocol._timers
 
     next_packet = r.DNSIncoming(packets.pop(0))
     expected_deferred.append(next_packet)
-    threadsafe_query(zc, protocol, next_packet, source_ip, const._MDNS_PORT)
+    threadsafe_query(zc, protocol, next_packet, source_ip, const._MDNS_PORT, None)
     assert protocol._deferred[source_ip] == expected_deferred
     assert source_ip in protocol._timers
-    threadsafe_query(zc, protocol, next_packet, source_ip, const._MDNS_PORT)
-    assert protocol._deferred[source_ip] == expected_deferred
-    assert source_ip in protocol._timers
-
-    next_packet = r.DNSIncoming(packets.pop(0))
-    expected_deferred.append(next_packet)
-    threadsafe_query(zc, protocol, next_packet, source_ip, const._MDNS_PORT)
+    threadsafe_query(zc, protocol, next_packet, source_ip, const._MDNS_PORT, None)
     assert protocol._deferred[source_ip] == expected_deferred
     assert source_ip in protocol._timers
 
     next_packet = r.DNSIncoming(packets.pop(0))
     expected_deferred.append(next_packet)
-    threadsafe_query(zc, protocol, next_packet, source_ip, const._MDNS_PORT)
+    threadsafe_query(zc, protocol, next_packet, source_ip, const._MDNS_PORT, None)
+    assert protocol._deferred[source_ip] == expected_deferred
+    assert source_ip in protocol._timers
+
+    next_packet = r.DNSIncoming(packets.pop(0))
+    expected_deferred.append(next_packet)
+    threadsafe_query(zc, protocol, next_packet, source_ip, const._MDNS_PORT, None)
     assert source_ip not in protocol._deferred
     assert source_ip not in protocol._timers
 
@@ -559,13 +559,13 @@ def test_tc_bit_defers_last_response_missing():
 
     next_packet = r.DNSIncoming(packets.pop(0))
     expected_deferred.append(next_packet)
-    threadsafe_query(zc, protocol, next_packet, source_ip, const._MDNS_PORT)
+    threadsafe_query(zc, protocol, next_packet, source_ip, const._MDNS_PORT, None)
     assert protocol._deferred[source_ip] == expected_deferred
     timer1 = protocol._timers[source_ip]
 
     next_packet = r.DNSIncoming(packets.pop(0))
     expected_deferred.append(next_packet)
-    threadsafe_query(zc, protocol, next_packet, source_ip, const._MDNS_PORT)
+    threadsafe_query(zc, protocol, next_packet, source_ip, const._MDNS_PORT, None)
     assert protocol._deferred[source_ip] == expected_deferred
     timer2 = protocol._timers[source_ip]
     if sys.version_info >= (3, 7):
@@ -573,7 +573,7 @@ def test_tc_bit_defers_last_response_missing():
     assert timer2 != timer1
 
     # Send the same packet again to similar multi interfaces
-    threadsafe_query(zc, protocol, next_packet, source_ip, const._MDNS_PORT)
+    threadsafe_query(zc, protocol, next_packet, source_ip, const._MDNS_PORT, None)
     assert protocol._deferred[source_ip] == expected_deferred
     assert source_ip in protocol._timers
     timer3 = protocol._timers[source_ip]
@@ -583,7 +583,7 @@ def test_tc_bit_defers_last_response_missing():
 
     next_packet = r.DNSIncoming(packets.pop(0))
     expected_deferred.append(next_packet)
-    threadsafe_query(zc, protocol, next_packet, source_ip, const._MDNS_PORT)
+    threadsafe_query(zc, protocol, next_packet, source_ip, const._MDNS_PORT, None)
     assert protocol._deferred[source_ip] == expected_deferred
     assert source_ip in protocol._timers
     timer4 = protocol._timers[source_ip]

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -349,7 +349,6 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
     @property
     def _socket_description(self) -> str:
         """A human readable description of the socket."""
-        assert self.transport is not None
         return f"{self._sock_fileno} ({self._sock_name})"
 
     def error_received(self, exc: Exception) -> None:
@@ -803,12 +802,14 @@ class Zeroconf(QuietLogger):
                 return
             for transport in self.engine.senders:
                 s = transport.get_extra_info('socket')
-                if sock_fileno is not None and not self.unicast and sock_fileno != s.fileno():
+                fileno = s.fileno()
+                if sock_fileno is not None and not self.unicast and sock_fileno != fileno:
                     continue
                 log.debug(
-                    'Sending to (%s, %d) via %s (%d bytes #%d) %r as %r...',
+                    'Sending to (%s, %d) via [socket %s (%s)] (%d bytes #%d) %r as %r...',
                     addr,
                     port,
+                    fileno,
                     transport.get_extra_info('sockname'),
                     len(packet),
                     packet_num + 1,

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -807,12 +807,9 @@ class Zeroconf(QuietLogger):
                     real_addr = _MDNS_ADDR6 if s.family == socket.AF_INET6 else _MDNS_ADDR
                 else:
                     real_addr = addr
-                if (
-                    sock_fileno is not None
-                    and not self.unicast
-                    and sock_fileno != fileno
-                    or not can_send_to(s, addr)
-                ):
+                if not can_send_to(s, real_addr):
+                    continue
+                if not self.unicast and sock_fileno is not None and sock_fileno != fileno:
                     continue
                 log.debug(
                     'Sending to (%s, %d) via [socket %s (%s)] (%d bytes #%d) %r as %r...',

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -215,8 +215,8 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
         self.data: Optional[bytes] = None
         self.last_time: float = 0
         self.transport: Optional[asyncio.DatagramTransport] = None
-        self._sock_name: Optional[str] = None
-        self._sock_fileno: Optional[int] = None
+        self.sock_name: Optional[str] = None
+        self.sock_fileno: Optional[int] = None
         self._deferred: Dict[str, List[DNSIncoming]] = {}
         self._timers: Dict[str, asyncio.TimerHandle] = {}
 
@@ -234,7 +234,7 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
         self, data: bytes, addrs: Union[Tuple[str, int], Tuple[str, int, int, int]]
     ) -> None:
         assert self.transport is not None
-        assert self._sock_fileno is not None
+        assert self.sock_fileno is not None
         v6_flow_scope: Union[Tuple[()], Tuple[int, int]] = ()
         if len(addrs) == 2:
             # https://github.com/python/mypy/issues/1178
@@ -296,7 +296,7 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
             self.zc.handle_response(msg)
             return
 
-        self.handle_query_or_defer(msg, addr, port, self._sock_fileno, v6_flow_scope)
+        self.handle_query_or_defer(msg, addr, port, self.sock_fileno, v6_flow_scope)
 
     def handle_query_or_defer(
         self,
@@ -349,7 +349,7 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
     @property
     def _socket_description(self) -> str:
         """A human readable description of the socket."""
-        return f"{self._sock_fileno} ({self._sock_name})"
+        return f"{self.sock_fileno} ({self.sock_name})"
 
     def error_received(self, exc: Exception) -> None:
         """Likely socket closed or IPv6."""
@@ -362,8 +362,8 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         self.transport = cast(asyncio.DatagramTransport, transport)
-        self._sock_name = self.transport.get_extra_info('sockname')
-        self._sock_fileno = self.transport.get_extra_info('socket').fileno()
+        self.sock_name = self.transport.get_extra_info('sockname')
+        self.sock_fileno = self.transport.get_extra_info('socket').fileno()
 
     def connection_lost(self, exc: Optional[Exception]) -> None:
         """Handle connection lost."""

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -234,6 +234,7 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
         self, data: bytes, addrs: Union[Tuple[str, int], Tuple[str, int, int, int]]
     ) -> None:
         assert self.transport is not None
+        assert self._sock_fileno is not None
         v6_flow_scope: Union[Tuple[()], Tuple[int, int]] = ()
         if len(addrs) == 2:
             # https://github.com/python/mypy/issues/1178
@@ -778,7 +779,7 @@ class Zeroconf(QuietLogger):
         addr: Optional[str] = None,
         port: int = _MDNS_PORT,
         v6_flow_scope: Union[Tuple[()], Tuple[int, int]] = (),
-        sock_fileno: int = None,
+        sock_fileno: Optional[int] = None,
     ) -> None:
         """Sends an outgoing packet threadsafe."""
         assert self.loop is not None
@@ -790,7 +791,7 @@ class Zeroconf(QuietLogger):
         addr: Optional[str] = None,
         port: int = _MDNS_PORT,
         v6_flow_scope: Union[Tuple[()], Tuple[int, int]] = (),
-        sock_fileno: int = None,
+        sock_fileno: Optional[int] = None,
     ) -> None:
         """Sends an outgoing packet."""
         if self._GLOBAL_DONE:
@@ -805,13 +806,13 @@ class Zeroconf(QuietLogger):
                 if sock_fileno is not None and not self.unicast and sock_fileno != s.fileno():
                     continue
                 log.debug(
-                    'Sending to (%s, %d) (%d bytes #%d) %r via %s as %r...',
+                    'Sending to (%s, %d) via %s (%d bytes #%d) %r as %r...',
                     addr,
                     port,
+                    transport.get_extra_info('sockname'),
                     len(packet),
                     packet_num + 1,
                     out,
-                    transport.get_extra_info('sockname'),
                     packet,
                 )
                 if addr is None:


### PR DESCRIPTION
When replying to a QU question, we do not know if the sending host is reachable
from all of the sending sockets. We now avoid this problem by replying via
the receiving socket. This was the existing behavior when `InterfaceChoice.Default`
is set.

This change extends the unicast relay behavior to used with `InterfaceChoice.Default`
to apply when `InterfaceChoice.All` or interfaces are explicitly passed when
instantiating a `Zeroconf` instance.

Fixes #951



Reference https://github.com/home-assistant/core/issues/54531
Reference https://github.com/home-assistant/core/issues/54434
Reference https://github.com/home-assistant/core/issues/54487