### PR TITLE
Throw EventLoopBlocked instead of concurrent.futures.TimeoutError

### DIFF
--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -23,7 +23,7 @@
 import sys
 
 from ._cache import DNSCache  # noqa # import needed for backwards compat
-from ._core import Zeroconf  # noqa # import needed for backwards compat
+from ._core import Zeroconf
 from ._dns import (  # noqa # import needed for backwards compat
     DNSAddress,
     DNSEntry,
@@ -37,7 +37,7 @@ from ._dns import (  # noqa # import needed for backwards compat
     DNSQuestionType,
 )
 from ._logger import QuietLogger, log  # noqa # import needed for backwards compat
-from ._exceptions import (  # noqa # import needed for backwards compat
+from ._exceptions import (
     AbstractMethodException,
     BadTypeInNameException,
     Error,
@@ -55,9 +55,7 @@ from ._services import (  # noqa # import needed for backwards compat
     ServiceListener,
     ServiceStateChange,
 )
-from ._services.browser import (  # noqa # import needed for backwards compat
-    ServiceBrowser,
-)
+from ._services.browser import ServiceBrowser
 from ._services.info import (  # noqa # import needed for backwards compat
     instance_name_from_service_info,
     ServiceInfo,
@@ -86,16 +84,24 @@ __license__ = 'LGPL'
 
 __all__ = [
     "__version__",
-    "DNSQuestionType",
     "Zeroconf",
     "ServiceInfo",
     "ServiceBrowser",
     "ServiceListener",
-    "Error",
+    "DNSQuestionType",
     "InterfaceChoice",
     "ServiceStateChange",
     "IPVersion",
     "ZeroconfServiceTypes",
+    # Exceptions
+    "Error",
+    "AbstractMethodException",
+    "BadTypeInNameException",
+    "EventLoopBlocked",
+    "IncomingDecodeError",
+    "NamePartTooLongException",
+    "NonUniqueNameException",
+    "ServiceNameAlreadyRegistered",
 ]
 
 if sys.version_info <= (3, 6):  # pragma: no cover

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -36,7 +36,6 @@ from ._dns import (  # noqa # import needed for backwards compat
     DNSText,
     DNSQuestionType,
 )
-from ._logger import QuietLogger, log  # noqa # import needed for backwards compat
 from ._exceptions import (
     AbstractMethodException,
     BadTypeInNameException,
@@ -47,6 +46,7 @@ from ._exceptions import (
     NonUniqueNameException,
     ServiceNameAlreadyRegistered,
 )
+from ._logger import QuietLogger, log  # noqa # import needed for backwards compat
 from ._protocol.incoming import DNSIncoming  # noqa # import needed for backwards compat
 from ._protocol.outgoing import DNSOutgoing  # noqa # import needed for backwards compat
 from ._services import (  # noqa # import needed for backwards compat

--- a/zeroconf/__init__.py
+++ b/zeroconf/__init__.py
@@ -41,6 +41,7 @@ from ._exceptions import (  # noqa # import needed for backwards compat
     AbstractMethodException,
     BadTypeInNameException,
     Error,
+    EventLoopBlocked,
     IncomingDecodeError,
     NamePartTooLongException,
     NonUniqueNameException,

--- a/zeroconf/_core.py
+++ b/zeroconf/_core.py
@@ -192,7 +192,12 @@ class AsyncEngine:
             transport.close()
 
     def close(self) -> None:
-        """Close from sync context."""
+        """Close from sync context.
+
+        While it is not expected during normal operation,
+        this function may raise EventLoopBlocked if the underlying
+        call to `_async_close` cannot be completed.
+        """
         assert self.loop is not None
         # Guard against Zeroconf.close() being called from the eventloop
         if get_running_loop() == self.loop:
@@ -554,7 +559,12 @@ class Zeroconf(QuietLogger):
         service.  The name of the service may be changed if needed to make
         it unique on the network. Additionally multiple cooperating responders
         can register the same service on the network for resilience
-        (if you want this behavior set `cooperating_responders` to `True`)."""
+        (if you want this behavior set `cooperating_responders` to `True`).
+
+        While it is not expected during normal operation,
+        this function may raise EventLoopBlocked if the underlying
+        call to `register_service` cannot be completed.
+        """
         assert self.loop is not None
         run_coro_with_timeout(
             await_awaitable(
@@ -591,7 +601,12 @@ class Zeroconf(QuietLogger):
     def update_service(self, info: ServiceInfo) -> None:
         """Registers service information to the network with a default TTL.
         Zeroconf will then respond to requests for information for that
-        service."""
+        service.
+
+        While it is not expected during normal operation,
+        this function may raise EventLoopBlocked if the underlying
+        call to `async_update_service` cannot be completed.
+        """
         assert self.loop is not None
         run_coro_with_timeout(
             await_awaitable(self.async_update_service(info)), self.loop, _REGISTER_TIME * _REGISTER_BROADCASTS
@@ -662,7 +677,12 @@ class Zeroconf(QuietLogger):
                 out.add_answer_at_time(dns_address, 0)
 
     def unregister_service(self, info: ServiceInfo) -> None:
-        """Unregister a service."""
+        """Unregister a service.
+
+        While it is not expected during normal operation,
+        this function may raise EventLoopBlocked if the underlying
+        call to `async_unregister_service` cannot be completed.
+        """
         assert self.loop is not None
         run_coro_with_timeout(
             self.async_unregister_service(info), self.loop, _UNREGISTER_TIME * _REGISTER_BROADCASTS
@@ -708,7 +728,12 @@ class Zeroconf(QuietLogger):
             self.async_send(out)
 
     def unregister_all_services(self) -> None:
-        """Unregister all registered services."""
+        """Unregister all registered services.
+
+        While it is not expected during normal operation,
+        this function may raise EventLoopBlocked if the underlying
+        call to `async_unregister_all_services` cannot be completed.
+        """
         assert self.loop is not None
         run_coro_with_timeout(
             self.async_unregister_all_services(), self.loop, _UNREGISTER_TIME * _REGISTER_BROADCASTS

--- a/zeroconf/_exceptions.py
+++ b/zeroconf/_exceptions.py
@@ -22,28 +22,38 @@
 
 
 class Error(Exception):
-    pass
+    """Base class for all zeroconf exceptions."""
 
 
 class IncomingDecodeError(Error):
-    pass
+    """Exception when there is invalid data in an incoming packet."""
 
 
 class NonUniqueNameException(Error):
-    pass
+    """Exception when the name is already registered."""
 
 
 class NamePartTooLongException(Error):
-    pass
+    """Exception when the name is too long."""
 
 
 class AbstractMethodException(Error):
-    pass
+    """Exception when a required method is not implemented."""
 
 
 class BadTypeInNameException(Error):
-    pass
+    """Exception when the type in a name is invalid."""
 
 
 class ServiceNameAlreadyRegistered(Error):
-    pass
+    """Exception when a service name is already registered."""
+
+
+class EventLoopBlocked(Error):
+    """Exception when the event loop is blocked.
+
+    This exception is never expected to be thrown
+    during normal operation. It should only happen
+    when the cpu is maxed out or there is something blocking
+    the event loop.
+    """

--- a/zeroconf/_services/info.py
+++ b/zeroconf/_services/info.py
@@ -451,6 +451,10 @@ class ServiceInfo(RecordUpdateListener):
     ) -> bool:
         """Returns true if the service could be discovered on the
         network, and updates this object with details discovered.
+
+        While it is not expected during normal operation,
+        this function may raise EventLoopBlocked if the underlying
+        call to `async_request` cannot be completed.
         """
         assert zc.loop is not None and zc.loop.is_running()
         if zc.loop == get_running_loop():

--- a/zeroconf/_utils/asyncio.py
+++ b/zeroconf/_utils/asyncio.py
@@ -21,8 +21,8 @@
 """
 
 import asyncio
-import contextlib
 import concurrent.futures
+import contextlib
 import queue
 from typing import Any, Awaitable, Coroutine, List, Optional, Set, cast
 

--- a/zeroconf/_utils/asyncio.py
+++ b/zeroconf/_utils/asyncio.py
@@ -22,10 +22,12 @@
 
 import asyncio
 import contextlib
+import concurrent.futures
 import queue
 from typing import Any, Awaitable, Coroutine, List, Optional, Set, cast
 
 from .time import millis_to_seconds
+from .._exceptions import EventLoopBlocked
 from ..const import _LOADED_SYSTEM_TIMEOUT
 
 # The combined timeouts should be lower than _CLOSE_TIMEOUT + _WAIT_FOR_LOOP_TASKS_TIMEOUT
@@ -91,10 +93,22 @@ async def await_awaitable(aw: Awaitable) -> None:
 
 
 def run_coro_with_timeout(aw: Coroutine, loop: asyncio.AbstractEventLoop, timeout: float) -> Any:
-    """Run a coroutine with a timeout."""
-    return asyncio.run_coroutine_threadsafe(aw, loop).result(
-        millis_to_seconds(timeout) + _LOADED_SYSTEM_TIMEOUT
-    )
+    """Run a coroutine with a timeout.
+
+    The timeout should only be used as a safeguard to prevent
+    the program from blocking forever. The timeout should
+    never be expected to be reached during normal operation.
+
+    While not expected during normal operations, the
+    function raises `EventLoopBlocked` if the coroutine takes
+    longer to complete than the timeout.
+    """
+    try:
+        return asyncio.run_coroutine_threadsafe(aw, loop).result(
+            millis_to_seconds(timeout) + _LOADED_SYSTEM_TIMEOUT
+        )
+    except concurrent.futures.TimeoutError as ex:
+        raise EventLoopBlocked from ex
 
 
 def shutdown_loop(loop: asyncio.AbstractEventLoop) -> None:


### PR DESCRIPTION
While run_coro_with_timeout is never expected to timeout during
normal operation, we want to provide additional clarity to
help the developer track down the cause when run_coro_with_timeout
unexpectedly reaches a timeout.

related https://github.com/home-assistant-libs/pychromecast/issues/560