### PR TITLE
Add coverage for sending answers removes future queued answers

### DIFF
--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -764,6 +764,7 @@ async def test_we_try_four_times_with_random_delay():
 
     # we are going to patch the zeroconf send to check query transmission
     request_count = 0
+
     def async_send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT):
         """Sends an outgoing packet."""
         nonlocal request_count


### PR DESCRIPTION
- If we send an answer that is queued to be sent out in the future
  we should remove it from the queue as the question has already
  been answered and we do not want to generate additional traffic.