### PR TITLE
Add tests for instance names containing dot(s)

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -76,8 +76,8 @@ class Exceptions(unittest.TestCase):
 
     def test_good_instance_names(self):
         assert r.service_type_name('.._x._tcp.local.') == '_x._tcp.local.'
-        assert r.service_type_name('x.y._http._tcp.local') == '_http._tcp.local.'
-        assert r.service_type_name('1.2.3._mqtt._tcp.local') == '_mqtt._tcp.local.'
+        assert r.service_type_name('x.y._http._tcp.local.') == '_http._tcp.local.'
+        assert r.service_type_name('1.2.3._mqtt._tcp.local.') == '_mqtt._tcp.local.'
         assert r.service_type_name('x.sub._http._tcp.local.') == '_http._tcp.local.'
         assert (
             r.service_type_name('6d86f882b90facee9170ad3439d72a4d6ee9f511._zget._http._tcp.local.')

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -76,6 +76,8 @@ class Exceptions(unittest.TestCase):
 
     def test_good_instance_names(self):
         assert r.service_type_name('.._x._tcp.local.') == '_x._tcp.local.'
+        assert r.service_type_name('x.y._http._tcp.local') == '_http._tcp.local.'
+        assert r.service_type_name('1.2.3._mqtt._tcp.local') == '_mqtt._tcp.local.'
         assert r.service_type_name('x.sub._http._tcp.local.') == '_http._tcp.local.'
         assert (
             r.service_type_name('6d86f882b90facee9170ad3439d72a4d6ee9f511._zget._http._tcp.local.')


### PR DESCRIPTION
Adds two tests with instance names containing dots, which
are currently not handled correctly.

Reproducer for https://github.com/jstasiak/python-zeroconf/issues/146

Maintainers: You probably don't want to merge this PR as long as the underlying issue is not fixed.