### PR TITLE
Replace wait_event_or_timeout internals with async_timeout

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+async_timeout>=4.0.1
 autopep8
 black;implementation_name=="cpython"
 bump2version

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,5 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     keywords=['Bonjour', 'Avahi', 'Zeroconf', 'Multicast DNS', 'Service Discovery', 'mDNS'],
-    install_requires=['ifaddr>=0.1.7'],
+    install_requires=['async_timeout>=4.0.1', 'ifaddr>=0.1.7'],
 )

--- a/zeroconf/_utils/asyncio.py
+++ b/zeroconf/_utils/asyncio.py
@@ -25,6 +25,8 @@ import concurrent.futures
 import contextlib
 from typing import Any, Awaitable, Coroutine, Optional, Set
 
+import async_timeout
+
 from .time import millis_to_seconds
 from .._exceptions import EventLoopBlocked
 from ..const import _LOADED_SYSTEM_TIMEOUT
@@ -35,28 +37,11 @@ _GET_ALL_TASKS_TIMEOUT = 3
 _WAIT_FOR_LOOP_TASKS_TIMEOUT = 3  # Must be larger than _TASK_AWAIT_TIMEOUT
 
 
-# Switch to asyncio.wait_for once https://bugs.python.org/issue39032 is fixed
 async def wait_event_or_timeout(event: asyncio.Event, timeout: float) -> None:
     """Wait for an event or timeout."""
-    loop = asyncio.get_event_loop()
-    future = loop.create_future()
-
-    def _handle_timeout_or_wait_complete(*_: Any) -> None:
-        if not future.done():
-            future.set_result(None)
-
-    timer_handle = loop.call_later(timeout, _handle_timeout_or_wait_complete)
-    event_wait = loop.create_task(event.wait())
-    event_wait.add_done_callback(_handle_timeout_or_wait_complete)
-
-    try:
-        await future
-    finally:
-        timer_handle.cancel()
-        if not event_wait.done():
-            event_wait.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await event_wait
+    with contextlib.suppress(asyncio.TimeoutError):
+        async with async_timeout.timeout(timeout):
+            await event.wait()
 
 
 async def _async_get_all_tasks(loop: asyncio.AbstractEventLoop) -> Set[asyncio.Task]:
@@ -114,7 +99,6 @@ def shutdown_loop(loop: asyncio.AbstractEventLoop) -> None:
     loop.call_soon_threadsafe(loop.stop)
 
 
-# Remove the call to _get_running_loop once we drop python 3.6 support
 def get_running_loop() -> Optional[asyncio.AbstractEventLoop]:
     """Check if an event loop is already running."""
     with contextlib.suppress(RuntimeError):


### PR DESCRIPTION
Its unlikely that https://bugs.python.org/issue39032 and
https://github.com/python/cpython/issues/83213 will be fixed
soon. While we moved away from an `asyncio.Condition`, we still
has a similar problem with waiting for an `asyncio.Event` which
`wait_event_or_timeout` played well with. `async_timeout` avoids
creating a task so its a bit more efficient. Since we call
these when resolving `ServiceInfo`, avoiding task creation
will resolve a performance problem when `ServiceBrowser`s
startup as they tend to create task storms when coupled
with `ServiceInfo` lookups.