### PR TITLE
Sort responses to increase chance of name compression

### DIFF
--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -101,6 +101,9 @@ def construct_outgoing_unicast_answers(
 def _add_answers_additionals(out: DNSOutgoing, answers: _AnswerWithAdditionalsType) -> None:
     # Find additionals and suppress any additionals that are already in answers
     sending: Set[DNSRecord] = set(answers.keys())
+    # Answers are sorted to group names together to increase the chance
+    # that similar names will end up in the same packet and can reduce the
+    # overall size of the outgoing response via name compression
     for answer, additionals in sorted(answers.items(), key=lambda kv: kv[0].name):
         out.add_answer_at_time(answer, 0)
         for additional in additionals:

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -100,12 +100,13 @@ def construct_outgoing_unicast_answers(
 
 def _add_answers_additionals(out: DNSOutgoing, answers: _AnswerWithAdditionalsType) -> None:
     # Find additionals and suppress any additionals that are already in answers
-    additionals: Set[DNSRecord] = set().union(*answers.values())  # type: ignore
-    additionals -= answers.keys()
-    for answer in answers:
+    sending: Set[DNSRecord] = set(answers.keys())
+    for answer, additionals in sorted(answers.items(), key=lambda kv: kv[0].name):
         out.add_answer_at_time(answer, 0)
-    for additional in additionals:
-        out.add_additional_answer(additional)
+        for additional in additionals:
+            if additional not in sending:
+                out.add_additional_answer(additional)
+                sending.add(additional)
 
 
 def sanitize_incoming_record(record: DNSRecord) -> None:


### PR DESCRIPTION
- When building an outgoing response, sort the names together
  to increase the likelyhood of name compression. In testing
  this reduced the number of packets for large responses
  (from 7 packets to 6)

closes #953