### PR TITLE
chore(ci): run release workflow only on main repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
       - test
       - lint
       - commitlint
-    if: ${{ github.repository_owner }} == "python-zeroconf"
+    if: github.repository_owner == 'python-zeroconf'
 
     runs-on: ubuntu-latest
     environment: release


### PR DESCRIPTION
Must use single quotes and prevent always true.

### Reference

fix pervious attempt #1441
fixes #1440
