### PR TITLE
Simplify the can_send_to check

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -67,7 +67,6 @@ from ._updates import RecordUpdate, RecordUpdateListener  # noqa # import needed
 from ._utils.name import service_type_name  # noqa # import needed for backwards compat
 from ._utils.net import (  # noqa # import needed for backwards compat
     add_multicast_member,
-    can_send_to,
     autodetect_ip_version,
     create_sockets,
     get_all_addresses_v6,

--- a/zeroconf/_utils/net.py
+++ b/zeroconf/_utils/net.py
@@ -379,9 +379,13 @@ def get_errno(e: Exception) -> int:
     return cast(int, e.args[0])
 
 
-def can_send_to(sock: socket.socket, address: str) -> bool:
-    addr = ipaddress.ip_address(address)
-    return cast(bool, addr.version == 6 if sock.family == socket.AF_INET6 else addr.version == 4)
+def can_send_to(ipv6_socket: bool, address: str) -> bool:
+    """Check if the address type matches the socket type.
+
+    This function does not validate if the address is a valid
+    ipv6 or ipv4 address.
+    """
+    return ":" in address if ipv6_socket else ":" not in address
 
 
 def autodetect_ip_version(interfaces: InterfacesType) -> IPVersion:


### PR DESCRIPTION
- There is no need to call can_send_to when we derive the target
  since we already know we can send to it.

- can_send_to was converting the addr string into an ipaddress object
  to check if it was IPv4 or IPv6. Since this all happens internally there
  was no need for the additional validation and check. We can use a must
  more simple test.