### PR TITLE
Fix port changes not being seen by ServiceInfo

### DIFF
--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -933,8 +933,8 @@ async def test_port_changes_are_seen():
             const._TYPE_SRV,
             const._CLASS_IN | const._CLASS_UNIQUE,
             10000,
-            0,
-            0,
+            90,
+            90,
             81,
             host,
         ),
@@ -945,6 +945,6 @@ async def test_port_changes_are_seen():
     info = ServiceInfo(type_, registration_name, 80, 10, 10, desc, host)
     await info.async_request(aiozc.zeroconf, timeout=200)
     assert info.port == 81
-    assert info.priority == 10
-    assert info.weight == 10
+    assert info.priority == 90
+    assert info.weight == 90
     await aiozc.async_close()

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -942,7 +942,9 @@ async def test_port_changes_are_seen():
     )
     aiozc.zeroconf.handle_response(r.DNSIncoming(generated.packets()[0]))
 
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, host)
+    info = ServiceInfo(type_, registration_name, 80, 10, 10, desc, host)
     await info.async_request(aiozc.zeroconf, timeout=200)
     assert info.port == 81
+    assert info.priority == 10
+    assert info.weight == 10
     await aiozc.async_close()

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -865,3 +865,84 @@ async def test_release_wait_when_new_recorded_added():
     assert await asyncio.wait_for(task, timeout=2)
     assert info.addresses == [b'\x7f\x00\x00\x01']
     await aiozc.async_close()
+
+
+@pytest.mark.asyncio
+async def test_port_changes_are_seen():
+    """Test that port changes are seen by async_request."""
+    type_ = "_http._tcp.local."
+    registration_name = "multiarec.%s" % type_
+    desc = {'path': '/~paulsm/'}
+    aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
+    host = "multahost.local."
+
+    # New kwarg way
+    generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    generated.add_answer_at_time(
+        r.DNSNsec(
+            registration_name,
+            const._TYPE_NSEC,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            const._DNS_OTHER_TTL,
+            registration_name,
+            [const._TYPE_AAAA],
+        ),
+        0,
+    )
+    generated.add_answer_at_time(
+        r.DNSService(
+            registration_name,
+            const._TYPE_SRV,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            10000,
+            0,
+            0,
+            80,
+            host,
+        ),
+        0,
+    )
+    generated.add_answer_at_time(
+        r.DNSAddress(
+            host,
+            const._TYPE_A,
+            const._CLASS_IN,
+            10000,
+            b'\x7f\x00\x00\x01',
+        ),
+        0,
+    )
+    generated.add_answer_at_time(
+        r.DNSText(
+            registration_name,
+            const._TYPE_TXT,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            10000,
+            b'\x04ff=0\x04ci=2\x04sf=0\x0bsh=6fLM5A==',
+        ),
+        0,
+    )
+    await aiozc.zeroconf.async_wait_for_start()
+    await asyncio.sleep(0)
+    aiozc.zeroconf.handle_response(r.DNSIncoming(generated.packets()[0]))
+
+    generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    generated.add_answer_at_time(
+        r.DNSService(
+            registration_name,
+            const._TYPE_SRV,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            10000,
+            0,
+            0,
+            81,
+            host,
+        ),
+        0,
+    )
+    aiozc.zeroconf.handle_response(r.DNSIncoming(generated.packets()[0]))
+
+    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, host)
+    await info.async_request(aiozc.zeroconf, timeout=200)
+    assert info.port == 81
+    await aiozc.async_close()

--- a/zeroconf/_services/info.py
+++ b/zeroconf/_services/info.py
@@ -312,7 +312,7 @@ class ServiceInfo(RecordUpdateListener):
         for record_update in records:
             update_addresses |= self._process_record_threadsafe(record_update[0], now)
 
-        # Only update addresses if the DNSService (.server) has changed
+        # Only update addresses if the DNSService has changed
         if not update_addresses:
             return
 
@@ -354,7 +354,12 @@ class ServiceInfo(RecordUpdateListener):
             if record.key != self.key:
                 return False
             self.name = record.name
-            server_changed = record.server != self.server
+            server_changed = (
+                record.server != self.server
+                or record.port != self.port
+                or record.weight != self.weight
+                or record.priority != self.priority
+            )
             self.server = record.server
             self.server_key = record.server.lower()
             self.port = record.port


### PR DESCRIPTION
If there were multiple dns service records it was possible that a port change could be missed.