### PR TITLE
Reduce logging overhead

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -398,6 +398,40 @@ def test_register_service_with_custom_ttl():
     zc.close()
 
 
+def test_logging_packets(caplog):
+    """Test packets are only logged with debug logging."""
+
+    # instantiate a zeroconf instance
+    zc = Zeroconf(interfaces=['127.0.0.1'])
+
+    # start a browser
+    type_ = "_homeassistant._tcp.local."
+    name = "MyTestHome"
+    info_service = r.ServiceInfo(
+        type_,
+        f'{name}.{type_}',
+        80,
+        0,
+        0,
+        {'path': '/~paulsm/'},
+        "ash-90.local.",
+        addresses=[socket.inet_aton("10.0.1.2")],
+    )
+
+    logging.getLogger('zeroconf').setLevel(logging.DEBUG)
+    caplog.clear()
+    zc.register_service(info_service, ttl=3000)
+    assert "Sending to" in caplog.text
+    assert zc.cache.get(info_service.dns_pointer()).ttl == 3000
+    logging.getLogger('zeroconf').setLevel(logging.INFO)
+    caplog.clear()
+    zc.unregister_service(info_service)
+    assert "Sending to" not in caplog.text
+    logging.getLogger('zeroconf').setLevel(logging.DEBUG)
+
+    zc.close()
+
+
 def test_get_service_info_failure_path():
     """Verify get_service_info return None when the underlying call returns False."""
     zc = Zeroconf(interfaces=['127.0.0.1'])
@@ -433,6 +467,7 @@ def test_sending_unicast():
 
 
 def test_tc_bit_defers():
+
     zc = Zeroconf(interfaces=['127.0.0.1'])
     _wait_for_start(zc)
     type_ = "_tcbitdefer._tcp.local."

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -405,8 +405,8 @@ def test_logging_packets(caplog):
     zc = Zeroconf(interfaces=['127.0.0.1'])
 
     # start a browser
-    type_ = "_homeassistant._tcp.local."
-    name = "MyTestHome"
+    type_ = "_logging._tcp.local."
+    name = "TLD"
     info_service = r.ServiceInfo(
         type_,
         f'{name}.{type_}',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -467,7 +467,6 @@ def test_sending_unicast():
 
 
 def test_tc_bit_defers():
-
     zc = Zeroconf(interfaces=['127.0.0.1'])
     _wait_for_start(zc)
     type_ = "_tcbitdefer._tcp.local."

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -263,7 +263,7 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
             )
             return
 
-        if len(data) > _MAX_MSG_ABSOLUTE:
+        if data_len > _MAX_MSG_ABSOLUTE:
             # Guard against oversized packets to ensure bad implementations cannot overwhelm
             # the system.
             log.debug(

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -22,6 +22,7 @@
 
 import asyncio
 import itertools
+import logging
 import random
 import socket
 import sys
@@ -217,6 +218,7 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
         self.last_time: float = 0
         self.transport: Optional[asyncio.DatagramTransport] = None
         self.sock_name: Optional[str] = None
+        self.sock_description: Optional[str] = None
         self.sock_fileno: Optional[int] = None
         self._deferred: Dict[str, List[DNSIncoming]] = {}
         self._timers: Dict[str, asyncio.TimerHandle] = {}
@@ -236,6 +238,8 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
     ) -> None:
         assert self.transport is not None
         v6_flow_scope: Union[Tuple[()], Tuple[int, int]] = ()
+        debug_log = log.isEnabledFor(logging.DEBUG)
+
         if len(addrs) == 2:
             # https://github.com/python/mypy/issues/1178
             addr, port = addrs  # type: ignore
@@ -243,54 +247,58 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
         else:
             # https://github.com/python/mypy/issues/1178
             addr, port, flow, scope = addrs  # type: ignore
-            log.debug('IPv6 scope_id %d associated to the receiving interface', scope)
+            if debug_log:
+                log.debug('IPv6 scope_id %d associated to the receiving interface', scope)
             v6_flow_scope = (flow, scope)
 
         now = current_time_millis()
         if self.suppress_duplicate_packet(data, now):
             # Guard against duplicate packets
-            log.debug(
-                'Ignoring duplicate message received from %r:%r [socket %s] (%d bytes) as [%r]',
-                addr,
-                port,
-                self._socket_description,
-                len(data),
-                data,
-            )
+            if debug_log:
+                log.debug(
+                    'Ignoring duplicate message received from %r:%r [socket %s] (%d bytes) as [%r]',
+                    addr,
+                    port,
+                    self.sock_description,
+                    len(data),
+                    data,
+                )
             return
 
         if len(data) > _MAX_MSG_ABSOLUTE:
             # Guard against oversized packets to ensure bad implementations cannot overwhelm
             # the system.
-            log.debug(
-                "Discarding incoming packet with length %s, which is larger "
-                "than the absolute maximum size of %s",
-                len(data),
-                _MAX_MSG_ABSOLUTE,
-            )
+            if debug_log:
+                log.debug(
+                    "Discarding incoming packet with length %s, which is larger "
+                    "than the absolute maximum size of %s",
+                    len(data),
+                    _MAX_MSG_ABSOLUTE,
+                )
             return
 
         msg = DNSIncoming(data, scope, now)
