### PR TITLE
chore: set cython max line length to 110

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,5 +198,5 @@ build-backend = "poetry.core.masonry.api"
 ignore-words-list = ["additionals", "HASS"]
 
 [tool.cython-lint]
-max-line-length = 88
+max-line-length = 110
 ignore = ['E501'] # too many to fix right now


### PR DESCRIPTION
same as used for main python files