### PR TITLE
Create full IPv6 address tuple to enable service discovery on Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,8 +75,6 @@ IPv6 support is relatively new and currently limited, specifically:
 
 * `InterfaceChoice.All` is an alias for `InterfaceChoice.Default` on non-POSIX
   systems.
-* On Windows specific interfaces can only be requested as interface indexes,
-  not as IP addresses.
 * Dual-stack IPv6 sockets are used, which may not be supported everywhere (some
   BSD variants do not have them).
 * Listening on localhost (`::1`) does not work. Help with understanding why is

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -834,6 +834,11 @@ class Zeroconf(QuietLogger):
             out,
             packet,
         )
+        # Get flowinfo and scopeid for the IPV6 socket to create a complete IPv6
+        # address tuple: https://docs.python.org/3.6/library/socket.html#socket-families
+        if s.family == socket.AF_INET6 and not v6_flow_scope:
+            _, _, sock_flowinfo, sock_scopeid = s.getsockname()
+            v6_flow_scope = (sock_flowinfo, sock_scopeid)
         transport.sendto(packet, (real_addr, port or _MDNS_PORT, *v6_flow_scope))
 
     def _close(self) -> None:


### PR DESCRIPTION
Fixes IPv6 service discovery on Windows and  supports service discovery on specified interface indexes, and IP addresses - both on Windows and Linux.
Closes #932 