### PR TITLE
Strip scope_id from IPv6 address if given.

### DIFF
--- a/tests/utils/test_net.py
+++ b/tests/utils/test_net.py
@@ -39,6 +39,7 @@ def test_ip6_to_address_and_index():
     """Test we can extract from mocked adapters."""
     adapters = _generate_mock_adapters()
     assert netutils.ip6_to_address_and_index(adapters, "2001:db8::") == (('2001:db8::', 1, 1), 1)
+    assert netutils.ip6_to_address_and_index(adapters, "2001:db8::%1") == (('2001:db8::', 1, 1), 1)
     with pytest.raises(RuntimeError):
         assert netutils.ip6_to_address_and_index(adapters, "2005:db8::")
 

--- a/zeroconf/_utils/net.py
+++ b/zeroconf/_utils/net.py
@@ -84,7 +84,7 @@ def get_all_addresses_v6() -> List[Tuple[Tuple[str, int, int], int]]:
 
 def ip6_to_address_and_index(adapters: List[Any], ip: str) -> Tuple[Tuple[str, int, int], int]:
     if '%' in ip:
-        ip = ip[:ip.index('%')]  # Strip scope_id.
+        ip = ip[: ip.index('%')]  # Strip scope_id.
     ipaddr = ipaddress.ip_address(ip)
     for adapter in adapters:
         for adapter_ip in adapter.ips:

--- a/zeroconf/_utils/net.py
+++ b/zeroconf/_utils/net.py
@@ -83,7 +83,8 @@ def get_all_addresses_v6() -> List[Tuple[Tuple[str, int, int], int]]:
 
 
 def ip6_to_address_and_index(adapters: List[Any], ip: str) -> Tuple[Tuple[str, int, int], int]:
-    ip = ip[:ip.index('%')]  # Strip scope_id.
+    if '%' in ip:
+        ip = ip[:ip.index('%')]  # Strip scope_id.
     ipaddr = ipaddress.ip_address(ip)
     for adapter in adapters:
         for adapter_ip in adapter.ips:

--- a/zeroconf/_utils/net.py
+++ b/zeroconf/_utils/net.py
@@ -83,6 +83,7 @@ def get_all_addresses_v6() -> List[Tuple[Tuple[str, int, int], int]]:
 
 
 def ip6_to_address_and_index(adapters: List[Any], ip: str) -> Tuple[Tuple[str, int, int], int]:
+    ip = ip[:ip.index('%')]  # Strip scope_id.
     ipaddr = ipaddress.ip_address(ip)
     for adapter in adapters:
         for adapter_ip in adapter.ips:


### PR DESCRIPTION
This prevents a crash on Python versions < 3.9 when scope_id is supplied in the address, and also fixes finding the related interface.

In preparation of home assistant moving to minimal-Python 3.9 requirement, and enabling scope_ids via https://github.com/home-assistant/core/blob/a90c8ab5584ce50e8dfae67790cb56f3d1d1ea86/homeassistant/components/network/__init__.py#L55.