### PR TITLE
Fix equality and hash for dns records with the unique bit

### DIFF
--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -211,6 +211,21 @@ def test_dns_record_hashablity_does_not_consider_ttl():
     assert len(record_set) == 1
 
 
+def test_dns_record_hashablity_does_not_consider_unique():
+    """Test DNSRecord are hashable and unique is ignored."""
+
+    # Verify the unique value is not considered in the hash
+    record1 = r.DNSAddress(
+        'irrelevant', const._TYPE_A, const._CLASS_IN | const._CLASS_UNIQUE, const._DNS_OTHER_TTL, b'same'
+    )
+    record2 = r.DNSAddress('irrelevant', const._TYPE_A, const._CLASS_IN, const._DNS_OTHER_TTL, b'same')
+
+    assert record1.class_ == record2.class_
+    assert record1.__hash__() == record2.__hash__()
+    record_set = {record1, record2}
+    assert len(record_set) == 1
+
+
 def test_dns_address_record_hashablity():
     """Test DNSAddress are hashable."""
     address1 = r.DNSAddress('irrelevant', const._TYPE_A, const._CLASS_IN, 1, b'a')

--- a/zeroconf/_dns.py
+++ b/zeroconf/_dns.py
@@ -115,7 +115,7 @@ class DNSQuestion(DNSEntry):
 
     def __init__(self, name: str, type_: int, class_: int) -> None:
         super().__init__(name, type_, class_)
-        self._hash = hash((self.key, type_, class_))
+        self._hash = hash((self.key, type_, self.class_))
 
     def answered_by(self, rec: 'DNSRecord') -> bool:
         """Returns true if the question is answered by the record"""
@@ -247,7 +247,7 @@ class DNSAddress(DNSRecord):
         super().__init__(name, type_, class_, ttl, created)
         self.address = address
         self.scope_id = scope_id
-        self._hash = hash((self.key, type_, class_, address, scope_id))
+        self._hash = hash((self.key, type_, self.class_, address, scope_id))
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet"""
@@ -290,7 +290,7 @@ class DNSHinfo(DNSRecord):
         super().__init__(name, type_, class_, ttl, created)
         self.cpu = cpu
         self.os = os
-        self._hash = hash((self.key, type_, class_, cpu, os))
+        self._hash = hash((self.key, type_, self.class_, cpu, os))
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet"""
@@ -326,7 +326,7 @@ class DNSPointer(DNSRecord):
     ) -> None:
         super().__init__(name, type_, class_, ttl, created)
         self.alias = alias
-        self._hash = hash((self.key, type_, class_, alias))
+        self._hash = hash((self.key, type_, self.class_, alias))
 
     @property
     def max_size_compressed(self) -> int:
@@ -367,7 +367,7 @@ class DNSText(DNSRecord):
         assert isinstance(text, (bytes, type(None)))
         super().__init__(name, type_, class_, ttl, created)
         self.text = text
-        self._hash = hash((self.key, type_, class_, text))
+        self._hash = hash((self.key, type_, self.class_, text))
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet"""
@@ -411,7 +411,7 @@ class DNSService(DNSRecord):
         self.weight = weight
         self.port = port
         self.server = server
-        self._hash = hash((self.key, type_, class_, priority, weight, port, server))
+        self._hash = hash((self.key, type_, self.class_, priority, weight, port, server))
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet"""
@@ -459,7 +459,7 @@ class DNSNsec(DNSRecord):
         super().__init__(name, type_, class_, ttl, created)
         self.next_name = next_name
         self.rdtypes = rdtypes
-        self._hash = hash((self.key, type_, class_, next_name, *self.rdtypes))
+        self._hash = hash((self.key, type_, self.class_, next_name, *self.rdtypes))
 
     def __eq__(self, other: Any) -> bool:
         """Tests equality on cpu and os"""


### PR DESCRIPTION
- These records should have the same hash and equality since
  the unique bit is not considered when adding or removing
  the records from the cache