### PR TITLE
Defer expunging records to give responders enough time to refresh records

### DIFF
--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -960,7 +960,7 @@ async def test_generate_service_query_suppress_duplicate_questions():
     outs = _services_browser.generate_service_query(zc, now, [name], multicast=False)
     assert outs
 
-    zc.question_history.async_expire(now + 2000)
+    zc.question_history.async_expunge(now + 2000)
     # No suppression after clearing the history
     outs = _services_browser.generate_service_query(zc, now, [name], multicast=True)
     assert outs

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -57,12 +57,12 @@ def test_question_expire():
     # Verify the question is suppressed if the known answers are the same
     assert history.suppresses(question, now, other_known_answers)
 
-    history.async_expire(now)
+    history.async_expunge(now)
 
     # Verify the question is suppressed if the known answers are the same since the cache hasn't expired
     assert history.suppresses(question, now, other_known_answers)
 
-    history.async_expire(now + 1000)
+    history.async_expunge(now + 1000)
 
     # Verify the question not longer suppressed since the cache has expired
     assert not history.suppresses(question, now, other_known_answers)

--- a/zeroconf/_cache.py
+++ b/zeroconf/_cache.py
@@ -34,7 +34,7 @@ from ._dns import (
     dns_entry_matches,
 )
 from ._utils.time import current_time_millis
-from .const import _OTHER_TYPES, _MIN_HOST_RECORD_EXPUNGE_TIME, _TYPE_PTR
+from .const import _MIN_HOST_RECORD_EXPUNGE_TIME, _OTHER_TYPES, _TYPE_PTR
 
 _UNIQUE_RECORD_TYPES = (DNSAddress, DNSHinfo, DNSPointer, DNSText, DNSService)
 _UniqueRecordsType = Union[DNSAddress, DNSHinfo, DNSPointer, DNSText, DNSService]

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -169,9 +169,9 @@ class AsyncEngine:
     def _async_cache_cleanup(self) -> None:
         """Periodic cache cleanup."""
         now = current_time_millis()
-        self.zc.question_history.async_expire(now)
+        self.zc.question_history.async_expunge(now)
         self.zc.record_manager.async_updates(
-            now, [RecordUpdate(record, None) for record in self.zc.cache.async_expire(now)]
+            now, [RecordUpdate(record, None) for record in self.zc.cache.async_expunge(now)]
         )
         self.zc.record_manager.async_updates_complete()
         assert self.loop is not None

--- a/zeroconf/_history.py
+++ b/zeroconf/_history.py
@@ -59,8 +59,8 @@ class QuestionHistory:
             return False
         return True
 
