### PR TITLE
Defer decoding known answers until needed

### DIFF
--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -348,7 +348,7 @@ class QueryHandler:
         threadsafe.
         """
         known_answers = DNSRRSet(
-            itertools.chain(*(msg.answers for msg in msgs if not _message_is_probe(msg)))
+            itertools.chain.from_iterable(msg.answers for msg in msgs if not _message_is_probe(msg))
         )
         query_res = _QueryResponse(self.cache, msgs)
 


### PR DESCRIPTION
- Right now we decode all known the answers in the packet even if we never need to look at them because we can't answer any of the questions in the packet

- Decoding packets is the most expensive operation zeroconf performs on active networks. In fact it's the most expensive operation on a mostly idle home assistant instance.

- Defer decoding to only when we need to check for suppression to save cpu time.

- Closes #980 