### PR TITLE
Skip goodbye packets for addresses when there is another service registered with the same name

### DIFF
--- a/tests/services/test_registry.py
+++ b/tests/services/test_registry.py
@@ -28,6 +28,29 @@ class TestServiceRegistry(unittest.TestCase):
         registry.async_remove(info)
         registry.async_add(info)
 
+    def test_register_same_server(self):
+        type_ = "_test-srvc-type._tcp.local."
+        name = "xxxyyy"
+        name2 = "xxxyyy2"
+        registration_name = "%s.%s" % (name, type_)
+        registration_name2 = "%s.%s" % (name2, type_)
+
+        desc = {'path': '/~paulsm/'}
+        info = ServiceInfo(
+            type_, registration_name, 80, 0, 0, desc, "same.local.", addresses=[socket.inet_aton("10.0.1.2")]
+        )
+        info2 = ServiceInfo(
+            type_, registration_name2, 80, 0, 0, desc, "same.local.", addresses=[socket.inet_aton("10.0.1.2")]
+        )
+        registry = r.ServiceRegistry()
+        registry.async_add(info)
+        registry.async_add(info2)
+        assert registry.async_get_infos_server("same.local.") == [info, info2]
+        registry.async_remove(info)
+        assert registry.async_get_infos_server("same.local.") == [info2]
+        registry.async_remove(info2)
+        assert registry.async_get_infos_server("same.local.") == []
+
     def test_unregister_multiple_times(self):
         """Verify we can unregister a service multiple times.
 

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -240,7 +240,6 @@ async def test_async_service_registration_same_server_different_ports() -> None:
     ]
 
 
-
 @pytest.mark.asyncio
 async def test_async_service_registration_same_server_same_ports() -> None:
     """Test registering services with the same server with the exact same srv record."""
@@ -306,6 +305,7 @@ async def test_async_service_registration_same_server_same_ports() -> None:
         ('remove', type_, registration_name),
         ('remove', type_, registration_name2),
     ]
+
 
 @pytest.mark.asyncio
 async def test_async_service_registration() -> None:

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -214,7 +214,7 @@ async def test_async_service_registration_same_server() -> None:
     info2 = ServiceInfo(
         type_,
         registration_name2,
-        80,
+        81,
         0,
         0,
         desc,
@@ -225,13 +225,16 @@ async def test_async_service_registration_same_server() -> None:
     tasks.append(await aiozc.async_register_service(info))
     tasks.append(await aiozc.async_register_service(info2))
     await asyncio.gather(*tasks)
-    await aiozc.async_close()
 
+    task = await aiozc.async_unregister_service(info)
+    await task
+    entries = aiozc.zeroconf.cache.async_entries_with_server("ash-2.local.")
+    assert len(entries) == 1
+    assert info2.dns_service() in entries
+    await aiozc.async_close()
     assert calls == [
         ('add', type_, registration_name),
-        ('update', type_, registration_name),
         ('add', type_, registration_name2),
-        ('update', type_, registration_name2),
         ('remove', type_, registration_name),
         ('remove', type_, registration_name2),
     ]

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -174,6 +174,130 @@ async def test_async_service_registration() -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_service_registration_same_server() -> None:
+    """Test registering services with the same server."""
+    aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
+    type_ = "_test1-srvc-type._tcp.local."
+    name = "xxxyyy"
+    name2 = "xxxyyy2"
+
+    registration_name = f"{name}.{type_}"
+    registration_name2 = f"{name2}.{type_}"
+
+    calls = []
+
+    class MyListener(ServiceListener):
+        def add_service(self, zeroconf: Zeroconf, type: str, name: str) -> None:
+            calls.append(("add", type, name))
+
+        def remove_service(self, zeroconf: Zeroconf, type: str, name: str) -> None:
+            calls.append(("remove", type, name))
+
+        def update_service(self, zeroconf: Zeroconf, type: str, name: str) -> None:
+            calls.append(("update", type, name))
+
+    listener = MyListener()
+
+    aiozc.zeroconf.add_service_listener(type_, listener)
+
+    desc = {'path': '/~paulsm/'}
+    info = ServiceInfo(
+        type_,
+        registration_name,
+        80,
+        0,
+        0,
+        desc,
+        "ash-2.local.",
+        addresses=[socket.inet_aton("10.0.1.2")],
+    )
+    info2 = ServiceInfo(
+        type_,
+        registration_name2,
+        80,
+        0,
+        0,
+        desc,
+        "ash-2.local.",
+        addresses=[socket.inet_aton("10.0.1.2")],
+    )
+    tasks = []
+    tasks.append(await aiozc.async_register_service(info))
+    tasks.append(await aiozc.async_register_service(info2))
+    await asyncio.gather(*tasks)
+    await aiozc.async_close()
+
+    assert calls == [
+        ('add', type_, registration_name),
+        ('update', type_, registration_name),
+        ('add', type_, registration_name2),
+        ('update', type_, registration_name2),
+        ('remove', type_, registration_name),
+        ('remove', type_, registration_name2),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_service_registration() -> None:
+    """Test registering services broadcasts the registration by default."""
+    aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
+    type_ = "_test1-srvc-type._tcp.local."
+    name = "xxxyyy"
+    registration_name = f"{name}.{type_}"
+
+    calls = []
+
+    class MyListener(ServiceListener):
+        def add_service(self, zeroconf: Zeroconf, type: str, name: str) -> None:
+            calls.append(("add", type, name))
+
+        def remove_service(self, zeroconf: Zeroconf, type: str, name: str) -> None:
+            calls.append(("remove", type, name))
+
+        def update_service(self, zeroconf: Zeroconf, type: str, name: str) -> None:
+            calls.append(("update", type, name))
+
+    listener = MyListener()
+
+    aiozc.zeroconf.add_service_listener(type_, listener)
+
+    desc = {'path': '/~paulsm/'}
+    info = ServiceInfo(
+        type_,
+        registration_name,
+        80,
+        0,
+        0,
+        desc,
+        "ash-2.local.",
+        addresses=[socket.inet_aton("10.0.1.2")],
+    )
+    task = await aiozc.async_register_service(info)
+    await task
+    new_info = ServiceInfo(
+        type_,
+        registration_name,
+        80,
+        0,
+        0,
+        desc,
+        "ash-2.local.",
+        addresses=[socket.inet_aton("10.0.1.3")],
+    )
+    task = await aiozc.async_update_service(new_info)
+    await task
+    task = await aiozc.async_unregister_service(new_info)
+    await task
+    await aiozc.async_close()
+
+    assert calls == [
+        ('add', type_, registration_name),
+        ('update', type_, registration_name),
+        ('remove', type_, registration_name),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_async_service_registration_name_conflict() -> None:
     """Test registering services throws on name conflict."""
     aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -308,66 +308,6 @@ async def test_async_service_registration_same_server_same_ports() -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_service_registration() -> None:
-    """Test registering services broadcasts the registration by default."""
-    aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
-    type_ = "_test1-srvc-type._tcp.local."
-    name = "xxxyyy"
-    registration_name = f"{name}.{type_}"
-
-    calls = []
-
-    class MyListener(ServiceListener):
-        def add_service(self, zeroconf: Zeroconf, type: str, name: str) -> None:
-            calls.append(("add", type, name))
-
-        def remove_service(self, zeroconf: Zeroconf, type: str, name: str) -> None:
-            calls.append(("remove", type, name))
-
-        def update_service(self, zeroconf: Zeroconf, type: str, name: str) -> None:
-            calls.append(("update", type, name))
-
-    listener = MyListener()
-
-    aiozc.zeroconf.add_service_listener(type_, listener)
-
-    desc = {'path': '/~paulsm/'}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
-    )
-    task = await aiozc.async_register_service(info)
-    await task
-    new_info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.3")],
-    )
-    task = await aiozc.async_update_service(new_info)
-    await task
-    task = await aiozc.async_unregister_service(new_info)
-    await task
-    await aiozc.async_close()
-
-    assert calls == [
-        ('add', type_, registration_name),
-        ('update', type_, registration_name),
-        ('remove', type_, registration_name),
-    ]
-
-
-@pytest.mark.asyncio
 async def test_async_service_registration_name_conflict() -> None:
     """Test registering services throws on name conflict."""
     aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -91,7 +91,7 @@ class TestRegistrar(unittest.TestCase):
             _process_outgoing_packet(zc.generate_service_query(info))
         zc.registry.async_add(info)
         for _ in range(3):
-            _process_outgoing_packet(zc.generate_service_broadcast(info, None))
+            _process_outgoing_packet(zc.generate_service_broadcast(info, None, True))
         assert nbr_answers == 12 and nbr_additionals == 0 and nbr_authorities == 3
         nbr_answers = nbr_additionals = nbr_authorities = 0
 
@@ -116,7 +116,7 @@ class TestRegistrar(unittest.TestCase):
         expected_ttl = 0
         zc.registry.async_remove(info)
         for _ in range(3):
-            _process_outgoing_packet(zc.generate_service_broadcast(info, 0))
+            _process_outgoing_packet(zc.generate_service_broadcast(info, 0, True))
         assert nbr_answers == 12 and nbr_additionals == 0 and nbr_authorities == 0
         nbr_answers = nbr_additionals = nbr_authorities = 0
 
@@ -128,7 +128,7 @@ class TestRegistrar(unittest.TestCase):
         expected_ttl = const._DNS_HOST_TTL * 2
         assert expected_ttl != const._DNS_HOST_TTL
         for _ in range(3):
-            _process_outgoing_packet(zc.generate_service_broadcast(info, expected_ttl))
+            _process_outgoing_packet(zc.generate_service_broadcast(info, expected_ttl, True))
         assert nbr_answers == 12 and nbr_additionals == 0 and nbr_authorities == 3
         nbr_answers = nbr_additionals = nbr_authorities = 0
 
@@ -150,7 +150,7 @@ class TestRegistrar(unittest.TestCase):
         expected_ttl = 0
         zc.registry.async_remove(info)
         for _ in range(3):
-            _process_outgoing_packet(zc.generate_service_broadcast(info, 0))
+            _process_outgoing_packet(zc.generate_service_broadcast(info, 0, True))
         assert nbr_answers == 12 and nbr_additionals == 0 and nbr_authorities == 0
         nbr_answers = nbr_additionals = nbr_authorities = 0
         zc.close()

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -91,7 +91,7 @@ class TestRegistrar(unittest.TestCase):
             _process_outgoing_packet(zc.generate_service_query(info))
         zc.registry.async_add(info)
         for _ in range(3):
-            _process_outgoing_packet(zc.generate_service_broadcast(info, None, True))
+            _process_outgoing_packet(zc.generate_service_broadcast(info, None))
         assert nbr_answers == 12 and nbr_additionals == 0 and nbr_authorities == 3
         nbr_answers = nbr_additionals = nbr_authorities = 0
 
@@ -116,7 +116,7 @@ class TestRegistrar(unittest.TestCase):
         expected_ttl = 0
         zc.registry.async_remove(info)
         for _ in range(3):
-            _process_outgoing_packet(zc.generate_service_broadcast(info, 0, True))
+            _process_outgoing_packet(zc.generate_service_broadcast(info, 0))
         assert nbr_answers == 12 and nbr_additionals == 0 and nbr_authorities == 0
         nbr_answers = nbr_additionals = nbr_authorities = 0
 
@@ -128,7 +128,7 @@ class TestRegistrar(unittest.TestCase):
         expected_ttl = const._DNS_HOST_TTL * 2
         assert expected_ttl != const._DNS_HOST_TTL
         for _ in range(3):
-            _process_outgoing_packet(zc.generate_service_broadcast(info, expected_ttl, True))
+            _process_outgoing_packet(zc.generate_service_broadcast(info, expected_ttl))
         assert nbr_answers == 12 and nbr_additionals == 0 and nbr_authorities == 3
         nbr_answers = nbr_additionals = nbr_authorities = 0
 
@@ -150,7 +150,7 @@ class TestRegistrar(unittest.TestCase):
         expected_ttl = 0
         zc.registry.async_remove(info)
         for _ in range(3):
-            _process_outgoing_packet(zc.generate_service_broadcast(info, 0, True))
+            _process_outgoing_packet(zc.generate_service_broadcast(info, 0))
         assert nbr_answers == 12 and nbr_additionals == 0 and nbr_authorities == 0
         nbr_answers = nbr_additionals = nbr_authorities = 0
         zc.close()

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -572,16 +572,27 @@ class Zeroconf(QuietLogger):
         return asyncio.ensure_future(self._async_broadcast_service(info, _REGISTER_TIME, None))
 
     async def _async_broadcast_service(
-        self, info: ServiceInfo, interval: int, ttl: Optional[int], broadcast_addresses: bool = True, broadcast_service: bool = True
+        self,
+        info: ServiceInfo,
+        interval: int,
+        ttl: Optional[int],
+        broadcast_addresses: bool = True,
+        broadcast_service: bool = True,
     ) -> None:
         """Send a broadcasts to announce a service at intervals."""
         for i in range(_REGISTER_BROADCASTS):
             if i != 0:
                 await asyncio.sleep(millis_to_seconds(interval))
-            self.async_send(self.generate_service_broadcast(info, ttl, broadcast_addresses, broadcast_service))
+            self.async_send(
+                self.generate_service_broadcast(info, ttl, broadcast_addresses, broadcast_service)
+            )
 
     def generate_service_broadcast(
-        self, info: ServiceInfo, ttl: Optional[int], broadcast_addresses: bool = True, broadcast_service: bool = True
+        self,
+        info: ServiceInfo,
+        ttl: Optional[int],
+        broadcast_addresses: bool = True,
+        broadcast_service: bool = True,
     ) -> DNSOutgoing:
         """Generate a broadcast to announce a service."""
         out = DNSOutgoing(_FLAGS_QR_RESPONSE | _FLAGS_AA)
@@ -604,7 +615,12 @@ class Zeroconf(QuietLogger):
         return out
 
     def _add_broadcast_answer(  # pylint: disable=no-self-use
-        self, out: DNSOutgoing, info: ServiceInfo, override_ttl: Optional[int], broadcast_addresses: bool = True, broadcast_service: bool = True
+        self,
+        out: DNSOutgoing,
+        info: ServiceInfo,
+        override_ttl: Optional[int],
+        broadcast_addresses: bool = True,
+        broadcast_service: bool = True,
     ) -> None:
         """Add answers to broadcast a service."""
         now = current_time_millis()

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -648,14 +648,9 @@ class Zeroconf(QuietLogger):
         # goodbye packets for the address records
 
         entries = self.registry.async_get_infos_server(info.server)
-        broadcast_service = True
+        record = info.dns_service()
+        broadcast_service = not any(entry == record for entry in entries)
         broadcast_addresses = not bool(entries)
-        if entries:
-            record = info.dns_service()
-            for entry in entries:
-                if entry == record:
-                    broadcast_service = False
-                    break
         return asyncio.ensure_future(
             self._async_broadcast_service(info, _UNREGISTER_TIME, 0, broadcast_addresses, broadcast_service)
         )


### PR DESCRIPTION
- If a ServiceInfo that used the same server name as another ServiceInfo
  was unregistered, goodbye packets would be sent for the addresses and
  would cause the other service to be seen as offline.