### PR TITLE
chore: fix changelog entries and generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+<!-- version list -->
+
+## v0.148.0 (2025-10-05)
+
+### Features
+
+- Trigger semantic releases for 0.x branch
+  ([#1626](https://github.com/python-zeroconf/python-zeroconf/pull/1626),
+  [`812a2b3`](https://github.com/python-zeroconf/python-zeroconf/commit/812a2b3ff4370593a7a0c3ad67389c76c434aa9b))
+
 
 ## v0.147.3 (2025-10-04)
 
@@ -1984,3 +1994,5 @@ Include documentation and test files in source distributions, in order to make t
 
 
 ## v0.15.1 (2014-07-10)
+
+- Initial Release


### PR DESCRIPTION
PSR changed the default for changelog generation from `init` to `update` with `v10`.
https://python-semantic-release.readthedocs.io/en/stable/configuration/configuration.html#mode

`update` does require an insertion flag inside the changelog file. The default for markdown is `<!-- version list -->`. As this isn't present currently, the changelog file wasn't updated properly for the last releases (`0.148.0`, `1.0.0`).

To fix it
1. Temporarily add `changelog.mode = "init"` to the config.
2. Regenerate the changelog with `semantic-release changelog`
3. Remove `changelog.mode` again
4. Add `<!-- version list -->` (the default insertion flag for PSR) to the top of the changelog file.

https://python-semantic-release.readthedocs.io/en/stable/concepts/changelog_templates.html#changelog-templates-migrating-existing-changelog