-    def async_expire(self, now: float) -> None:
-        """Expire the history of old questions."""
+    def async_expunge(self, now: float) -> None:
+        """Expunge the history of old questions."""
         removes = [
             question
             for question, now_known_answers in self._history.items()

--- a/zeroconf/const.py
+++ b/zeroconf/const.py
@@ -32,7 +32,7 @@ _LISTENER_TIME = 200  # ms
 _BROWSER_TIME = 1000  # ms
 _DUPLICATE_QUESTION_INTERVAL = _BROWSER_TIME - 1  # ms
 _BROWSER_BACKOFF_LIMIT = 3600  # s
-_CACHE_CLEANUP_INTERVAL = 10000  # ms
+_CACHE_CLEANUP_INTERVAL = 60000  # ms
 _LOADED_SYSTEM_TIMEOUT = 10  # s
 _ONE_SECOND = 1000  # ms
 
@@ -50,6 +50,10 @@ _MDNS_PORT = 5353
 _DNS_PORT = 53
 _DNS_HOST_TTL = 120  # two minute for host records (A, SRV etc) as-per RFC6762
 _DNS_OTHER_TTL = 4500  # 75 minutes for non-host records (PTR, TXT etc) as-per RFC6762
+# _MIN_RECORD_EXPUNGE_TIME must never exceed 50% of _DNS_OTHER_TTL to ensure
+# ServiceStateChange.Removed are always sent
+_MIN_RECORD_EXPUNGE_TIME = _DNS_HOST_TTL * 2
+
 # Currently we enforce a minimum TTL for PTR records to avoid
 # ServiceBrowsers generating excessive queries refresh queries.
 # Apple uses a 15s minimum TTL, however we do not have the same

--- a/zeroconf/const.py
+++ b/zeroconf/const.py
@@ -48,8 +48,13 @@ _MDNS_ADDR = '224.0.0.251'
 _MDNS_ADDR6 = 'ff02::fb'
 _MDNS_PORT = 5353
 _DNS_PORT = 53
+
+
 _DNS_HOST_TTL = 120  # s - two minute for host records (A, SRV etc) as-per RFC6762
 _DNS_OTHER_TTL = 4500  # s - 75 minutes for non-host records (PTR, TXT etc) as-per RFC6762
+# We need to keep the corresponing A, SRV, etc records in the cache
+# for at least as long as their PTR, TXT, etc records to avoid
+# excessive callbacks
 _MIN_HOST_RECORD_EXPUNGE_TIME = _DNS_OTHER_TTL * 1000  # ms
 
 # Currently we enforce a minimum TTL for PTR records to avoid
@@ -105,6 +110,8 @@ _TYPE_AAAA = 28
 _TYPE_SRV = 33
 _TYPE_NSEC = 47
 _TYPE_ANY = 255
+
+_OTHER_TYPES = {_TYPE_PTR, _TYPE_TXT}
 
 # Mapping constants to names
 

--- a/zeroconf/const.py
+++ b/zeroconf/const.py
@@ -50,9 +50,7 @@ _MDNS_PORT = 5353
 _DNS_PORT = 53
 _DNS_HOST_TTL = 120  # s - two minute for host records (A, SRV etc) as-per RFC6762
 _DNS_OTHER_TTL = 4500  # s - 75 minutes for non-host records (PTR, TXT etc) as-per RFC6762
-# _MIN_RECORD_EXPUNGE_TIME must never exceed 50% of _DNS_OTHER_TTL to ensure
-# ServiceStateChange.Removed are always sent
-_MIN_RECORD_EXPUNGE_TIME = _DNS_HOST_TTL * 2 * 1000  # ms
+_MIN_HOST_RECORD_EXPUNGE_TIME = _DNS_OTHER_TTL * 1000  # ms
 
 # Currently we enforce a minimum TTL for PTR records to avoid
 # ServiceBrowsers generating excessive queries refresh queries.

--- a/zeroconf/const.py
+++ b/zeroconf/const.py
@@ -48,11 +48,11 @@ _MDNS_ADDR = '224.0.0.251'
 _MDNS_ADDR6 = 'ff02::fb'
 _MDNS_PORT = 5353
 _DNS_PORT = 53
-_DNS_HOST_TTL = 120  # two minute for host records (A, SRV etc) as-per RFC6762
-_DNS_OTHER_TTL = 4500  # 75 minutes for non-host records (PTR, TXT etc) as-per RFC6762
+_DNS_HOST_TTL = 120  # s - two minute for host records (A, SRV etc) as-per RFC6762
+_DNS_OTHER_TTL = 4500  # s - 75 minutes for non-host records (PTR, TXT etc) as-per RFC6762
 # _MIN_RECORD_EXPUNGE_TIME must never exceed 50% of _DNS_OTHER_TTL to ensure
 # ServiceStateChange.Removed are always sent
-_MIN_RECORD_EXPUNGE_TIME = _DNS_HOST_TTL * 2
+_MIN_RECORD_EXPUNGE_TIME = _DNS_HOST_TTL * 2 * 1000  # ms
 
 # Currently we enforce a minimum TTL for PTR records to avoid
 # ServiceBrowsers generating excessive queries refresh queries.


### PR DESCRIPTION
- If we expunge the records too quickly, we end up with floods of
  ServiceStateChange.Updated callbacks when a responder refreshes
  records that have the shorter host ttl (120s)

- Fixes part 2 of https://github.com/jstasiak/python-zeroconf/issues/1013#issuecomment-949954933