-        if msg.valid:
-            log.debug(
-                'Received from %r:%r [socket %s]: %r (%d bytes) as [%r]',
-                addr,
-                port,
-                self._socket_description,
-                msg,
-                len(data),
-                data,
-            )
-        else:
-            log.debug(
-                'Received from %r:%r [socket %s]: (%d bytes) [%r]',
-                addr,
-                port,
-                self._socket_description,
-                len(data),
-                data,
-            )
-            return
+        if debug_log:
+            if msg.valid:
+                log.debug(
+                    'Received from %r:%r [socket %s]: %r (%d bytes) as [%r]',
+                    addr,
+                    port,
+                    self.sock_description,
+                    msg,
+                    len(data),
+                    data,
+                )
+            else:
+                log.debug(
+                    'Received from %r:%r [socket %s]: (%d bytes) [%r]',
+                    addr,
+                    port,
+                    self.sock_description,
+                    len(data),
+                    data,
+                )
+                return
 
         if not msg.is_query():
             self.zc.handle_response(msg)
@@ -346,24 +354,20 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
 
         self.zc.handle_assembled_query(packets, addr, port, transport, v6_flow_scope)
 
-    @property
-    def _socket_description(self) -> str:
-        """A human readable description of the socket."""
-        return f"{self.sock_fileno} ({self.sock_name})"
-
     def error_received(self, exc: Exception) -> None:
         """Likely socket closed or IPv6."""
         # We preformat the message string with the socket as we want
         # log_exception_once to log a warrning message once PER EACH
         # different socket in case there are problems with multiple
         # sockets
-        msg_str = f"Error with socket {self._socket_description}): %s"
+        msg_str = f"Error with socket {self.sock_description}): %s"
         self.log_exception_once(exc, msg_str, exc)
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         self.transport = cast(asyncio.DatagramTransport, transport)
         self.sock_name = self.transport.get_extra_info('sockname')
         self.sock_fileno = self.transport.get_extra_info('socket').fileno()
+        self.sock_description = f"{self.sock_fileno} ({self.sock_name})"
 
     def connection_lost(self, exc: Optional[Exception]) -> None:
         """Handle connection lost."""
@@ -817,16 +821,20 @@ class Zeroconf(QuietLogger):
         # If no transport is specified, we send to all the ones
         # with the same address family
         transports = [transport] if transport else self.engine.senders
+        log_debug = log.isEnabledFor(logging.DEBUG)
 
         for packet_num, packet in enumerate(out.packets()):
             if len(packet) > _MAX_MSG_ABSOLUTE:
                 self.log_warning_once("Dropping %r over-sized packet (%d bytes) %r", out, len(packet), packet)
                 return
             for send_transport in transports:
-                self._async_send_transport(send_transport, packet, packet_num, out, addr, port, v6_flow_scope)
+                self._async_send_transport(
+                    log_debug, send_transport, packet, packet_num, out, addr, port, v6_flow_scope
+                )
 
     def _async_send_transport(
         self,
+        log_debug: bool,
         transport: asyncio.DatagramTransport,
         packet: bytes,
         packet_num: int,
@@ -843,17 +851,18 @@ class Zeroconf(QuietLogger):
             real_addr = addr
             if not can_send_to(ipv6_socket, real_addr):
                 return
-        log.debug(
-            'Sending to (%s, %d) via [socket %s (%s)] (%d bytes #%d) %r as %r...',
-            real_addr,
-            port or _MDNS_PORT,
-            s.fileno(),
-            transport.get_extra_info('sockname'),
-            len(packet),
-            packet_num + 1,
-            out,
-            packet,
-        )
+        if log_debug:
+            log.debug(
+                'Sending to (%s, %d) via [socket %s (%s)] (%d bytes #%d) %r as %r...',
+                real_addr,
+                port or _MDNS_PORT,
+                s.fileno(),
+                transport.get_extra_info('sockname'),
+                len(packet),
+                packet_num + 1,
+                out,
+                packet,
+            )
         # Get flowinfo and scopeid for the IPV6 socket to create a complete IPv6
         # address tuple: https://docs.python.org/3.6/library/socket.html#socket-families
         if ipv6_socket and not v6_flow_scope:

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -476,8 +476,8 @@ class RecordManager:
         # and rrclass that were received more than one second ago are declared
         # invalid, and marked to expire from the cache in one second.
         answers_rrset = DNSRRSet(answers)
-        for unique_type in unique_types:
-            for entry in self.cache.async_all_by_details(*unique_type):
+        for name, type_, class_ in unique_types:
+            for entry in self.cache.async_all_by_details(name, type_, class_):
                 if (now - entry.created > _ONE_SECOND) and entry not in answers_rrset:
                     # Expire in 1s
                     entry.set_created_ttl(now, 1)

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -476,8 +476,8 @@ class RecordManager:
         # and rrclass that were received more than one second ago are declared
         # invalid, and marked to expire from the cache in one second.
         answers_rrset = DNSRRSet(answers)
-        for name, type_, class_ in unique_types:
-            for entry in self.cache.async_all_by_details(name, type_, class_):
+        for unique_type in unique_types:
+            for entry in self.cache.async_all_by_details(*unique_type):
                 if (now - entry.created > _ONE_SECOND) and entry not in answers_rrset:
                     # Expire in 1s
                     entry.set_created_ttl(now, 1)


### PR DESCRIPTION
- logging would make calls to look up socket information and then discard it if the log level was not debug.
