### PR TITLE
Only reschedule types if the send next time changes

### DIFF
--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -496,7 +496,7 @@ def test_backoff():
                 else:
                     assert not got_query.is_set()
                 time_offset += initial_query_interval
-                zeroconf_browser.loop.call_soon_threadsafe(browser.schedule_changed)
+                zeroconf_browser.loop.call_soon_threadsafe(browser._async_send_ready_queries_schedule_next)
 
         finally:
             browser.cancel()


### PR DESCRIPTION
- When the PTR response was seen again, the timer was being canceled and
  rescheduled even if the timer was for the same time. While this did
  not cause any breakage, it is quite inefficient. 