### PR TITLE
Handle Service types that end with another service type

### DIFF
--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -1028,7 +1028,7 @@ def test_service_browser_matching():
     type_ = "_http._tcp.local."
     registration_name = "xxxyyy.%s" % type_
     not_match_type_ = "_asustor-looksgood_http._tcp.local."
-    not_match_registration_name = "xxxyyy.%s" % not_match_type_    
+    not_match_registration_name = "xxxyyy.%s" % not_match_type_
     callbacks = []
 
     class MyServiceListener(r.ServiceListener):
@@ -1055,7 +1055,9 @@ def test_service_browser_matching():
     address_parsed = "10.0.1.2"
     address = socket.inet_aton(address_parsed)
     info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[address])
-    should_not_match = ServiceInfo(not_match_type_, not_match_registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[address])
+    should_not_match = ServiceInfo(
+        not_match_type_, not_match_registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[address]
+    )
 
     def mock_incoming_msg(records) -> r.DNSIncoming:
         generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
@@ -1069,8 +1071,15 @@ def test_service_browser_matching():
     )
     _inject_response(
         zc,
-        mock_incoming_msg([should_not_match.dns_pointer(), should_not_match.dns_service(), should_not_match.dns_text(), *should_not_match.dns_addresses()]),
-    )    
+        mock_incoming_msg(
+            [
+                should_not_match.dns_pointer(),
+                should_not_match.dns_service(),
+                should_not_match.dns_text(),
+                *should_not_match.dns_addresses(),
+            ]
+        ),
+    )
     time.sleep(0.2)
     info.port = 400
     _inject_response(
@@ -1081,7 +1090,7 @@ def test_service_browser_matching():
     _inject_response(
         zc,
         mock_incoming_msg([should_not_match.dns_service()]),
-    )    
+    )
     time.sleep(0.2)
 
     assert callbacks == [

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -1017,3 +1017,77 @@ async def test_query_scheduler():
     assert set(query_scheduler.process_ready_types(now + delay * 20)) == set()
 
     assert set(query_scheduler.process_ready_types(now + delay * 31)) == {"_http._tcp.local."}
+
+
+def test_service_browser_matching():
+    """Test that the ServiceBrowser matching does not match partial names."""
+
+    # instantiate a zeroconf instance
+    zc = Zeroconf(interfaces=['127.0.0.1'])
+    # start a browser
+    type_ = "_http._tcp.local."
+    registration_name = "xxxyyy.%s" % type_
+    not_match_type_ = "_asustor-looksgood_http._tcp.local."
+    not_match_registration_name = "xxxyyy.%s" % not_match_type_    
+    callbacks = []
+
+    class MyServiceListener(r.ServiceListener):
+        def add_service(self, zc, type_, name) -> None:
+            nonlocal callbacks
+            if name == registration_name:
+                callbacks.append(("add", type_, name))
+
+        def remove_service(self, zc, type_, name) -> None:
+            nonlocal callbacks
+            if name == registration_name:
+                callbacks.append(("remove", type_, name))
+
+        def update_service(self, zc, type_, name) -> None:
+            nonlocal callbacks
+            if name == registration_name:
+                callbacks.append(("update", type_, name))
+
+    listener = MyServiceListener()
+
+    browser = r.ServiceBrowser(zc, type_, None, listener)
+
+    desc = {'path': '/~paulsm/'}
+    address_parsed = "10.0.1.2"
+    address = socket.inet_aton(address_parsed)
+    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[address])
+    should_not_match = ServiceInfo(not_match_type_, not_match_registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[address])
+
+    def mock_incoming_msg(records) -> r.DNSIncoming:
+        generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+        for record in records:
+            generated.add_answer_at_time(record, 0)
+        return r.DNSIncoming(generated.packets()[0])
+
+    _inject_response(
+        zc,
+        mock_incoming_msg([info.dns_pointer(), info.dns_service(), info.dns_text(), *info.dns_addresses()]),
+    )
+    _inject_response(
+        zc,
+        mock_incoming_msg([should_not_match.dns_pointer(), should_not_match.dns_service(), should_not_match.dns_text(), *should_not_match.dns_addresses()]),
+    )    
+    time.sleep(0.2)
+    info.port = 400
+    _inject_response(
+        zc,
+        mock_incoming_msg([info.dns_service()]),
+    )
+    should_not_match.port = 400
+    _inject_response(
+        zc,
+        mock_incoming_msg([should_not_match.dns_service()]),
+    )    
+    time.sleep(0.2)
+
+    assert callbacks == [
+        ('add', type_, registration_name),
+        ('update', type_, registration_name),
+    ]
+    browser.cancel()
+
+    zc.close()

--- a/zeroconf/_handlers.py
+++ b/zeroconf/_handlers.py
@@ -515,12 +515,12 @@ class RecordManager:
         This function must be run from the event loop.
         """
         now = current_time_millis()
-        records: List[RecordUpdate] = []
-        for question in questions:
-            for record in self.cache.async_entries_with_name(question.name):
-                if not record.is_expired(now) and question.answered_by(record):
-                    records.append(RecordUpdate(record, None))
-
+        records: List[RecordUpdate] = [
+            RecordUpdate(record, None)
+            for question in questions
+            for record in self.cache.async_entries_with_name(question.name)
+            if not record.is_expired(now) and question.answered_by(record)
+        ]
         if not records:
             return
         listener.async_update_records(self.zc, now, records)

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -326,7 +326,7 @@ class _ServiceBrowserBase(RecordUpdateListener):
 
     def _record_matching_type(self, record: DNSRecord) -> Optional[str]:
         """Return the type if the record matches one of the types we are browsing."""
-        return next((type_ for type_ in self.types if record.name.endswith('.' + type_)), None)
+        return next((type_ for type_ in self.types if record.name.endswith(f".{type_}")), None)
 
     def _enqueue_callback(
         self,

--- a/zeroconf/_services/browser.py
+++ b/zeroconf/_services/browser.py
@@ -326,7 +326,7 @@ class _ServiceBrowserBase(RecordUpdateListener):
 
     def _record_matching_type(self, record: DNSRecord) -> Optional[str]:
         """Return the type if the record matches one of the types we are browsing."""
-        return next((type_ for type_ in self.types if record.name.endswith(type_)), None)
+        return next((type_ for type_ in self.types if record.name.endswith('.' + type_)), None)
 
     def _enqueue_callback(
         self,


### PR DESCRIPTION
Fixes erroneous match with service names that have a type that ends with a shorter type.
Given "%NAS._asustor-looksgood_http._tcp.local.",
type "_asustor-looksgood_http._tcp.local." should not match "_http._tcp.local."

My example: currently with an Asustor NAS the "%NAS._asustor-looksgood_http._tcp.local." service appears to have a "_http._tcp.local." service_type while its actual type is "_asustor-looksgood_http._tcp.local."  
This causes an exception because the ServiceInfo __init__ checks:
```
if not type_.endswith(service_type_name(name, strict=False)):
            raise BadTypeInNameException

 File "/usr/src/homeassistant/homeassistant/components/zeroconf/__init__.py", line 405, in _process_service_update
    async_service_info = AsyncServiceInfo(service_type, name)
  File "/usr/local/lib/python3.9/site-packages/zeroconf/_services/info.py", line 131, in __init__
    raise BadTypeInNameException
```