### PR TITLE
Skip unavailable interfaces during socket bind

### DIFF
--- a/zeroconf/_utils/net.py
+++ b/zeroconf/_utils/net.py
@@ -243,7 +243,18 @@ def new_socket(
         # https://opensource.apple.com/source/xnu/xnu-4570.41.2/bsd/sys/socket.h
         s.setsockopt(socket.SOL_SOCKET, 0x1104, 1)
 
-    s.bind((bind_addr[0], port, *bind_addr[1:]))
+    bind_tup = (bind_addr[0], port, *bind_addr[1:])
+    try:
+        s.bind(bind_tup)
+    except OSError as ex:
+        if ex.errno == errno.EADDRNOTAVAIL:
+            log.warning(
+                'Address not available when adding %s to multicast '
+                'group, it is expected to happen on some systems',
+                bind_tup,
+            )
+            return None
+        raise
     log.debug('Created socket %s', s)
     return s
 
@@ -323,6 +334,8 @@ def new_respond_socket(
         apple_p2p=apple_p2p,
         bind_addr=cast(Tuple[Tuple[str, int, int], int], interface)[0] if is_v6 else (cast(str, interface),),
     )
+    if not respond_socket:
+        return None
     log.debug('Configuring socket %s with multicast interface %s', respond_socket, interface)
     if is_v6:
         iface_bin = struct.pack('@I', cast(int, interface[1]))

--- a/zeroconf/_utils/net.py
+++ b/zeroconf/_utils/net.py
@@ -249,8 +249,7 @@ def new_socket(
     except OSError as ex:
         if ex.errno == errno.EADDRNOTAVAIL:
             log.warning(
-                'Address not available when binding to %s, '
-                'it is expected to happen on some systems',
+                'Address not available when binding to %s, ' 'it is expected to happen on some systems',
                 bind_tup,
             )
             return None

--- a/zeroconf/_utils/net.py
+++ b/zeroconf/_utils/net.py
@@ -218,7 +218,7 @@ def new_socket(
     port: int = _MDNS_PORT,
     ip_version: IPVersion = IPVersion.V4Only,
     apple_p2p: bool = False,
-) -> socket.socket:
+) -> Optional[socket.socket]:
     log.debug(
         'Creating new socket with port %s, ip_version %s, apple_p2p %s and bind_addr %r',
         port,

--- a/zeroconf/_utils/net.py
+++ b/zeroconf/_utils/net.py
@@ -249,8 +249,8 @@ def new_socket(
     except OSError as ex:
         if ex.errno == errno.EADDRNOTAVAIL:
             log.warning(
-                'Address not available when adding %s to multicast '
-                'group, it is expected to happen on some systems',
+                'Address not available when binding to %s, '
+                'it is expected to happen on some systems',
                 bind_tup,
             )
             return None


### PR DESCRIPTION
- We already skip these when adding multicast members.
  Apply the same logic to the socket bind call

Reference https://github.com/home-assistant/core/issues/57678