### PR TITLE
Prevent service lookups from deadlocking if time abruptly moves backwards

### DIFF
--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -442,7 +442,7 @@ def test_backoff():
     old_send = zeroconf_browser.async_send
 
     time_offset = 0.0
-    start_time = time.time() * 1000
+    start_time = time.monotonic() * 1000
     initial_query_interval = _services_browser._BROWSER_TIME / 1000
 
     def current_time_millis():

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -850,7 +850,7 @@ async def test_integration():
 
     def _new_current_time_millis():
         """Current system time in milliseconds"""
-        return (time.time() * 1000) + (time_offset * 1000)
+        return (time.monotonic() * 1000) + (time_offset * 1000)
 
     expected_ttl = const._DNS_HOST_TTL
     nbr_answers = 0

--- a/zeroconf/_utils/time.py
+++ b/zeroconf/_utils/time.py
@@ -26,7 +26,7 @@ import time
 
 def current_time_millis() -> float:
     """Current system time in milliseconds"""
-    return time.time() * 1000
+    return time.monotonic() * 1000
 
 
 def millis_to_seconds(millis: float) -> float:


### PR DESCRIPTION
Prevent service lookups from deadlocking if time abruptly moves backwards

- Usually via an ntp update